### PR TITLE
Split component seeds into separate export, seeder runs them last.

### DIFF
--- a/packages/server-core/src/entities/seeder-config.ts
+++ b/packages/server-core/src/entities/seeder-config.ts
@@ -9,6 +9,9 @@ export const entitySeeds: Array<ServicesSeedConfig> = [
     collectionTypeSeed,
     collectionSeed,
     entitySeed,
+];
+
+export const componentSeeds: Array<ServicesSeedConfig> = [
     componentTypeSeed,
-    componentSeed,
-  ];
+    componentSeed
+];

--- a/packages/server-core/src/seeder-config.ts
+++ b/packages/server-core/src/seeder-config.ts
@@ -1,6 +1,6 @@
 
 import { ServicesSeedConfig } from '@xrengine/common/src/interfaces/ServicesSeedConfig';
-import { entitySeeds } from './entities/seeder-config';
+import { entitySeeds, componentSeeds } from './entities/seeder-config';
 import { mediaSeeds } from './media/seeder-config';
 import { networkingSeeds } from './networking/seeder-config';
 import { paymentSeeds } from './payments/seeder-config';
@@ -17,7 +17,8 @@ export const seeds: Array<ServicesSeedConfig> = [
     ...socialSeeds,
     ...socialMediaSeeds,
     ...userSeeds,
-    ...worldSeeds
+    ...worldSeeds,
+    ...componentSeeds
   ];
 
 export default seeds;


### PR DESCRIPTION
A problem was encountered where component seeds were executing before entity seeds, leading to
errors because components need to have valid entityIds. Feathers-seeder doesn't execute seeds
sequentially, so just being after entity seeds in the array of 'entity' seeds doesn't guarantee
they'll be executed later.

Component seeds were split into separate export, and are now at the very bottom of the array
of seeds in src/seeder-config.ts to hopefully always be executed after entity seeds.