### PR TITLE
Fixed bug with oauth redirect_uri in feathers v5.

### DIFF
--- a/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
@@ -207,7 +207,7 @@ const ProfileMenu = (props: Props): any => {
 								}}
 							/>
 						</span>
-						<h2>{selfUser?.userRole === 'admin' ? t('user:usermenu.profile.youAreA') : t('user:usermenu.profile.youAreAn')} <span>{selfUser?.userRole}</span>.</h2>
+						<h2>{selfUser?.userRole === 'admin' ? t('user:usermenu.profile.youAreAn') : t('user:usermenu.profile.youAreA')} <span>{selfUser?.userRole}</span>.</h2>
 						<h4>{(selfUser.userRole === 'user' || selfUser.userRole === 'admin') && <div onClick={handleLogout}>{t('user:usermenu.profile.logout')}</div>}</h4>
 						{ selfUser?.inviteCode != null && <h2>{t('user:usermenu.profile.inviteCode')}: {selfUser.inviteCode}</h2> }
 					</div>

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -54,8 +54,14 @@ if (config.server.enabled) {
           }
         })
     );
-    
 
+    //Feathers authentication-oauth will use http for its redirect_uri if this is 'dev'.
+    //Doesn't appear anything else uses it.
+    app.set('env', 'production');
+    //Feathers authentication-oauth will only append the port in production, but then it will also
+    //hard-code http as the protocol, so manually mashing host + port together if in local.
+    app.set('host', config.server.local ? (config.server.hostname + ':' + config.server.port) : config.server.hostname);
+    app.set('port', config.server.port);
     app.set('paginate', config.server.paginate);
     app.set('authentication', config.authentication);
 


### PR DESCRIPTION
v5 constructs its redirect_uri before passing to grant, instead of grant just assembling
the uri from all the configured values. Constructed uri comes from express variables 'host'
and 'port', so set those on init.

New version also hard-sets protocol to http if in development, which we don't want.
Setting 'env' variable on express to 'production' in all cases; it doesn't appear anything else
checks this variable.

Fixed annoying mixup of 'an/a' on user profile.