### PR TITLE
Entity scene objects now added via query instead of manually

### DIFF
--- a/packages/engine/src/assets/classes/AssetLoader.ts
+++ b/packages/engine/src/assets/classes/AssetLoader.ts
@@ -160,11 +160,6 @@ export class AssetLoader {
             } else {
                 addObject3DComponent(this.params.entity, { obj3d: asset });
             }
-
-            asset.children.forEach(obj => {
-                const e = createEntity();
-                addObject3DComponent(e, { obj3d: obj, parentEntity: this.params.entity });
-            });
         }
     }
 

--- a/packages/engine/src/ecs/functions/EngineFunctions.ts
+++ b/packages/engine/src/ecs/functions/EngineFunctions.ts
@@ -164,8 +164,10 @@ function processDeferredEntityRemoval () {
 
       const component = entity.componentsToRemove[Component._typeId];
       delete entity.componentsToRemove[Component._typeId];
-      component.dispose();
-      Engine.numComponents[component._typeId]--;
+      if(component) {
+        component.dispose();
+        Engine.numComponents[component._typeId]--;
+      }
     }
   }
 

--- a/packages/engine/src/game/templates/Golf/behaviors/addHole.ts
+++ b/packages/engine/src/game/templates/Golf/behaviors/addHole.ts
@@ -10,8 +10,9 @@ import { ColliderComponent } from '../../../../physics/components/ColliderCompon
 import { GolfCollisionGroups } from '../GolfGameConstants';
 import { Object3DComponent } from '../../../../scene/components/Object3DComponent';
 import { getGame } from '../../../functions/functions';
+import { GameObjectInteractionBehavior } from '../../../interfaces/GameObjectPrefab';
 
-export const onHoleCollideWithBall = (entityHole: Entity, delta: number, args: { hitEvent: ColliderHitEvent }, entityBall: Entity) => {
+export const onHoleCollideWithBall: GameObjectInteractionBehavior = (entityHole: Entity, delta: number, args: { hitEvent: ColliderHitEvent }, entityBall: Entity) => {
   
   const game = getGame(entityHole);
   const teeEntity = game.gameObjects['GolfTee'][0];
@@ -26,7 +27,6 @@ export const onHoleCollideWithBall = (entityHole: Entity, delta: number, args: {
     },
     rotation: {}
   })
-  return;
 }
 
 

