### PR TITLE
send viewVector instead of quaternion for characters

### DIFF
--- a/packages/engine/src/game/templates/Golf/behaviors/addHole.ts
+++ b/packages/engine/src/game/templates/Golf/behaviors/addHole.ts
@@ -1,7 +1,7 @@
 import { Vector3, Quaternion } from 'three';
 import { Behavior } from '../../../../common/interfaces/Behavior';
 import { Entity } from '../../../../ecs/classes/Entity';
-import { Body, BodyType, createShapeFromConfig, Shape, SHAPES, Transform } from 'three-physx';
+import { Body, BodyType, ColliderHitEvent, CollisionEvents, createShapeFromConfig, Shape, SHAPES, Transform } from 'three-physx';
 import { PhysicsSystem } from '../../../../physics/systems/PhysicsSystem';
 
 import { addComponent, getComponent } from '../../../../ecs/functions/EntityFunctions';
@@ -13,6 +13,8 @@ import { TransformComponent } from '../../../../transform/components/TransformCo
 import { ColliderComponent } from '../../../../physics/components/ColliderComponent';
 import { GolfCollisionGroups } from '../GolfGameConstants';
 import { Object3DComponent } from '../../../../scene/components/Object3DComponent';
+import { addActionComponent } from '../../../functions/functionsActions';
+import { HasHadCollision } from '../../../actions/HasHadCollision';
 /**
  * @author HydraFire <github.com/HydraFire>
  */
@@ -51,7 +53,14 @@ export const addHole: Behavior = (entity: Entity, args?: any, delta?: number, en
   })
 
   // if we loaded this collider with a model, make it invisible
-//  getComponent(entity, Object3DComponent)?.value?.traverse(obj => obj.visible = false)
+  getComponent(entity, Object3DComponent)?.value?.traverse(obj => obj.visible = false)
 
-  //addColliderWithEntity(entity);
+  body.addEventListener(CollisionEvents.TRIGGER_START, (ev: ColliderHitEvent) => {
+    const otherEntity = ev.bodyOther.userData as Entity;
+    if(typeof otherEntity === 'undefined') return
+    const ballObject = getComponent<GameObject>(otherEntity, GameObject)
+    if(!ballObject || ballObject.role !== 'GolfHole') return;
+    addActionComponent(otherEntity, HasHadCollision);
+  })
+
 };

--- a/packages/engine/src/game/templates/Golf/prefab/GolfBallPrefab.ts
+++ b/packages/engine/src/game/templates/Golf/prefab/GolfBallPrefab.ts
@@ -10,7 +10,7 @@ import { UserControlledColliderComponent } from '../../../../physics/components/
 import { Group, Mesh, Vector3 } from 'three';
 import { AssetLoader } from '../../../../assets/classes/AssetLoader';
 import { Engine } from '../../../../ecs/classes/Engine';
-import { Body, BodyType, CollisionEvents, createShapeFromConfig, SHAPES } from 'three-physx';
+import { Body, BodyType, ColliderHitEvent, CollisionEvents, createShapeFromConfig, SHAPES } from 'three-physx';
 import { CollisionGroups } from '../../../../physics/enums/CollisionGroups';
 import { PhysicsSystem } from '../../../../physics/systems/PhysicsSystem';
 import { addComponent, getComponent, getMutableComponent } from '../../../../ecs/functions/EntityFunctions';
