### PR TITLE
Fixed bug in handleConnectToWorld.

### DIFF
--- a/packages/client/src/transports/SocketWebRTCClientTransport.ts
+++ b/packages/client/src/transports/SocketWebRTCClientTransport.ts
@@ -145,7 +145,7 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
           new Promise((resolve, reject) => {
             setTimeout(() => reject(new Error('Connect timed out')), 10000);
           })
-      ]);
+        ]);
       } catch(err) {
         console.log(err);
         EngineEvents.instance.dispatchEvent({ type: EngineEvents.EVENTS.CONNECT_TO_WORLD_TIMEOUT, instance: instance === true });

--- a/packages/gameserver/src/NetworkFunctions.ts
+++ b/packages/gameserver/src/NetworkFunctions.ts
@@ -178,12 +178,12 @@ export function validateNetworkObjects(): void {
 
 
 export async function handleConnectToWorld(socket, data, callback, userId, user, avatarDetail): Promise<any> {
-  if(!Engine.sceneLoaded) {
-    await new Promise<void>((resolve) => {
-      EngineEvents.instance.once(EngineEvents.EVENTS.SCENE_LOADED, resolve);
-    });
-  }
     const transport = Network.instance.transport as any;
+    if(!Engine.sceneLoaded && (transport.app as any).isChannelInstance !== true) {
+      await new Promise<void>((resolve) => {
+        EngineEvents.instance.once(EngineEvents.EVENTS.SCENE_LOADED, resolve);
+      });
+    }
 
     console.log('Connect to world from ' + userId);
     // console.log("Avatar detail is", avatarDetail);


### PR DESCRIPTION
handleConnectToWorld waits for the engine to load the scene, but it shouldn't do this for
channel instance servers.