--- a/packages/engine/src/game/templates/Golf/behaviors/nextTurn.ts
+++ b/packages/engine/src/game/templates/Golf/behaviors/nextTurn.ts
@@ -9,14 +9,14 @@ import { YourTurn } from "../components/YourTurnTagComponent";
  */
 
 export const nextTurn: Behavior = (entity: Entity, args?: any, delta?: number, entityTarget?: Entity, time?: number, checks?: any): void => {
-  console.warn('NEXT TURN');
+  // console.warn('NEXT TURN');
   const game = getGame(entity);
   const arrPlayersInGame = Object.keys(game.gamePlayers).filter(role => game.gamePlayers[role].length);
   if (arrPlayersInGame.length < 2) return;
 
   const whoseRoleTurnNow = arrPlayersInGame.filter(role => hasComponent(game.gamePlayers[role][0], YourTurn))[0];
   const roleNumber = parseFloat(whoseRoleTurnNow[0]);
-  console.warn('remove TURN');
+  // console.warn('remove TURN');
   removeStateComponent(game.gamePlayers[whoseRoleTurnNow][0], YourTurn);
 
   const sortedRoleNumbers = arrPlayersInGame.map(v => parseFloat(v[0])).sort((a,b) => b - a);

--- a/packages/engine/src/game/templates/Golf/prefab/GolfBallPrefab.ts
+++ b/packages/engine/src/game/templates/Golf/prefab/GolfBallPrefab.ts
@@ -40,7 +40,6 @@ function assetLoadCallback(group: Group, entity: Entity) {
   ballMesh.receiveShadow = true;
   ballMesh.material && WebGLRendererSystem.instance.csm.setupMaterial(ballMesh.material);
   addComponent(entity, Object3DComponent, { value: ballMesh });
-  Engine.scene.add(ballMesh);
 
   // DEBUG - teleport ball to over hole
   if(typeof globalThis.document !== 'undefined')

--- a/packages/engine/src/game/templates/Golf/prefab/GolfClubPrefab.ts
+++ b/packages/engine/src/game/templates/Golf/prefab/GolfClubPrefab.ts
@@ -26,6 +26,7 @@ import { getHandTransform } from '../../../../xr/functions/WebXRFunctions';
 import { CharacterComponent } from '../../../../character/components/CharacterComponent';
 import { setupSceneObjects } from '../../../../scene/functions/setupSceneObjects';
 import { DebugArrowComponent } from '../../../../debug/DebugArrowComponent';
+import { GameObjectInteractionBehavior } from '../../../interfaces/GameObjectPrefab';
 
 const vector0 = new Vector3();
 const vector1 = new Vector3();
@@ -177,10 +178,10 @@ export const updateClub: Behavior = (entityClub: Entity, args?: any, delta?: num
 
 // https://github.com/PersoSirEduard/OculusQuest-Godot-MiniGolfGame/blob/master/Scripts/GolfClub/GolfClub.gd#L18
 
-export const onClubColliderWithBall = (entity: Entity, delta: number, args: { hitEvent: ColliderHitEvent }, entityOther: Entity) => {
+export const onClubColliderWithBall: GameObjectInteractionBehavior = (entity: Entity, delta: number, args: { hitEvent: ColliderHitEvent }, entityOther: Entity) => {
   if(!isClient) return;
   const golfClubComponent = getMutableComponent(entity, GolfClubComponent);
-  if(!golfClubComponent.canHitBall) return;
+  if(!golfClubComponent.canHitBall || golfClubComponent.hasHitBall) return;
 
   // force is in kg, we need it in grams, so x1000
   const velocityMultiplier = clubPowerMultiplier * 1000;
@@ -221,9 +222,9 @@ export const onClubColliderWithBall = (entity: Entity, delta: number, args: { hi
   args.hitEvent.bodyOther.addForce(vector1);
   golfClubComponent.hasHitBall = true;
   enableClub(entity, false);
-  setInterval(() => {
+  setTimeout(() => {
     golfClubComponent.hasHitBall = false;
-  }, 500)
+  }, 3000)
   return;
 }
 
@@ -287,7 +288,6 @@ export const initializeGolfClub = (entity: Entity) => {
     setupSceneObjects(meshGroup);
 
     addComponent(entity, Object3DComponent, { value: meshGroup });
-    Engine.scene.add(meshGroup);
   }
 
   const shapeHead = createShapeFromConfig({

--- a/packages/engine/src/game/templates/GolfGameMode.ts
+++ b/packages/engine/src/game/templates/GolfGameMode.ts
@@ -280,29 +280,7 @@ export const GolfGameMode: GameMode = somePrepareFunction({
     }
   },
   gameObjectRoles: {
-    'GolfBall': {
-      /*
-      'teleport': [
-        {
-          behavior: teleportObject,
-          watchers:[ [ Action.HasHadCollision ] ],
-          takeEffectOn: {
-            targetsRole: {
-              'GolfTee': {
-                checkers:[{
-                    function: customChecker,
-                    args: {
-                      on: 'GolfHole',
-                      watchers: [ [ Action.HasHadCollision ] ]
-                     }
-                  }]
-              }
-            }
-          }
-        },
-      ]
-      */
-    },
+    'GolfBall': {},
     'GolfTee': {},
     'GolfHole': {
       'goal': [

--- a/packages/engine/src/game/templates/gameDefault/behaviors/switchState.ts
+++ b/packages/engine/src/game/templates/gameDefault/behaviors/switchState.ts
@@ -12,7 +12,7 @@ import { getTargetEntity } from '../../../functions/functions';
    const entityArg = getTargetEntity(entity, entityTarget, args);
    if (hasComponent(entityArg, args.remove)) {
      removeStateComponent(entityArg, args.remove);
-     console.warn('switchState: '+args.add.name)
+    //  console.warn('switchState: '+args.add.name)
      addStateComponent(entityArg, args.add);
    }
  };

--- a/packages/engine/src/scene/behaviors/addObject3DComponent.ts
+++ b/packages/engine/src/scene/behaviors/addObject3DComponent.ts
@@ -208,7 +208,7 @@ export const addObject3DComponent: Behavior = (
   });
   if (args.parentEntity && hasComponent(args.parentEntity, Object3DComponent as any)) {
     getComponent<Object3DComponent>(args.parentEntity, Object3DComponent).value.add(object3d);
-  } else Engine.scene.add(object3d);
+  }
   object3d.entity = entity;
   return entity;
 };

--- a/packages/engine/src/transform/systems/TransformSystem.ts
+++ b/packages/engine/src/transform/systems/TransformSystem.ts
@@ -1,4 +1,5 @@
 import { Euler, Quaternion } from 'three';
+import { Engine } from '../../ecs/classes/Engine';
 import { System } from '../../ecs/classes/System';
 import { getComponent, getMutableComponent, hasComponent, removeComponent } from "../../ecs/functions/EntityFunctions";
 import { SystemUpdateType } from '../../ecs/functions/SystemUpdateType';
@@ -21,6 +22,24 @@ export class TransformSystem extends System {
   updateType = SystemUpdateType.Fixed;
 
   execute (delta) {
+
+    this.queryResults.object3d?.added?.forEach((entity) => {
+      const object3DComponent = getComponent<Object3DComponent>(entity, Object3DComponent);
+      if(!Engine.scene.children.includes(object3DComponent.value)) {
+        Engine.scene.add(object3DComponent.value);
+      } else {
+        console.warn('[Object3DComponent]: Scene object has been added manually.')
+      }
+    })
+
+    this.queryResults.object3d?.removed?.forEach((entity) => {
+      const object3DComponent = getComponent<Object3DComponent>(entity, Object3DComponent, true);
+      if(Engine.scene.children.includes(object3DComponent.value)) {
+        Engine.scene.remove(object3DComponent.value);
+      } else {
+        console.warn('[Object3DComponent]: Scene object has been removed manually.')
+      }
+    })
 
     this.queryResults.parent.all?.forEach(entity => {
       const parentTransform = getMutableComponent(entity, TransformComponent);
@@ -156,6 +175,13 @@ export class TransformSystem extends System {
 }
 
 TransformSystem.queries = {
+  object3d: {
+    components: [Object3DComponent],
+    listen: {
+      added: true,
+      changed: true
+    }
+  },
   parent: {
     components: [TransformParentComponent, TransformComponent]
   },


### PR DESCRIPTION
- Instead of adding/removing scene objects in various places, consolidate to Object3DComponent query
- Stop creating entities for all child objects recursively in the asset loader
- Various fixes