@@ -88,15 +88,15 @@ export const initializeGolfBall = (entity: Entity) => {
 
   const collider = getMutableComponent(entity, ColliderComponent);
   collider.body = body;
-/*
-  body.addEventListener(CollisionEvents.TRIGGER_START, (ev: ColliderHitEvent) => {
-    const otherEntity = ev.bodyOther.userData as Entity;
-    if(typeof otherEntity === 'undefined') return
-    const ballObject = getComponent<GameObject>(otherEntity, GameObject)
-    if(!ballObject || ballObject.role !== 'GolfHole') return;
-    addActionComponent(otherEntity, HasHadCollision);
-  })
-*/
+
+
+  // DEBUG - teleport ball to over hole
+  if(typeof globalThis.document !== 'undefined')
+    document.addEventListener('keypress', (ev) => {
+      if(ev.key === 'o') {
+        collider.body.updateTransform({ translation: { x: -2.2, y: 1, z: 0.23 }})
+      }
+    })
 }
 
 export const createGolfBallPrefab = ( args:{ parameters?: any, networkId?: number, uniqueId: string, ownerId?: string }) => {

--- a/packages/engine/src/game/templates/Golf/prefab/GolfClubPrefab.ts
+++ b/packages/engine/src/game/templates/Golf/prefab/GolfClubPrefab.ts
@@ -92,7 +92,7 @@ export const updateClub: Behavior = (entityClub: Entity, args?: any, delta?: num
   if(!hasComponent(entityClub, UserControlledColliderComponent)) return;
   // only need to update club if it's our own
   // TODO: remove this when we have IK rig in and can get the right hand pos data
-  if(getComponent(entityClub, UserControlledColliderComponent).ownerNetworkId !== Network.instance.localAvatarNetworkId) return;
+  // if(getComponent(entityClub, UserControlledColliderComponent).ownerNetworkId !== Network.instance.localAvatarNetworkId) return;
 
   const golfClubComponent = getMutableComponent(entityClub, GolfClubComponent);
 
@@ -191,7 +191,7 @@ export const initializeGolfClub = (entity: Entity) => {
 
   // only raycast if it's our own club
   // TODO: remove this when we have IK rig in and can get the right hand pos data
-  if(ownerNetworkObject.networkId === Network.instance.localAvatarNetworkId) {
+  // if(ownerNetworkObject.networkId === Network.instance.localAvatarNetworkId) {
     golfClubComponent.raycast = PhysicsSystem.instance.addRaycastQuery({
       type: SceneQueryType.Closest,
       origin: new Vector3(),
@@ -202,7 +202,7 @@ export const initializeGolfClub = (entity: Entity) => {
     // manually do this until three-physx is fixed
     golfClubComponent.raycast.origin = new Vector3();
     golfClubComponent.raycast.direction = new Vector3();
-  }
+  // }
 
   if(isClient) {
     const handleObject = new Mesh(new BoxBufferGeometry(clubHalfWidth, clubHalfWidth, 0.25), new MeshStandardMaterial({ color: 0xff2126, transparent: true }));

--- a/packages/engine/src/networking/components/NetworkObject.ts
+++ b/packages/engine/src/networking/components/NetworkObject.ts
@@ -20,5 +20,5 @@ NetworkObject._schema = {
   networkId: { type: Types.Number },
   uniqueId: { type: Types.String },
   componentMap: { type: Types.Ref },
-  snapShotTime: { type: Types.Number }
+  snapShotTime: { type: Types.Number, default: 0 }
 };

--- a/packages/engine/src/networking/interfaces/WorldState.ts
+++ b/packages/engine/src/networking/interfaces/WorldState.ts
@@ -6,7 +6,7 @@ import { StateEntityGroup, StateEntityIKGroup } from "../types/SnapshotDataTypes
 
 /** Interface for handling network input. */
 export interface NetworkInputInterface {
-  /** ID of network. */
+  /** network ID of user. */
   networkId: number
   /** Button input received over the network. */
   buttons: Array<{

--- a/packages/engine/src/networking/schema/clientInputSchema.ts
+++ b/packages/engine/src/networking/schema/clientInputSchema.ts
@@ -6,6 +6,18 @@ import { NetworkClientInputInterface } from "../interfaces/WorldState";
 * @author HydraFire <github.com/HydraFire>
  */
 
+export const transformSchema = new Schema({
+  networkId: uint32,
+  snapShotTime: uint32,
+  x: float32,
+  y: float32,
+  z: float32,
+  qX: float32,
+  qY: float32,
+  qZ: float32,
+  qW: float32
+});
+
 export const inputKeySchema = new Schema({
   input: uint8,
   value: uint8, // float32
@@ -56,6 +68,7 @@ export const inputKeyArraySchema = new Schema({
   buttons: [inputKeySchema],
   viewVector: viewVectorSchema,
   snapShotTime: uint32,
+  transforms: [transformSchema],
   clientGameAction: [clientGameAction]
 });
 

--- a/packages/engine/src/networking/systems/ServerNetworkIncomingSystem.ts
+++ b/packages/engine/src/networking/systems/ServerNetworkIncomingSystem.ts
@@ -145,10 +145,10 @@ export class ServerNetworkIncomingSystem extends System {
         console.log('input but no actor...', clientInput.networkId)
       }
 
-      const networkObject = getMutableComponent(Network.instance.networkObjects[clientInput.networkId].component.entity, NetworkObject);
-      if (networkObject != null) {
-        networkObject.snapShotTime = clientInput.snapShotTime;
-        if (networkObject.snapShotTime > clientInput.snapShotTime) return;
+      const userNetworkObject = getMutableComponent(Network.instance.networkObjects[clientInput.networkId].component.entity, NetworkObject);
+      if (userNetworkObject != null) {
+        userNetworkObject.snapShotTime = clientInput.snapShotTime;
+        if (userNetworkObject.snapShotTime > clientInput.snapShotTime) return;
       }
       const delegatedInputReceiver = getComponent(Network.instance.networkObjects[clientInput.networkId].component.entity, DelegatedInputReceiver);
 
@@ -212,7 +212,7 @@ export class ServerNetworkIncomingSystem extends System {
 
       clientInput.transforms?.forEach((transform: StateEntity) => {
         const networkObject = Network.instance.networkObjects[transform.networkId];
-        if(networkObject && networkObject.ownerId === Network.instance.clients[clientInput.networkId].userId) {
+        if(networkObject && networkObject.ownerId === userNetworkObject.ownerId) {
           const collider = getComponent(networkObject.component.entity, ColliderComponent)
           collider.body.updateTransform({
             translation: {

--- a/packages/engine/src/networking/systems/ServerNetworkOutgoingSystem.ts
+++ b/packages/engine/src/networking/systems/ServerNetworkOutgoingSystem.ts
@@ -1,6 +1,8 @@
+import { CharacterComponent } from '../../character/components/CharacterComponent';
 import { IKComponent } from '../../character/components/IKComponent';
 import { Entity } from '../../ecs/classes/Entity';
 import { System } from '../../ecs/classes/System';
+import { Not } from '../../ecs/functions/ComponentFunctions';
 import { getComponent } from '../../ecs/functions/EntityFunctions';
 import { SystemUpdateType } from '../../ecs/functions/SystemUpdateType';
 import { TransformComponent } from '../../transform/components/TransformComponent';
@@ -33,8 +35,7 @@ export class ServerNetworkOutgoingSystem extends System {
       const transformComponent = getComponent(entity, TransformComponent);
       const networkObject = getComponent(entity, NetworkObject);
       const currentPosition = transformComponent.position;
-      const snapShotTime = networkObject.snapShotTime ?? 0;
-
+      const snapShotTime = networkObject.snapShotTime;
 
       Network.instance.transformState.transforms.push({
         networkId: networkObject.networkId,
@@ -42,47 +43,73 @@ export class ServerNetworkOutgoingSystem extends System {
         x: currentPosition.x,
         y: currentPosition.y,
         z: currentPosition.z,
+        // TODO: reduce quaternions over network to three components
         qX: transformComponent.rotation.x,
         qY: transformComponent.rotation.y,
         qZ: transformComponent.rotation.z,
         qW: transformComponent.rotation.w
       });
+    });
+
+    this.queryResults.characterTransforms.all?.forEach((entity: Entity) => {
+
+      const transformComponent = getComponent(entity, TransformComponent);
+      const actor = getComponent(entity, CharacterComponent);
+      const networkObject = getComponent(entity, NetworkObject);
+      const currentPosition = transformComponent.position;
+      const snapShotTime = networkObject.snapShotTime;
+      Network.instance.transformState.transforms.push({
+        networkId: networkObject.networkId,
+        snapShotTime: snapShotTime,
+        x: currentPosition.x,
+        y: currentPosition.y,
+        z: currentPosition.z,
+        qX: actor.viewVector.x,
+        qY: actor.viewVector.y,
+        qZ: actor.viewVector.z,
+        qW: 0 // TODO: reduce quaternions over network to three components
+      });
+    });
+
+    this.queryResults.ikTransforms.all?.forEach((entity: Entity) => {
+
+      const networkObject = getComponent(entity, NetworkObject);
+      const snapShotTime = networkObject.snapShotTime;
 
       const ikComponent = getComponent(entity, IKComponent)
-      if(ikComponent) {
-        const transforms = ikComponent.avatarIKRig.inputs
-        Network.instance.transformState.ikTransforms.push({
-          networkId: networkObject.networkId,
-          snapShotTime: snapShotTime,
-          hmd: {
-            x: transforms.hmd.position.x,
-            y: transforms.hmd.position.y,
-            z: transforms.hmd.position.z,
-            qW: transforms.hmd.quaternion.w,
-            qX: transforms.hmd.quaternion.x,
-            qY: transforms.hmd.quaternion.y,
-            qZ: transforms.hmd.quaternion.z,
-          },
-          left: {
-            x: transforms.leftGamepad.position.x,
-            y: transforms.leftGamepad.position.y,
-            z: transforms.leftGamepad.position.z,
-            qW: transforms.leftGamepad.quaternion.w,
-            qX: transforms.leftGamepad.quaternion.x,
-            qY: transforms.leftGamepad.quaternion.y,
-            qZ: transforms.leftGamepad.quaternion.z,
-          },
-          right: {
-            x: transforms.rightGamepad.position.x,
-            y: transforms.rightGamepad.position.y,
-            z: transforms.rightGamepad.position.z,
-            qW: transforms.rightGamepad.quaternion.w,
-            qX: transforms.rightGamepad.quaternion.x,
-            qY: transforms.rightGamepad.quaternion.y,
-            qZ: transforms.rightGamepad.quaternion.z,
-          },
-        })
-      }
+      const transforms = ikComponent.avatarIKRig.inputs;
+
+      Network.instance.transformState.ikTransforms.push({
+        networkId: networkObject.networkId,
+        snapShotTime: snapShotTime,
+        hmd: {
+          x: transforms.hmd.position.x,
+          y: transforms.hmd.position.y,
+          z: transforms.hmd.position.z,
+          qW: transforms.hmd.quaternion.w,
+          qX: transforms.hmd.quaternion.x,
+          qY: transforms.hmd.quaternion.y,
+          qZ: transforms.hmd.quaternion.z,
+        },
+        left: {
+          x: transforms.leftGamepad.position.x,
+          y: transforms.leftGamepad.position.y,
+          z: transforms.leftGamepad.position.z,
+          qW: transforms.leftGamepad.quaternion.w,
+          qX: transforms.leftGamepad.quaternion.x,
+          qY: transforms.leftGamepad.quaternion.y,
+          qZ: transforms.leftGamepad.quaternion.z,
+        },
+        right: {
+          x: transforms.rightGamepad.position.x,
+          y: transforms.rightGamepad.position.y,
+          z: transforms.rightGamepad.position.z,
+          qW: transforms.rightGamepad.quaternion.w,
+          qX: transforms.rightGamepad.quaternion.x,
+          qY: transforms.rightGamepad.quaternion.y,
+          qZ: transforms.rightGamepad.quaternion.z,
+        },
+      })
     });
 
     if (
@@ -95,7 +122,7 @@ export class ServerNetworkOutgoingSystem extends System {
       Network.instance.worldState.gameStateActions.length
     ) {
       const bufferReliable = WorldStateModel.toBuffer(Network.instance.worldState);
-      if(!bufferReliable){
+      if (!bufferReliable) {
         console.warn("Reliable buffer is null");
         console.warn(Network.instance.worldState);
       } else {
@@ -114,7 +141,13 @@ export class ServerNetworkOutgoingSystem extends System {
   /** System queries. */
   static queries: any = {
     networkTransforms: {
-      components: [ NetworkObject, TransformComponent ] // CharacterComponent ? we sent double to network objects to ?
+      components: [Not(CharacterComponent), NetworkObject, TransformComponent] // CharacterComponent ? we sent double to network objects to ?
+    },
+    characterTransforms: {
+      components: [CharacterComponent, NetworkObject, TransformComponent] // CharacterComponent ? we sent double to network objects to ?
+    },
+    ikTransforms: {
+      components: [IKComponent, NetworkObject, TransformComponent] // CharacterComponent ? we sent double to network objects to ?
     },
   }
 }

--- a/packages/engine/src/physics/systems/PhysicsSystem.ts
+++ b/packages/engine/src/physics/systems/PhysicsSystem.ts
@@ -189,7 +189,7 @@ export class PhysicsSystem extends System {
               qY: collider.body.transform.rotation.y,
               qZ: collider.body.transform.rotation.z,
               qW: collider.body.transform.rotation.w,
-              snapShotTime: networkObject.snapShotTime ?? 0,
+              snapShotTime: networkObject.snapShotTime,
             });
             return;
           }

--- a/packages/engine/src/xr/functions/WebXRFunctions.ts
+++ b/packages/engine/src/xr/functions/WebXRFunctions.ts
@@ -38,7 +38,6 @@ export const startXR = async (): Promise<boolean> => {
     cameraFollow.mode = CameraModes.XR;
     const actor = getMutableComponent(Network.instance.localClientEntity, CharacterComponent);
 
-    // until retargeting is fixed, we can simply just not init IK
     initiateIK(Network.instance.localClientEntity)
 
     head = Engine.xrRenderer.getCamera();
@@ -240,6 +239,7 @@ export const getHandTransform = (entity: Entity, hand: ParityValue = ParityValue
   const actor = getComponent(entity, CharacterComponent);
   const transform = getComponent(entity, TransformComponent);
   if(isInXR(entity)) {
+    console.log('isInXR')
     const input = getComponent(entity, Input).data.get(hand === ParityValue.LEFT ? BaseInput.XR_LEFT_HAND : BaseInput.XR_RIGHT_HAND)
     if(input) {
       const sixdof = input.value as SIXDOFType;


### PR DESCRIPTION
- [x] sends the character's viewVector instead of it's rotation over the network, allowing pitch and roll data to be sent (as opposed to just yaw due to the way the server handles client rotation)

- [x] fix client ownership of network objects