### PR TITLE
Re-enabled positional audio and fixed bugs in Harmony.

### DIFF
--- a/packages/client-core/src/social/reducers/chat/service.ts
+++ b/packages/client-core/src/social/reducers/chat/service.ts
@@ -13,6 +13,7 @@ import {
   patchedChannel,
   removedChannel
 } from './actions';
+import waitForClientAuthenticated from "../../../util/wait-for-client-authenticated";
 
 import { User } from '@xrengine/common/src/interfaces/User';
 import Store from '../../../store';
@@ -25,14 +26,13 @@ const store = Store.store;
 export function getChannels(skip?: number, limit?: number) {
   return async (dispatch: Dispatch, getState: any): Promise<any> => {
     try {
-      // console.log('FETCHING CHANNELS');
+      await waitForClientAuthenticated();
       const channelResult = await client.service('channel').find({
         query: {
           $limit: limit != null ? limit : getState().get('chat').get('channels').get('channels').get('limit'),
           $skip: skip != null ? skip : getState().get('chat').get('channels').get('channels').get('skip')
         }
       });
-      // console.log(channelResult);
       dispatch(loadedChannels(channelResult));
     } catch (err) {
       console.log(err);

--- a/packages/client-core/src/user/reducers/auth/service.ts
+++ b/packages/client-core/src/user/reducers/auth/service.ts
@@ -715,7 +715,7 @@ const getAvatarResources = (user) => {
 };
 
 const loadAvatarForUpdatedUser = async (user) => {
-  if (!user || !user.instanceId) Promise.resolve(true);
+  if (user.instanceId == null && user.channelInstanceId == null) return Promise.resolve(true);
 
   return new Promise(async resolve => {
     const networkUser = Network.instance?.clients[user.id];
@@ -799,11 +799,11 @@ const loadXRAvatarForUpdatedUser = async (user) => {
 
 if(!Config.publicRuntimeConfig.offlineMode) {
   client.service('user').on('patched', async (params) => {
-    console.log('User patched');
     const selfUser = (store.getState() as any).get('auth').get('user');
     const user = resolveUser(params.userRelationship);
 
-    await loadAvatarForUpdatedUser(user);
+    console.log('User patched', user);
+    if (Network.instance != null) await loadAvatarForUpdatedUser(user);
 
     if (selfUser.id === user.id) {
       if (selfUser.instanceId !== user.instanceId) store.dispatch(clearLayerUsers());

--- a/packages/client-core/src/util/wait-for-client-authenticated.ts
+++ b/packages/client-core/src/util/wait-for-client-authenticated.ts
@@ -1,0 +1,9 @@
+import { client } from '../feathers';
+
+async function waitForClientAuthenticated (): Promise<void> {
+    console.log('Client authenticated?', client.authentication?.authenticated);
+    if (client.authentication?.authenticated === true) return Promise.resolve();
+    else return await new Promise(resolve => setTimeout(async () => {await waitForClientAuthenticated(); resolve();}, 100));
+}
+
+export default waitForClientAuthenticated;

--- a/packages/client/src/components/Harmony/index.tsx
+++ b/packages/client/src/components/Harmony/index.tsx
@@ -354,6 +354,11 @@ const Harmony = (props: Props): any => {
     }, []);
 
     useEffect(() => {
+        if (selfUser.instanceId != null && userState.get('layerUsersUpdateNeeded') === true) getLayerUsers(true);
+        if (selfUser.channelInstanceId != null && userState.get('channelLayerUsersUpdateNeeded') === true) getLayerUsers(false);
+    }, [ userState ]);
+
+    useEffect(() => {
         if ((Network.instance?.transport as any)?.channelType === 'instance') {
             const channelEntries = [...channels.entries()];
             const instanceChannel = channelEntries.find((entry) => entry[1].instanceId != null);
@@ -489,6 +494,7 @@ const Harmony = (props: Props): any => {
             updateChannelTypeState();
             updateCamVideoState();
             updateCamAudioState();
+            EngineEvents.instance.dispatchEvent({ type: EngineEvents.EVENTS.SCENE_LOADED });
         }
     };
 

--- a/packages/client/src/reducers/channelConnection/service.ts
+++ b/packages/client/src/reducers/channelConnection/service.ts
@@ -15,6 +15,7 @@ import {
   channelServerProvisioning
 } from './actions';
 import { SocketWebRTCClientTransport } from "../../transports/SocketWebRTCClientTransport";
+import {triggerUpdateConsumers} from "../mediastream/service";
 
 const store = Store.store;
 
@@ -79,6 +80,8 @@ export function connectToChannelServer(channelId: string, isHarmonyPage?: boolea
         videoEnabled: currentLocation?.locationSettings?.videoEnabled === true || !(currentLocation?.locationSettings?.locationType === 'showroom' && user.locationAdmins?.find(locationAdmin => locationAdmin.locationId === currentLocation.id) == null),
         isHarmonyPage: isHarmonyPage
       });
+
+      EngineEvents.instance.addEventListener(MediaStreamSystem.EVENTS.TRIGGER_UPDATE_CONSUMERS, triggerUpdateConsumers);
 
       dispatch(channelServerConnected());
     } catch (err) {

--- a/packages/engine/src/networking/systems/ClientNetworkStateSystem.ts
+++ b/packages/engine/src/networking/systems/ClientNetworkStateSystem.ts
@@ -89,7 +89,7 @@ export class ClientNetworkStateSystem extends System {
     super(attributes);
     ClientNetworkStateSystem.instance = this;
     
-    EngineEvents.instance.once(EngineEvents.EVENTS.CONNECT_TO_WORLD, ({ worldState }) => { 
+    EngineEvents.instance.once(EngineEvents.EVENTS.CONNECT_TO_WORLD, ({ worldState }) => {
       this.receivedServerState.push(worldState);
     });
     EngineEvents.instance.once(EngineEvents.EVENTS.JOINED_WORLD, ({ worldState }) => {
@@ -114,7 +114,6 @@ export class ClientNetworkStateSystem extends System {
    * @param delta Time since last frame.
    */
   execute = (delta: number): void => {
-
     const receivedClientInput = [...this.receivedServerState];
     this.receivedServerState = [];
     receivedClientInput?.forEach((worldStateBuffer: WorldStateInterface) => {


### PR DESCRIPTION
Location audio was not working because Positional audio system was not being started.
Uncommented lines in initialize.ts to re-enable it.

Made some minor fixes to loadAvatarForUpdatedUser. Needed to return Promise.resolve
if user not in an instance, and needed to check that both instanceId and channelInstanceId
are null in order to do that. Also made user.on('patched') only call it if the Network is
initialized.

Moved initialization of ClientNetworkStateSystem to be next to ClientNetworkSystem.
It was in the block that only gets intialized when the canvas is in use, and it can
be needed when there is not canvas (i.e. Harmony).

Fixed some bugs in Harmony:
* Needs to fire SCENE_LOADED manually to start Engine
* Listens to userState and triggers re-fetching layer users.
* provisionChannelServer listens for TRIGGER_UPDATE_CONSUMERS and calls triggerUpdateConsumers

Added a utility function waitForClientAuthenticated. This just loops until the client has been
authenticated and returns a promise. The Channel find call was occurring before the client had
credentials and was failing. If any other calls are failing for the same reason, this can be
await'ed before making the call.