### PR TITLE
Untangled circular dependency between client and client-core with redux.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,48 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/barankyle/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+
+### Bug Fixes
+
+* **deps:** pin dependencies ([ac0be70](https://github.com/barankyle/xr3ngine/commit/ac0be70b9194c3809e74ba8875529c091d084014))
+* **deps:** pin dependency terser-webpack-plugin to 5.1.1 ([0b8aa13](https://github.com/barankyle/xr3ngine/commit/0b8aa13533bd9e0515af589b5fce1203939f16f2))
+* **deps:** update capacitor monorepo to v2.4.7 ([9793e4e](https://github.com/barankyle/xr3ngine/commit/9793e4e8608bcd34b52e9dcfd81c853151662b7e))
+* **deps:** update dependency @feathersjs/hooks to v0.6.4 ([df63c37](https://github.com/barankyle/xr3ngine/commit/df63c37dcf4eb61a8e9ed4bdcfa2053d60164d8b))
+* **deps:** update dependency @material-ui/data-grid to v4.0.0-alpha.25 ([0b31f6f](https://github.com/barankyle/xr3ngine/commit/0b31f6f31de9dfe90c9b384e5aad1126bd483b40))
+* **deps:** update dependency aws-sdk to v2.885.0 ([b99dbc0](https://github.com/barankyle/xr3ngine/commit/b99dbc0a7ba9aa44ae49c88bd89dc1161a25a7e1))
+* **deps:** update dependency aws-sdk to v2.886.0 ([b37bc42](https://github.com/barankyle/xr3ngine/commit/b37bc42fd77d765bc1a947ff097cef2360e3bbac))
+* **deps:** update dependency aws-sdk to v2.887.0 ([1fc3094](https://github.com/barankyle/xr3ngine/commit/1fc3094cd008466281f8410ebf0b69e3c23ba4c9))
+* **deps:** update dependency aws-sdk to v2.888.0 ([7e040cb](https://github.com/barankyle/xr3ngine/commit/7e040cbe484c74602def81e26f28cb55264ed177))
+* **deps:** update dependency aws-sdk to v2.892.0 ([06db15c](https://github.com/barankyle/xr3ngine/commit/06db15cc17ade5417feafeda07fc3ee77fbe3d3f))
+* **deps:** update dependency concurrently to v6.0.2 ([2ed83cb](https://github.com/barankyle/xr3ngine/commit/2ed83cb943881bf0d9bc850ec5541f8983047c41))
+* **deps:** update dependency feathers-blob to v2.4.0 ([40afa5e](https://github.com/barankyle/xr3ngine/commit/40afa5e33767fc9d1c1d8baad7820028478a71cc))
+* **deps:** update dependency js-yaml to v4.1.0 ([cf84acd](https://github.com/barankyle/xr3ngine/commit/cf84acd3dbfc606c5be67d26abbb445270eb8536))
+* **deps:** update dependency react-apexcharts to v1.3.9 ([a5461a6](https://github.com/barankyle/xr3ngine/commit/a5461a66b727f8d5cbf9480ad1142dd56642433e))
+* **deps:** update dependency react-i18next to v11.8.13 ([8fd41b7](https://github.com/barankyle/xr3ngine/commit/8fd41b7bb47a07fadc9558cab7dea60d1d2031f9))
+* **deps:** update dependency react-modal to v3.13.1 ([293901c](https://github.com/barankyle/xr3ngine/commit/293901c94afa9dc883d17ffd22e9b3577dab88d6))
+* **deps:** update dependency react-redux to v7.2.4 ([8bc2601](https://github.com/barankyle/xr3ngine/commit/8bc26013abb25ce0c07a96006d7d03d9e4d84665))
+* **deps:** update dependency redux to v4.1.0 ([fa7ccd9](https://github.com/barankyle/xr3ngine/commit/fa7ccd9e2fce1df39a8537c2ba93f5e0d77834b1))
+* **deps:** update dependency url-toolkit to v2.2.2 ([9d5aa72](https://github.com/barankyle/xr3ngine/commit/9d5aa72ab4ad254eb60d08822a90c7dd22a9a5fd))
+* **deps:** update dependency vite to v2.2.2 ([9141bf3](https://github.com/barankyle/xr3ngine/commit/9141bf38bfc5ae48ae5489916a6485baeb6194cb))
+* **deps:** update docusaurus monorepo to v2.0.0-alpha.ffe8b6106 ([62cf058](https://github.com/barankyle/xr3ngine/commit/62cf0584d6a0d4ea7339b50380e2425b38d1c38c))
+* **deps:** update nivo monorepo to v0.68.0 ([e4e44b8](https://github.com/barankyle/xr3ngine/commit/e4e44b860e2c34e368f47c071f72c3f140abfb7b))
+* clearEventQueues assignes new array ref, and breaks some event listeners that are using that references ([6195fa3](https://github.com/barankyle/xr3ngine/commit/6195fa3b9d3e8d93db362730f3dcaf7703f9c09b))
+* Dockerfile-dev to reduce vulnerabilities ([4ac9f77](https://github.com/barankyle/xr3ngine/commit/4ac9f776eac61b4e827496d913b6c39fdaeac9b1))
+* missing style.scss ([8f94a8d](https://github.com/barankyle/xr3ngine/commit/8f94a8d1c55f619ab9c339aa25205b719598ef0f))
+* removed "input/touchEvents" in "test" call ([cb2a2f2](https://github.com/barankyle/xr3ngine/commit/cb2a2f28f67b12ab0dca701a78351c832ee7fcbf))
+
+
+### Reverts
+
+* Revert "updates buffer size instead of recreating" ([4f2a31c](https://github.com/barankyle/xr3ngine/commit/4f2a31cf4ba032b76bd24a010ac6d8dcdc58d458))
+* Revert "push the tag and latest" ([e73b192](https://github.com/barankyle/xr3ngine/commit/e73b1928144dc187ff44828d6447a4d66a9e33db))
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.2.18",
+  "version": "0.2.20",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "hoist": true,

--- a/packages/bot/CHANGELOG.md
+++ b/packages/bot/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/xr3ngine/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+**Note:** Version bump only for package @xr3ngine/bot
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 **Note:** Version bump only for package @xr3ngine/bot

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xr3ngine/bot",
-  "version": "0.2.18",
+  "version": "0.2.20",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/client-core/CHANGELOG.md
+++ b/packages/client-core/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/xr3ngine/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+
+### Bug Fixes
+
+* **deps:** pin dependencies ([ac0be70](https://github.com/xr3ngine/xr3ngine/commit/ac0be70b9194c3809e74ba8875529c091d084014))
+* **deps:** update dependency react-i18next to v11.8.13 ([8fd41b7](https://github.com/xr3ngine/xr3ngine/commit/8fd41b7bb47a07fadc9558cab7dea60d1d2031f9))
+* **deps:** update dependency react-modal to v3.13.1 ([293901c](https://github.com/xr3ngine/xr3ngine/commit/293901c94afa9dc883d17ffd22e9b3577dab88d6))
+* **deps:** update dependency react-redux to v7.2.4 ([8bc2601](https://github.com/xr3ngine/xr3ngine/commit/8bc26013abb25ce0c07a96006d7d03d9e4d84665))
+* **deps:** update dependency redux to v4.1.0 ([fa7ccd9](https://github.com/xr3ngine/xr3ngine/commit/fa7ccd9e2fce1df39a8537c2ba93f5e0d77834b1))
+* **deps:** update dependency url-toolkit to v2.2.2 ([9d5aa72](https://github.com/xr3ngine/xr3ngine/commit/9d5aa72ab4ad254eb60d08822a90c7dd22a9a5fd))
+* **deps:** update nivo monorepo to v0.68.0 ([e4e44b8](https://github.com/xr3ngine/xr3ngine/commit/e4e44b860e2c34e368f47c071f72c3f140abfb7b))
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 

--- a/packages/client-core/package.json
+++ b/packages/client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xr3ngine/client-core",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "repository": {
     "type": "git",
     "url": "git://github.com/xr3ngine/xr3ngine.git"
@@ -45,8 +45,8 @@
     "@types/styled-components": "5.1.9",
     "@typescript-eslint/eslint-plugin": "4.22.0",
     "@typescript-eslint/parser": "4.22.0",
-    "@xr3ngine/common": "^0.2.18",
-    "@xr3ngine/engine": "^0.2.18",
+    "@xr3ngine/common": "^0.2.20",
+    "@xr3ngine/engine": "^0.2.20",
     "antd": "4.15.4",
     "app-root-path": "3.0.0",
     "autobind-decorator": "2.4.0",

--- a/packages/client-core/package.json
+++ b/packages/client-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xr3ngine/client-core",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "repository": {
     "type": "git",
     "url": "git://github.com/xr3ngine/xr3ngine.git"

--- a/packages/client-core/src/admin/reducers/admin/service.ts
+++ b/packages/client-core/src/admin/reducers/admin/service.ts
@@ -19,9 +19,11 @@ import { client } from '../../../feathers';
 import { dispatchAlertSuccess, dispatchAlertError } from '../../../common/reducers/alert/service';
 import { PublicVideo, videosFetchedSuccess, videosFetchedError } from '../../../media/components/video/actions';
 import { locationsRetrieved, locationCreated, locationPatched, locationRemoved } from '../../../social/reducers/location/actions';
-import store from '../../../store';
+import Store from '../../../store';
 import { loadedUsers, userCreated, userPatched, userRemoved } from '../../../user/reducers/user/actions';
 import { collectionsFetched } from '../../../world/reducers/scenes/actions';
+
+const store = Store.store;
 
 export function createVideo (data: VideoCreationForm) {
   return async (dispatch: Dispatch, getState: any) => {

--- a/packages/client-core/src/social/reducers/chat/service.ts
+++ b/packages/client-core/src/social/reducers/chat/service.ts
@@ -15,10 +15,12 @@ import {
 } from './actions';
 
 import { User } from '@xr3ngine/common/src/interfaces/User';
-import store from '../../../store';
+import Store from '../../../store';
 import { dispatchAlertError } from '../../../common/reducers/alert/service';
 
 import { Config } from '../../../helper';
+
+const store = Store.store;
 
 export function getChannels(skip?: number, limit?: number) {
   return async (dispatch: Dispatch, getState: any): Promise<any> => {

--- a/packages/client-core/src/social/reducers/friend/service.ts
+++ b/packages/client-core/src/social/reducers/friend/service.ts
@@ -8,10 +8,12 @@ import {
   fetchingFriends
 } from './actions';
 import {dispatchAlertError} from "../../../common/reducers/alert/service";
-import store from '../../../store';
+import Store from '../../../store';
 import { User } from '@xr3ngine/common/src/interfaces/User';
 
 import { Config } from '../../../helper';
+
+const store = Store.store;
 
 // export function getUserRelationship(userId: string) {
 //   return (dispatch: Dispatch): any => {

--- a/packages/client-core/src/social/reducers/group/service.ts
+++ b/packages/client-core/src/social/reducers/group/service.ts
@@ -2,7 +2,7 @@ import { Config } from '../../../helper';
 import { Dispatch } from 'redux';
 import { dispatchAlertError } from '../../../common/reducers/alert/service';
 import { client } from '../../../feathers';
-import store from '../../../store';
+import Store from '../../../store';
 import {
   createdGroup,
   createdGroupUser,
@@ -15,6 +15,8 @@ import {
   removedGroup,
   removedGroupUser
 } from './actions';
+
+const store = Store.store;
 
 export function getGroups(skip?: number, limit?: number) {
   return async (dispatch: Dispatch, getState: any): Promise<any> => {

--- a/packages/client-core/src/social/reducers/invite/service.ts
+++ b/packages/client-core/src/social/reducers/invite/service.ts
@@ -15,8 +15,10 @@ import {
   fetchingSentInvites,
 } from './actions';
 import { Invite } from '@xr3ngine/common/src/interfaces/Invite';
-import store from "../../../store";
+import Store from "../../../store";
 import {User} from "@xr3ngine/common/src/interfaces/User";
+
+const store = Store.store;
 
 const emailRegex = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;
 const phoneRegex = /^[0-9]{10}$/;

--- a/packages/client-core/src/social/reducers/inviteType/service.ts
+++ b/packages/client-core/src/social/reducers/inviteType/service.ts
@@ -5,7 +5,6 @@ import {
     fetchingInvitesTypes,
    retrievedInvitesTypes
 } from "./actions";
-import store from "../../../store";
 
 export function retrieveInvites () {
     return async (dispatch: Dispatch, getState: any): Promise<any> => {

--- a/packages/client-core/src/social/reducers/party/service.ts
+++ b/packages/client-core/src/social/reducers/party/service.ts
@@ -16,7 +16,9 @@ import {
 
 import { Config } from '../../../helper';
 import { dispatchAlertError } from '../../../common/reducers/alert/service';
-import store from '../../../store';
+import Store from '../../../store';
+
+const store = Store.store;
 
 export function getParty () {
   return async (dispatch: Dispatch, getState: any): Promise<any> => {

--- a/packages/client-core/src/store.ts
+++ b/packages/client-core/src/store.ts
@@ -1,26 +1,27 @@
 import { createStore, applyMiddleware } from 'redux';
 import { saveState } from './persisted.store';
 import thunkMiddleware from 'redux-thunk';
-import reducers from '../../client/src/reducers';
 import Immutable from 'immutable';
 import { composeWithDevTools } from 'redux-devtools-extension';
 
 const initialState: any = Immutable.Map();
 const middleware = applyMiddleware(thunkMiddleware);
-const store = createStore(
-  reducers,
-  initialState,
-  // if not production, enable redux dev tools.
-  process.env.NODE_ENV === 'production' ? middleware : composeWithDevTools(middleware)
-);
 
-export function configureStore() {
+export function configureStore(reducers) {
+  Store.store = createStore(
+      reducers,
+      initialState,
+      // if not production, enable redux dev tools.
+      process.env.NODE_ENV === 'production' ? middleware : composeWithDevTools(middleware)
+  );
   // add a listener that will be invoked on any state change.
-  store.subscribe(() => {
-    saveState(store.getState());
+  Store.store.subscribe(() => {
+    saveState(Store.store.getState());
   });
 
-  return store;
+  return Store.store;
 }
 
-export default store;
+export default class Store {
+  static store;
+}

--- a/packages/client-core/src/user/reducers/auth/service.ts
+++ b/packages/client-core/src/user/reducers/auth/service.ts
@@ -15,7 +15,7 @@ import { v1 } from 'uuid';
 import { client } from '../../../feathers';
 import { validateEmail, validatePhoneNumber } from '../../../helper';
 import { getStoredState } from '../../../persisted.store';
-import store from "../../../store";
+import Store from "../../../store";
 import {
   addedChannelLayerUser,
   addedLayerUser, clearChannelLayerUsers,
@@ -45,6 +45,8 @@ import {
   usernameUpdated,
   userUpdated
 } from './actions';
+
+const store = Store.store;
 
 export function doLoginAuto (allowGuest?: boolean, forceClientAuthReset?: boolean) {
   return async (dispatch: Dispatch): Promise<any> => {

--- a/packages/client-ml/CHANGELOG.md
+++ b/packages/client-ml/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/xr3ngine/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+
+### Bug Fixes
+
+* **deps:** update dependency react-modal to v3.13.1 ([293901c](https://github.com/xr3ngine/xr3ngine/commit/293901c94afa9dc883d17ffd22e9b3577dab88d6))
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 

--- a/packages/client-ml/package.json
+++ b/packages/client-ml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xr3ngine/client-ml",
-  "version": "0.2.18",
+  "version": "0.2.20",
   "repository": {
     "type": "git",
     "url": "git://github.com/xr3ngine/xr3ngine.git"
@@ -13,8 +13,7 @@
   },
   "npmClient": "yarn",
   "jest": "ts-jest",
-  "scripts": {
-  },
+  "scripts": {},
   "resolutions": {
     "@types/react": "17.0.4",
     "react": "17.0.2"

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/xr3ngine/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+
+### Bug Fixes
+
+* **deps:** pin dependencies ([ac0be70](https://github.com/xr3ngine/xr3ngine/commit/ac0be70b9194c3809e74ba8875529c091d084014))
+* **deps:** update dependency @material-ui/data-grid to v4.0.0-alpha.25 ([0b31f6f](https://github.com/xr3ngine/xr3ngine/commit/0b31f6f31de9dfe90c9b384e5aad1126bd483b40))
+* **deps:** update dependency react-apexcharts to v1.3.9 ([a5461a6](https://github.com/xr3ngine/xr3ngine/commit/a5461a66b727f8d5cbf9480ad1142dd56642433e))
+* **deps:** update dependency react-i18next to v11.8.13 ([8fd41b7](https://github.com/xr3ngine/xr3ngine/commit/8fd41b7bb47a07fadc9558cab7dea60d1d2031f9))
+* **deps:** update dependency react-modal to v3.13.1 ([293901c](https://github.com/xr3ngine/xr3ngine/commit/293901c94afa9dc883d17ffd22e9b3577dab88d6))
+* **deps:** update dependency react-redux to v7.2.4 ([8bc2601](https://github.com/xr3ngine/xr3ngine/commit/8bc26013abb25ce0c07a96006d7d03d9e4d84665))
+* **deps:** update dependency redux to v4.1.0 ([fa7ccd9](https://github.com/xr3ngine/xr3ngine/commit/fa7ccd9e2fce1df39a8537c2ba93f5e0d77834b1))
+* **deps:** update dependency url-toolkit to v2.2.2 ([9d5aa72](https://github.com/xr3ngine/xr3ngine/commit/9d5aa72ab4ad254eb60d08822a90c7dd22a9a5fd))
+* **deps:** update dependency vite to v2.2.2 ([9141bf3](https://github.com/xr3ngine/xr3ngine/commit/9141bf38bfc5ae48ae5489916a6485baeb6194cb))
+* missing style.scss ([8f94a8d](https://github.com/xr3ngine/xr3ngine/commit/8f94a8d1c55f619ab9c339aa25205b719598ef0f))
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -46,6 +46,7 @@
     "@types/react-redux": "7.1.16",
     "@types/redux-immutable": "4.0.1",
     "@types/styled-components": "5.1.9",
+    "@xr3ngine/client-core": "^0.2.19",
     "axios": "0.21.1",
     "browserfs": "1.4.3",
     "classnames": "2.3.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xr3ngine/client",
-  "version": "0.2.18",
+  "version": "0.2.20",
   "private": true,
   "repository": {
     "type": "git",
@@ -46,7 +46,7 @@
     "@types/react-redux": "7.1.16",
     "@types/redux-immutable": "4.0.1",
     "@types/styled-components": "5.1.9",
-    "@xr3ngine/client-core": "^0.2.19",
+    "@xr3ngine/client-core": "^0.2.20",
     "axios": "0.21.1",
     "browserfs": "1.4.3",
     "classnames": "2.3.1",

--- a/packages/client/src/components/Scene/golf.tsx
+++ b/packages/client/src/components/Scene/golf.tsx
@@ -18,7 +18,7 @@ import {
   getLocationByName
 } from '@xr3ngine/client-core/src/social/reducers/location/service';
 import { setCurrentScene } from '@xr3ngine/client-core/src/world/reducers/scenes/actions';
-import store from '@xr3ngine/client-core/src/store';
+import Store from '@xr3ngine/client-core/src/store';
 import { selectUserState } from '@xr3ngine/client-core/src/user/reducers/user/selector';
 import { selectInstanceConnectionState } from '../../reducers/instanceConnection/selector';
 import {
@@ -55,6 +55,8 @@ import { bindActionCreators, Dispatch } from 'redux';
 import url from 'url';
 import { CharacterInputSchema } from '@xr3ngine/engine/src/templates/character/CharacterInputSchema';
 import { GolfGameMode } from '@xr3ngine/engine/src/templates/game/GolfGameMode';
+
+const store = Store.store;
 
 const goHome = () => window.location.href = window.location.origin;
 

--- a/packages/client/src/components/Scene/location.tsx
+++ b/packages/client/src/components/Scene/location.tsx
@@ -16,7 +16,7 @@ import { client } from '@xr3ngine/client-core/src/feathers';
 import { selectLocationState } from '@xr3ngine/client-core/src/social/reducers/location/selector';
 import { getLocationByName, getLobby } from '@xr3ngine/client-core/src/social/reducers/location/service';
 import { setCurrentScene } from '@xr3ngine/client-core/src/world/reducers/scenes/actions';
-import store from '@xr3ngine/client-core/src/store';
+import Store from '@xr3ngine/client-core/src/store';
 import { selectUserState } from '@xr3ngine/client-core/src/user/reducers/user/selector';
 import { selectInstanceConnectionState } from '../../reducers/instanceConnection/selector';
 import {
@@ -55,6 +55,8 @@ import { CharacterInputSchema } from '@xr3ngine/engine/src/templates/character/C
 import { GamesSchema } from "@xr3ngine/engine/src/templates/game/GamesSchema";
 import WarningRefreshModal from "../AlertModals/WarningRetryModal";
 import { ClientInputSystem } from '@xr3ngine/engine/src/input/systems/ClientInputSystem';
+
+const store = Store.store;
 
 const goHome = () => window.location.href = window.location.origin;
 

--- a/packages/client/src/components/Scene/offlineLocation.tsx
+++ b/packages/client/src/components/Scene/offlineLocation.tsx
@@ -1,6 +1,6 @@
 import { MobileGamepadProps } from '@xr3ngine/client-core/src/common/components/MobileGamepad/MobileGamepadProps';
 import { generalStateList, setAppLoaded, setAppOnBoardingStep } from '@xr3ngine/client-core/src/common/reducers/app/actions';
-import store from '@xr3ngine/client-core/src/store';
+import Store from '@xr3ngine/client-core/src/store';
 import { testScenes, testUserId, testWorldState } from '@xr3ngine/common/src/assets/testScenes';
 import { isMobileOrTablet } from '@xr3ngine/engine/src/common/functions/isMobile';
 import { EngineEvents } from '@xr3ngine/engine/src/ecs/classes/EngineEvents';
@@ -16,6 +16,8 @@ import React, { useEffect, useState } from 'react';
 
 const MobileGamepad = React.lazy(() => import("@xr3ngine/client-core/src/common/components/MobileGamepad"));
 const engineRendererCanvasId = 'engine-renderer-canvas';
+
+const store = Store.store;
 
 interface Props {
   locationName: string;

--- a/packages/client/src/pages/_app.tsx
+++ b/packages/client/src/pages/_app.tsx
@@ -14,6 +14,7 @@ import { Config } from '@xr3ngine/client-core/src/helper';
 import { getDeviceType } from '@xr3ngine/client-core/src/common/reducers/devicedetect/actions';
 import { restoreState } from '@xr3ngine/client-core/src/persisted.store';
 import RouterComp from '../router';
+import reducers from '../reducers';
 import './styles.scss';
 
 const App = (): any => {
@@ -75,9 +76,9 @@ const App = (): any => {
   );
 };
 
-const StroreProvider = () => {
+const StoreProvider = () => {
   return (
-    <Provider store={configureStore()}>
+    <Provider store={configureStore(reducers)}>
       <BrowserRouter>
         <App />
       </BrowserRouter>
@@ -85,4 +86,4 @@ const StroreProvider = () => {
   );
 };
 
-export default StroreProvider;
+export default StoreProvider;

--- a/packages/client/src/reducers/channelConnection/service.ts
+++ b/packages/client/src/reducers/channelConnection/service.ts
@@ -5,7 +5,7 @@ import { MediaStreamSystem } from "@xr3ngine/engine/src/networking/systems/Media
 import { Config } from '@xr3ngine/client-core/src/helper';
 import { Dispatch } from 'redux';
 import { client } from '@xr3ngine/client-core/src/feathers';
-import store from "@xr3ngine/client-core/src/store";
+import Store from "@xr3ngine/client-core/src/store";
 
 import {
   channelServerConnected,
@@ -14,6 +14,8 @@ import {
   channelServerProvisioned,
   channelServerProvisioning
 } from './actions';
+
+const store = Store.store;
 
 export function provisionChannelServer(instanceId?: string, channelId?: string) {
   return async (dispatch: Dispatch, getState: any): Promise<any> => {

--- a/packages/client/src/reducers/instanceConnection/service.ts
+++ b/packages/client/src/reducers/instanceConnection/service.ts
@@ -1,5 +1,5 @@
 import { client } from '@xr3ngine/client-core/src/feathers';
-import store from "@xr3ngine/client-core/src/store";
+import Store from "@xr3ngine/client-core/src/store";
 import { EngineEvents } from "@xr3ngine/engine/src/ecs/classes/EngineEvents";
 import { Network } from "@xr3ngine/engine/src/networking/classes/Network";
 import { MediaStreamSystem } from "@xr3ngine/engine/src/networking/systems/MediaStreamSystem";
@@ -13,6 +13,8 @@ import {
   instanceServerProvisioned,
   instanceServerProvisioning
 } from './actions';
+
+const store = Store.store;
 
 export function provisionInstanceServer(locationId?: string, instanceId?: string, sceneId?: string) {
   return async (dispatch: Dispatch, getState: any): Promise<any> => {

--- a/packages/client/src/reducers/mediastream/service.ts
+++ b/packages/client/src/reducers/mediastream/service.ts
@@ -6,7 +6,9 @@ import {
   setFaceTrackingState,
   setConsumers
 } from './actions';
-import store from '@xr3ngine/client-core/src/store';
+import Store from '@xr3ngine/client-core/src/store';
+
+const store = Store.store;
 
 export const updateCamVideoState = () => {
   const ms = MediaStreamSystem.instance;

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/xr3ngine/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+**Note:** Version bump only for package @xr3ngine/common
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 **Note:** Version bump only for package @xr3ngine/common

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xr3ngine/common",
-  "version": "0.2.18",
+  "version": "0.2.20",
   "main": "index.ts",
   "module": "dist/common.es.js",
   "publishConfig": {

--- a/packages/docs/CHANGELOG.md
+++ b/packages/docs/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/barankyle/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+
+### Bug Fixes
+
+* **deps:** pin dependency terser-webpack-plugin to 5.1.1 ([0b8aa13](https://github.com/barankyle/xr3ngine/commit/0b8aa13533bd9e0515af589b5fce1203939f16f2))
+* **deps:** update docusaurus monorepo to v2.0.0-alpha.ffe8b6106 ([62cf058](https://github.com/barankyle/xr3ngine/commit/62cf0584d6a0d4ea7339b50380e2425b38d1c38c))
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xr3ngine/docs",
-  "version": "0.2.18",
+  "version": "0.2.20",
   "private": true,
   "nohoist": [
     "**/html-minifier-terser",

--- a/packages/engine/CHANGELOG.md
+++ b/packages/engine/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/xr3ngine/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+
+### Bug Fixes
+
+* clearEventQueues assignes new array ref, and breaks some event listeners that are using that references ([6195fa3](https://github.com/xr3ngine/xr3ngine/commit/6195fa3b9d3e8d93db362730f3dcaf7703f9c09b))
+* removed "input/touchEvents" in "test" call ([cb2a2f2](https://github.com/xr3ngine/xr3ngine/commit/cb2a2f28f67b12ab0dca701a78351c832ee7fcbf))
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -30,7 +30,7 @@
     "validate": "yarn run lint && yarn run test",
     "generate-doc": "node_modules/.bin/typedoc"
   },
-  "version": "0.2.18",
+  "version": "0.2.20",
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.4.1",
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@pixiv/three-vrm": "^0.6.0",
-    "@xr3ngine/common": "^0.2.18",
+    "@xr3ngine/common": "^0.2.20",
     "browserfs": "^1.4.3",
     "cross-fetch": "^3.0.6",
     "ctix": "^0.3.1",

--- a/packages/gameserver/CHANGELOG.md
+++ b/packages/gameserver/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/barankyle/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @feathersjs/hooks to v0.6.4 ([df63c37](https://github.com/barankyle/xr3ngine/commit/df63c37dcf4eb61a8e9ed4bdcfa2053d60164d8b))
+* **deps:** update dependency aws-sdk to v2.885.0 ([b99dbc0](https://github.com/barankyle/xr3ngine/commit/b99dbc0a7ba9aa44ae49c88bd89dc1161a25a7e1))
+* **deps:** update dependency aws-sdk to v2.886.0 ([b37bc42](https://github.com/barankyle/xr3ngine/commit/b37bc42fd77d765bc1a947ff097cef2360e3bbac))
+* **deps:** update dependency aws-sdk to v2.887.0 ([1fc3094](https://github.com/barankyle/xr3ngine/commit/1fc3094cd008466281f8410ebf0b69e3c23ba4c9))
+* **deps:** update dependency aws-sdk to v2.888.0 ([7e040cb](https://github.com/barankyle/xr3ngine/commit/7e040cbe484c74602def81e26f28cb55264ed177))
+* **deps:** update dependency aws-sdk to v2.892.0 ([06db15c](https://github.com/barankyle/xr3ngine/commit/06db15cc17ade5417feafeda07fc3ee77fbe3d3f))
+* **deps:** update dependency feathers-blob to v2.4.0 ([40afa5e](https://github.com/barankyle/xr3ngine/commit/40afa5e33767fc9d1c1d8baad7820028478a71cc))
+* **deps:** update dependency js-yaml to v4.1.0 ([cf84acd](https://github.com/barankyle/xr3ngine/commit/cf84acd3dbfc606c5be67d26abbb445270eb8536))
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 

--- a/packages/gameserver/package.json
+++ b/packages/gameserver/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xr3ngine/gameserver",
   "description": "Multiplayer Gameserver for XR3ngine",
-  "version": "0.2.18",
+  "version": "0.2.20",
   "private": true,
   "homepage": "",
   "main": "./src",
@@ -64,9 +64,8 @@
     "@feathersjs/socketio-client": "4.5.11",
     "@feathersjs/transport-commons": "4.5.11",
     "@google-cloud/agones-sdk": "1.14.0",
-    "@xr3ngine/engine": "^0.2.17",
-    "@xr3ngine/server-core": "^0.2.17",
-    "three-physx": "0.0.7",
+    "@xr3ngine/engine": "^0.2.20",
+    "@xr3ngine/server-core": "^0.2.20",
     "aws-sdk": "2.897.0",
     "bent": "7.3.12",
     "chargebee": "2.6.5",
@@ -105,6 +104,7 @@
     "sequelize": " 6.6.2",
     "serve-favicon": "2.5.0",
     "slugify": "1.5.0",
+    "three-physx": "0.0.7",
     "universal-analytics": "0.4.23",
     "uuid": "8.3.2",
     "winston": "3.3.3"

--- a/packages/native-plugin-example/CHANGELOG.md
+++ b/packages/native-plugin-example/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/xr3ngine/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+**Note:** Version bump only for package @xr3ngine/native-plugin-example
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 **Note:** Version bump only for package @xr3ngine/native-plugin-example

--- a/packages/native-plugin-example/package.json
+++ b/packages/native-plugin-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xr3ngine/native-plugin-example",
-  "version": "0.2.18",
+  "version": "0.2.20",
   "private": true,
   "repository": {
     "type": "git",
@@ -30,18 +30,18 @@
   },
   "dependencies": {
     "@capacitor/android": "2.4.7",
-    "@capacitor/ios": "2.4.7",
     "@capacitor/cli": "2.4.7",
-    "@xr3ngine/native-plugin-xr": "^0.2.15",
+    "@capacitor/ios": "2.4.7",
+    "@xr3ngine/native-plugin-xr": "^0.2.20",
     "react": "17.0.2"
   },
   "devDependencies": {
-    "vite-xrengine": "2.2.4",
     "@babel/core": "7.14.0",
     "@types/react": "17.0.4",
     "cross-env": "7.0.3",
     "eslint": "7.25.0",
-    "typescript": "4.2.4"
+    "typescript": "4.2.4",
+    "vite-xrengine": "2.2.4"
   },
   "license": "ISC"
 }

--- a/packages/native-plugin-xr/CHANGELOG.md
+++ b/packages/native-plugin-xr/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/xr3ngine/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+**Note:** Version bump only for package @xr3ngine/native-plugin-xr
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 **Note:** Version bump only for package @xr3ngine/native-plugin-xr

--- a/packages/native-plugin-xr/package.json
+++ b/packages/native-plugin-xr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xr3ngine/native-plugin-xr",
-  "version": "0.2.18",
+  "version": "0.2.20",
   "description": "Native XR and camera services inside any capacitor app",
   "main": "dist/plugin.js",
   "module": "dist/esm/index.js",
@@ -25,13 +25,11 @@
   "author": "XR3 Group",
   "license": "MIT",
   "devDependencies": {
-   
     "@capacitor/core": "2.4.7",
     "@ionic/prettier-config": "1.0.1",
     "@rollup/plugin-node-resolve": "11.2.1",
     "prettier": "2.2.1",
     "rimraf": "3.0.2",
-  
     "swiftlint": "1.0.1",
     "typescript": "4.2.4"
   },

--- a/packages/ops/CHANGELOG.md
+++ b/packages/ops/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/xr3ngine/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+**Note:** Version bump only for package @xr3ngine/ops
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 **Note:** Version bump only for package @xr3ngine/ops

--- a/packages/ops/package.json
+++ b/packages/ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xr3ngine/ops",
-  "version": "0.2.18",
+  "version": "0.2.20",
   "private": true,
   "description": "Dev Ops tooling for XR3ngine",
   "repository": "http://github.com/xr3ngine/xr3ngine",

--- a/packages/server-core/CHANGELOG.md
+++ b/packages/server-core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/barankyle/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+
+### Bug Fixes
+
+* **deps:** update dependency @feathersjs/hooks to v0.6.4 ([df63c37](https://github.com/barankyle/xr3ngine/commit/df63c37dcf4eb61a8e9ed4bdcfa2053d60164d8b))
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xr3ngine/server-core",
   "description": "Shared components for XR3ngine server",
-  "version": "0.2.18",
+  "version": "0.2.20",
   "homepage": "",
   "publishConfig": {
     "access": "public"
@@ -67,8 +67,8 @@
     "@feathersjs/socketio-client": "^4.5.9",
     "@feathersjs/transport-commons": "^4.5.9",
     "@google-cloud/agones-sdk": "^1.7.0",
-    "@xr3ngine/common": "^0.2.18",
-    "@xr3ngine/engine": "^0.2.18",
+    "@xr3ngine/common": "^0.2.20",
+    "@xr3ngine/engine": "^0.2.20",
     "aws-sdk": "^2.811.0",
     "bent": "^7.3.0",
     "chargebee": "^2.5.7",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/barankyle/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+
+### Bug Fixes
+
+* **deps:** pin dependencies ([ac0be70](https://github.com/barankyle/xr3ngine/commit/ac0be70b9194c3809e74ba8875529c091d084014))
+* **deps:** update dependency @feathersjs/hooks to v0.6.4 ([df63c37](https://github.com/barankyle/xr3ngine/commit/df63c37dcf4eb61a8e9ed4bdcfa2053d60164d8b))
+* **deps:** update dependency aws-sdk to v2.885.0 ([b99dbc0](https://github.com/barankyle/xr3ngine/commit/b99dbc0a7ba9aa44ae49c88bd89dc1161a25a7e1))
+* **deps:** update dependency aws-sdk to v2.886.0 ([b37bc42](https://github.com/barankyle/xr3ngine/commit/b37bc42fd77d765bc1a947ff097cef2360e3bbac))
+* **deps:** update dependency aws-sdk to v2.887.0 ([1fc3094](https://github.com/barankyle/xr3ngine/commit/1fc3094cd008466281f8410ebf0b69e3c23ba4c9))
+* **deps:** update dependency aws-sdk to v2.888.0 ([7e040cb](https://github.com/barankyle/xr3ngine/commit/7e040cbe484c74602def81e26f28cb55264ed177))
+* **deps:** update dependency aws-sdk to v2.892.0 ([06db15c](https://github.com/barankyle/xr3ngine/commit/06db15cc17ade5417feafeda07fc3ee77fbe3d3f))
+* **deps:** update dependency concurrently to v6.0.2 ([2ed83cb](https://github.com/barankyle/xr3ngine/commit/2ed83cb943881bf0d9bc850ec5541f8983047c41))
+* **deps:** update dependency feathers-blob to v2.4.0 ([40afa5e](https://github.com/barankyle/xr3ngine/commit/40afa5e33767fc9d1c1d8baad7820028478a71cc))
+* **deps:** update dependency js-yaml to v4.1.0 ([cf84acd](https://github.com/barankyle/xr3ngine/commit/cf84acd3dbfc606c5be67d26abbb445270eb8536))
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xr3ngine/server",
   "description": "API Server for XR3ngine",
-  "version": "0.2.18",
+  "version": "0.2.20",
   "private": true,
   "homepage": "",
   "main": "dist/index.js",
@@ -70,7 +70,7 @@
     "@feathersjs/socketio": "4.5.11",
     "@feathersjs/socketio-client": "4.5.11",
     "@feathersjs/transport-commons": "4.5.11",
-    "@xr3ngine/server-core": "^0.2.17",
+    "@xr3ngine/server-core": "^0.2.20",
     "aws-sdk": "2.897.0",
     "bent": "7.3.12",
     "chargebee": "2.6.5",

--- a/packages/social/CHANGELOG.md
+++ b/packages/social/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/xr3ngine/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+
+### Bug Fixes
+
+* **deps:** update dependency react-modal to v3.13.1 ([293901c](https://github.com/xr3ngine/xr3ngine/commit/293901c94afa9dc883d17ffd22e9b3577dab88d6))
+* **deps:** update dependency react-redux to v7.2.4 ([8bc2601](https://github.com/xr3ngine/xr3ngine/commit/8bc26013abb25ce0c07a96006d7d03d9e4d84665))
+* **deps:** update dependency redux to v4.1.0 ([fa7ccd9](https://github.com/xr3ngine/xr3ngine/commit/fa7ccd9e2fce1df39a8537c2ba93f5e0d77834b1))
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xr3ngine/social",
-  "version": "0.2.18",
+  "version": "0.2.20",
   "private": true,
   "repository": {
     "type": "git",
@@ -33,10 +33,10 @@
     "@capacitor/cli": "2.4.7",
     "@material-ui/core": "4.11.4",
     "@types/react-redux": "7.1.16",
-    "@xr3ngine/client-core": "^0.2.19",
-    "@xr3ngine/common": "^0.2.18",
-    "@xr3ngine/engine": "^0.2.18",
-    "@xr3ngine/native-plugin-xr": "^0.2.18",
+    "@xr3ngine/client-core": "^0.2.20",
+    "@xr3ngine/common": "^0.2.20",
+    "@xr3ngine/engine": "^0.2.20",
+    "@xr3ngine/native-plugin-xr": "^0.2.20",
     "app-root-path": "3.0.0",
     "device-detector-js": "2.2.9",
     "prop-types": "15.7.2",
@@ -50,13 +50,13 @@
     "three": "0.128.0"
   },
   "devDependencies": {
-    "vite-xrengine": "2.2.4",
     "@types/node": "13.13.51",
     "@types/react": "17.0.4",
     "config": "3.3.6",
     "cross-env": "7.0.3",
     "eslint": "7.25.0",
-    "typescript": "4.2.4"
+    "typescript": "4.2.4",
+    "vite-xrengine": "2.2.4"
   },
   "browser": {
     "fs": false

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -33,7 +33,7 @@
     "@capacitor/cli": "2.4.7",
     "@material-ui/core": "4.11.4",
     "@types/react-redux": "7.1.16",
-    "@xr3ngine/client-core": "^0.2.18",
+    "@xr3ngine/client-core": "^0.2.19",
     "@xr3ngine/common": "^0.2.18",
     "@xr3ngine/engine": "^0.2.18",
     "@xr3ngine/native-plugin-xr": "^0.2.18",

--- a/packages/social/src/pages/_app.tsx
+++ b/packages/social/src/pages/_app.tsx
@@ -14,6 +14,7 @@ import { Config } from '@xr3ngine/client-core/src/helper';
 import { getDeviceType } from '@xr3ngine/client-core/src/common/reducers/devicedetect/actions';
 import { restoreState } from '@xr3ngine/client-core/src/persisted.store';
 import RouterComp from '../router';
+import reducers from '../reducers';
 import './styles.scss';
 
 const App = (): any => {
@@ -75,9 +76,9 @@ const App = (): any => {
   );
 };
 
-const StroreProvider = () => {
+const StoreProvider = () => {
   return (
-    <Provider store={configureStore()}>
+    <Provider store={configureStore(reducers)}>
       <BrowserRouter>
         <App />
       </BrowserRouter>
@@ -85,4 +86,4 @@ const StroreProvider = () => {
   );
 };
 
-export default StroreProvider;
+export default StoreProvider;

--- a/packages/volumetric/CHANGELOG.md
+++ b/packages/volumetric/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.20](https://github.com/xr3ngine/xr3ngine/compare/v0.2.18...v0.2.20) (2021-05-04)
+
+**Note:** Version bump only for package @xr3ngine/volumetric
+
+
+
+
+
 ## 0.2.18 (2021-04-22)
 
 **Note:** Version bump only for package @xr3ngine/volumetric

--- a/packages/volumetric/package.json
+++ b/packages/volumetric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xr3ngine/volumetric",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "repository": {
     "type": "git",
     "url": "git://github.com/xr3ngine/xr3ngine.git"
@@ -27,7 +27,7 @@
     "@types/three": "0.127.1"
   },
   "dependencies": {
-    "@xr3ngine/engine": "^0.2.17",
+    "@xr3ngine/engine": "^0.2.20",
     "three": "0.128.0",
     "xmlhttprequest": "1.8.0"
   },


### PR DESCRIPTION
client was assembling reducers from client-core, but then client-core store.ts was importing
reducers from client. Updated store.ts to export a class with a static 'store' that configureStore()
can remake with reducers that are passed as a parameter: `configureStore(reducers)`.

social was likely using client's reducers, and is now using its own.

Updated client and social to follow this new implementation.