### PR TITLE
network bug fix, fix lots of golf logic, renaming

### DIFF
--- a/packages/engine/index.ts
+++ b/packages/engine/index.ts
@@ -117,7 +117,7 @@ export * from './src/editor/functions/StaticMode';
 export * from './src/editor/functions/thumbnails';
 export * from './src/editor/functions/utils';
 export * from './src/editor/renderer/EnvironmentMap';
-export * from './src/game/actions/HaveBeenInteracted';
+export * from './src/game/actions/HasHadInteraction';
 export * from './src/game/components/Game';
 export * from './src/game/components/GameObject';
 export * from './src/game/components/GamePlayer';

--- a/packages/engine/src/character/prefabs/NetworkPlayerCharacter.ts
+++ b/packages/engine/src/character/prefabs/NetworkPlayerCharacter.ts
@@ -232,7 +232,7 @@ export function createNetworkPlayer(args: { ownerId: string | number, networkId?
 	}
 	);
   if (!isClient) {
-    Network.instance.createObjects.push({
+    Network.instance.worldState.createObjects.push({
         networkId: networkComponent.networkId,
         ownerId: networkComponent.ownerId,
         prefabType: PrefabType.Player,

--- a/packages/engine/src/game/actions/HasHadInteraction.ts
+++ b/packages/engine/src/game/actions/HasHadInteraction.ts
@@ -4,7 +4,7 @@ import { Types } from "../../ecs/types/Types";
 /**
  * @author HydraFire <github.com/HydraFire>
  */
-export class HaveBeenInteracted extends Component<any> {
+export class HasHadInteraction extends Component<any> {
   entityNetworkId?: number;
   args?: any;
   static _schema = { 

--- a/packages/engine/src/game/functions/functions.ts
+++ b/packages/engine/src/game/functions/functions.ts
@@ -75,7 +75,7 @@ export const removeSpawnedObjects = ( entity: Entity, playerComponent, game ) =>
         if (networkObject.ownerId !== userUuId) return;
         if (networkObject.uniqueId === userUuId) return;
         // If it does, tell clients to destroy it
-        Network.instance.destroyObjects.push({ networkId: networkObject.component.networkId });
+        Network.instance.worldState.destroyObjects.push({ networkId: networkObject.component.networkId });
         // get network object
         const entityObject = Network.instance.networkObjects[key].component.entity;
         // Remove the entity and all of it's components

--- a/packages/engine/src/game/templates/DefaultGameMode.ts
+++ b/packages/engine/src/game/templates/DefaultGameMode.ts
@@ -6,7 +6,7 @@ import { Closed } from "./gameDefault/components/ClosedTagComponent";
 import { ButtonUp } from "./gameDefault/components/ButtonUpTagComponent";
 import { ButtonDown } from "./gameDefault/components/ButtonDownTagComponent";
 // game Action Tag Component
-import { HaveBeenInteracted } from "../../game/actions/HaveBeenInteracted";
+import { HasHadInteraction } from "../../game/actions/HasHadInteraction";
 // game behavior
 //import { upDownButton } from "./gameDefault/behaviors/upDownButton";
 //import { giveOpenOrCloseState, doorOpeningOrClosing } from "./gameDefault/behaviors/openOrCloseDoor";
@@ -22,7 +22,7 @@ export const DefaultGameMode: GameMode = {
   name: "Default",
   priority: 0,
   registerActionTagComponents: [
-    HaveBeenInteracted
+    HasHadInteraction
   ],
   registerStateTagComponents: [
     Open,
@@ -67,7 +67,7 @@ export const DefaultGameMode: GameMode = {
         {
           behavior: giveOpenOrCloseState,
           args: { on: 'target'},
-          watchers:[ [ HaveBeenInteracted ] ],
+          watchers:[ [ HasHadInteraction ] ],
           checkers:[{
             function: ifNamed,
             args: { on: 'me', name: 'button 1' }
@@ -88,7 +88,7 @@ export const DefaultGameMode: GameMode = {
         {
           behavior: giveOpenOrCloseState,
           args: { on: 'target'},
-          watchers:[ [ HaveBeenInteracted ] ],
+          watchers:[ [ HasHadInteraction ] ],
           checkers:[{
             function: ifNamed,
             args: { on: 'me', name: 'button 2' }
@@ -111,7 +111,7 @@ export const DefaultGameMode: GameMode = {
         {
           behavior: upDownButton,
           args:{ action: 'down', animationSpeed: 3 },
-          watchers:[ [ HaveBeenInteracted, ButtonUp ] ],
+          watchers:[ [ HasHadInteraction, ButtonUp ] ],
           checkers:[{
             function: ifNamed,
             args: { on: 'me', name: 'button 1' }
@@ -120,7 +120,7 @@ export const DefaultGameMode: GameMode = {
         {
           behavior: upDownButton,
           args:{ action: 'up', animationSpeed: 3 },
-          watchers:[ [ HaveBeenInteracted, ButtonDown ] ],
+          watchers:[ [ HasHadInteraction, ButtonDown ] ],
           checkers:[{
             function: ifNamed,
             args: { on: 'me', name: 'button 1' }
@@ -129,7 +129,7 @@ export const DefaultGameMode: GameMode = {
         {
           behavior: upDownButton,
           args:{ action: 'down', animationSpeed: 3 },
-          watchers:[ [ HaveBeenInteracted, ButtonUp ] ],
+          watchers:[ [ HasHadInteraction, ButtonUp ] ],
           checkers:[{
             function: ifNamed,
             args: { on: 'me', name: 'button 2' }
@@ -138,7 +138,7 @@ export const DefaultGameMode: GameMode = {
         {
           behavior: upDownButton,
           args:{ action: 'up', animationSpeed: 3 },
-          watchers:[ [ HaveBeenInteracted, ButtonDown ] ],
+          watchers:[ [ HasHadInteraction, ButtonDown ] ],
           checkers:[{
             function: ifNamed,
             args: { on: 'me', name: 'button 2' }
@@ -173,7 +173,7 @@ export const DefaultGameMode: GameMode = {
         {
           behavior: giveOpenOrCloseState,
           args: { on: 'me'},
-          watchers:[ [ HaveBeenInteracted ] ]
+          watchers:[ [ HasHadInteraction ] ]
         }
       ],
       'moveDoor': [

--- a/packages/engine/src/game/templates/Golf/behaviors/addTurn.ts
+++ b/packages/engine/src/game/templates/Golf/behaviors/addTurn.ts
@@ -5,14 +5,20 @@ import { addStateComponent, removeStateComponent } from '../../../../game/functi
 import { GamePlayer } from "../../../components/GamePlayer";
 import { getGame } from '../../../functions/functions';
 import { YourTurn } from "../components/YourTurnTagComponent";
+import { spawnBall } from './spawnBall';
 /**
  * @author HydraFire <github.com/HydraFire>
  */
 
-export const addTurn: Behavior = (entity: Entity, args?: any, delta?: number, entityTarget?: Entity, time?: number, checks?: any): void => {
-  const game = getGame(entity);
+export const addTurn: Behavior = (entityPlayer: Entity, args?: any, delta?: number, entityTarget?: Entity, time?: number, checks?: any): void => {
+  const game = getGame(entityPlayer);
   const noOneTurn = Object.keys(game.gamePlayers).every(role => game.gamePlayers[role].every(entity => !hasComponent(entity, YourTurn)));
   if (noOneTurn) {
-    addStateComponent(entity, YourTurn);
+    addStateComponent(entityPlayer, YourTurn);
   }
+
+  // Temporary
+  setTimeout(() => {
+    spawnBall(entityPlayer);
+  }, 2000)
 };

--- a/packages/engine/src/game/templates/Golf/behaviors/nextTurn.ts
+++ b/packages/engine/src/game/templates/Golf/behaviors/nextTurn.ts
@@ -9,14 +9,14 @@ import { YourTurn } from "../components/YourTurnTagComponent";
  */
 
 export const nextTurn: Behavior = (entity: Entity, args?: any, delta?: number, entityTarget?: Entity, time?: number, checks?: any): void => {
-  // console.warn('NEXT TURN');
+  console.warn('NEXT TURN');
   const game = getGame(entity);
   const arrPlayersInGame = Object.keys(game.gamePlayers).filter(role => game.gamePlayers[role].length);
   if (arrPlayersInGame.length < 2) return;
 
   const whoseRoleTurnNow = arrPlayersInGame.filter(role => hasComponent(game.gamePlayers[role][0], YourTurn))[0];
   const roleNumber = parseFloat(whoseRoleTurnNow[0]);
-  // console.warn('remove TURN');
+  console.warn('remove TURN');
   removeStateComponent(game.gamePlayers[whoseRoleTurnNow][0], YourTurn);
 
   const sortedRoleNumbers = arrPlayersInGame.map(v => parseFloat(v[0])).sort((a,b) => b - a);

--- a/packages/engine/src/game/templates/Golf/behaviors/spawnBall.ts
+++ b/packages/engine/src/game/templates/Golf/behaviors/spawnBall.ts
@@ -1,5 +1,5 @@
 import { Entity } from '../../../../ecs/classes/Entity';
-import { getComponent } from '../../../../ecs/functions/EntityFunctions';
+import { addComponent, getComponent } from '../../../../ecs/functions/EntityFunctions';
 import { NetworkObject } from '../../../../networking/components/NetworkObject';
 import { createGolfBallPrefab } from '../prefab/GolfBallPrefab';
 import { Network } from '../../../../networking/classes/Network';
@@ -8,6 +8,7 @@ import { getGame } from '../../../functions/functions';
 import { MathUtils } from 'three';
 import { GolfPrefabTypes } from '../GolfGameConstants';
 import { TransformComponent } from "../../../../transform/components/TransformComponent";
+
 /**
  * @author HydraFire <github.com/HydraFire>
  */
@@ -29,14 +30,9 @@ export const spawnBall = (playerEntity: Entity): void => {
     .filter((entity) => getComponent(entity, NetworkObject)?.ownerId === ownerId)
     .length > 0;
 
+  if(playerHasBall) return;
 
-  // console.log(ownerId, 'playerHasBall', playerHasBall)
-
-  // if we already have a ball in the world, we shouldn't spawn a new one
-  /// TODO: just give them one until we have unspawning etc working
-  // if(playerHasBall) return;
-
-  console.log('making ball for player', ownerId)
+  console.log('making ball for player', ownerId, playerHasBall)
 
   const networkId = Network.getNetworkId();
   const uuid = MathUtils.generateUUID();

--- a/packages/engine/src/game/templates/GolfGameMode.ts
+++ b/packages/engine/src/game/templates/GolfGameMode.ts
@@ -44,6 +44,7 @@ import { ColliderComponent } from "../../physics/components/ColliderComponent";
 import { BodyType } from "three-physx";
 import { Euler, Quaternion, Vector3 } from "three";
 import { removeSpawnedObjects } from "../functions/functions";
+import { updateBall } from "./Golf/prefab/GolfBallPrefab";
 
 
 
@@ -54,7 +55,7 @@ import { removeSpawnedObjects } from "../functions/functions";
 
 const templates = {
 
-  switchStateTAndObjectMove: ({x=0, y=0, z=0, stateToMove, stateToMoveBack, min=0.2, max=3 }) => {
+  switchStateAndObjectMove: ({x=0, y=0, z=0, stateToMove, stateToMoveBack, min=0.2, max=3 }) => {
     return [{
       behavior: objectMove,
       args:{ vectorAndSpeed: { x: x * -1, y: y * -1, z: z * -1} },
@@ -84,14 +85,14 @@ const templates = {
     }]
   },
 
-  haveBeenInteractedAndSwitchState: ({ remove, add }) => {
+  hasHadInteractionAndSwitchState: ({ remove, add }) => {
     return [{
       behavior: switchState,
-      watchers:[ [ Action.HaveBeenInteracted, remove ] ], // components in one array means HaveBeenInteracted && Close, in different means HaveBeenInteracted || Close
+      watchers:[ [ Action.HasHadInteraction, remove ] ], // components in one array means HasHadInteraction && Close, in different means HasHadInteraction || Close
       args: { on: 'me', remove: remove, add: add },
     },{
       behavior: switchState,
-      watchers:[ [ Action.HaveBeenInteracted, add ] ],
+      watchers:[ [ Action.HasHadInteraction, add ] ],
       args: { on: 'me', remove: add, add: remove },
     }]
   },
@@ -152,7 +153,7 @@ export const GolfGameMode: GameMode = somePrepareFunction({
   registerStateTagComponents: [], // now auto adding
   initGameState: {
     'newPlayer': {
-      behaviors: [addRole, spawnBall, spawnClub]
+      behaviors: [addRole, spawnClub]
     },
     '1-Player': {
       behaviors: [addTurn, initScore]
@@ -196,20 +197,6 @@ export const GolfGameMode: GameMode = somePrepareFunction({
     'newPlayer': {},
     '1-Player': {
       'hitBall': [
-/*
-        {
-          behavior: addForce,
-          args: { on: 'target', upForce: 250, forwardForce: 100 },
-          watchers:[ [ YourTurn ] ],
-          takeEffectOn: {
-            targetsRole: {
-              'GolfBall': {
-                watchers:[ [ HaveBeenInteracted ] ]
-              }
-            }
-          }
-        },
-*/
         {
           behavior: switchState,
           args: { on: 'target' },
@@ -235,7 +222,7 @@ export const GolfGameMode: GameMode = somePrepareFunction({
           takeEffectOn: {
             targetsRole: {
               'GolfBall': {
-                watchers:[ [ HaveBeenInteracted ] ],
+                watchers:[ [ HasHadInteraction ] ],
                 checkers:[{
                   function: ifNamed,
                   args: { on: 'target', name: '1' }
@@ -247,7 +234,7 @@ export const GolfGameMode: GameMode = somePrepareFunction({
 */
         { //doBallNotHiting //GameObjectCollisionTag
           behavior: switchState,
-          args: { on: 'target', add: State.Deactive, remove: State.Active },
+          args: { on: 'target', add: State.Inactive, remove: State.Active },
           watchers:[ [ State.YourTurn ] ],
           takeEffectOn: {
             targetsRole: {
@@ -271,7 +258,7 @@ export const GolfGameMode: GameMode = somePrepareFunction({
           takeEffectOn: {
             targetsRole: {
               'GolfBall': {
-                watchers:[ [ State.Deactive, Action.BallStopped ] ],
+                watchers:[ [ State.Inactive, Action.BallStopped ] ],
               }
             }
           }
@@ -280,7 +267,14 @@ export const GolfGameMode: GameMode = somePrepareFunction({
     }
   },
   gameObjectRoles: {
-    'GolfBall': {},
+    'GolfBall': {
+      'update': [
+        {
+          behavior: updateBall,
+          args: {},
+        }
+      ],
+    },
     'GolfTee': {},
     'GolfHole': {
       'goal': [
@@ -297,43 +291,6 @@ export const GolfGameMode: GameMode = somePrepareFunction({
             }
           }
         },
-        /* NEED WORK
-        {
-          behavior: giveState,
-          args: { on: 'target', component: Goal },
-          watchers:[ [ HasHadCollision ] ],
-          takeEffectOn: {
-            targetsRole: {
-              '1-Player' : {
-                checkers:[{
-                    function: customChecker,
-                    args: {
-                      on: 'GolfBall',
-                      watchers: [ [ HasHadCollision ] ],
-                      checkers:[{
-                        function: ifNamed,
-                        args: { on: 'me', name: '1' }
-                      }]
-                     }
-                  }]
-              },
-              '2-Player' : {
-                checkers:[{
-                    function: customChecker,
-                    args: {
-                      on: 'GolfBall',
-                      watchers: [ [ HasHadCollision ] ],
-                      checkers:[{
-                        function: ifNamed,
-                        args: { on: 'me', name: '2' }
-                      }]
-                     }
-                  }]
-              },
-            }
-          }
-        },
-        */
        ]
     },
     'GolfClub': {
@@ -343,39 +300,27 @@ export const GolfGameMode: GameMode = somePrepareFunction({
           args: {},
         }
       ],
-      'grab': [
-        {
-          behavior: grabEquippable,
-          args: (entityGolfclub) =>  {
-            return { ...getComponent(entityGolfclub, Action.HaveBeenInteracted).args }
-          },
-          watchers:[ [ Action.HaveBeenInteracted ] ],
-          takeEffectOn: (entityGolfclub) =>  {
-            if(!getComponent(entityGolfclub, Action.HaveBeenInteracted).entityNetworkId) return;
-            return Network.instance.networkObjects[getComponent(entityGolfclub, Action.HaveBeenInteracted).entityNetworkId].component.entity },
-        },
-      ]
     },
     'GoalPanel': {
-      'objectMove': templates.switchStateTAndObjectMove( { y:1, stateToMoveBack: State.PanelDown, stateToMove: State.PanelUp,  min: 0.2, max: 3 })
+      'objectMove': templates.switchStateAndObjectMove( { y:1, stateToMoveBack: State.PanelDown, stateToMove: State.PanelUp,  min: 0.2, max: 3 })
     },
     '1stTurnPanel': {
-      'objectMove' : templates.switchStateTAndObjectMove({ y:1, min: 0.2, max: 4, stateToMoveBack: State.PanelDown, stateToMove: State.PanelUp })
+      'objectMove' : templates.switchStateAndObjectMove({ y:1, min: 0.2, max: 4, stateToMoveBack: State.PanelDown, stateToMove: State.PanelUp })
     },
     '2stTurnPanel': {
-      'objectMove' : templates.switchStateTAndObjectMove({ y:1, min: 0.2, max: 4, stateToMoveBack: State.PanelDown, stateToMove: State.PanelUp })
+      'objectMove' : templates.switchStateAndObjectMove({ y:1, min: 0.2, max: 4, stateToMoveBack: State.PanelDown, stateToMove: State.PanelUp })
     },
     'StartGamePanel': {
       'switchState': templates.isPlayerInGameAndSwitchState({ remove: State.PanelUp, add: State.PanelDown }),
-      'objectMove': templates.switchStateTAndObjectMove({ y:1, min: 0.2, max: 5, stateToMoveBack: State.PanelDown, stateToMove: State.PanelUp })
+      'objectMove': templates.switchStateAndObjectMove({ y:1, min: 0.2, max: 5, stateToMoveBack: State.PanelDown, stateToMove: State.PanelUp })
     },
     'WaitingPanel': {
       'switchState': templates.isPlayerInGameAndSwitchState({ remove: State.PanelDown, add: State.PanelUp }),
-      'objectMove': templates.switchStateTAndObjectMove({ y:1, min: 0.2, max: 5, stateToMoveBack: State.PanelDown, stateToMove: State.PanelUp })
+      'objectMove': templates.switchStateAndObjectMove({ y:1, min: 0.2, max: 5, stateToMoveBack: State.PanelDown, stateToMove: State.PanelUp })
     },
     'Door': {
-      'switchState': templates.haveBeenInteractedAndSwitchState({ remove: State.Closed, add: State.Open }),
-      'objectMove': templates.switchStateTAndObjectMove({ z:1, min: 0.2, max: 3, stateToMoveBack: State.Closed, stateToMove: State.Open })
+      'switchState': templates.hasHadInteractionAndSwitchState({ remove: State.Closed, add: State.Open }),
+      'objectMove': templates.switchStateAndObjectMove({ z:1, min: 0.2, max: 3, stateToMoveBack: State.Closed, stateToMove: State.Open })
     }
   }
 });

--- a/packages/engine/src/game/templates/gameDefault/behaviors/switchState.ts
+++ b/packages/engine/src/game/templates/gameDefault/behaviors/switchState.ts
@@ -1,9 +1,9 @@
-import { CollisionEvents } from 'three-physx';
 import { Behavior } from '../../../../common/interfaces/Behavior';
 import { Entity } from '../../../../ecs/classes/Entity';
 import { hasComponent } from "../../../../ecs/functions/EntityFunctions";
 import { addStateComponent, removeStateComponent } from '../../../../game/functions/functionsState';
 import { getTargetEntity } from '../../../functions/functions';
+
 /**
  * @author HydraFire <github.com/HydraFire>
  */
@@ -12,7 +12,7 @@ import { getTargetEntity } from '../../../functions/functions';
    const entityArg = getTargetEntity(entity, entityTarget, args);
    if (hasComponent(entityArg, args.remove)) {
      removeStateComponent(entityArg, args.remove);
-    //  console.warn('switchState: '+args.add.name)
+     console.warn('switchState: '+args.add.name)
      addStateComponent(entityArg, args.add);
    }
  };

--- a/packages/engine/src/game/templates/gameDefault/components/InactiveTagComponent.ts
+++ b/packages/engine/src/game/templates/gameDefault/components/InactiveTagComponent.ts
@@ -4,4 +4,4 @@ import { Component } from "../../../../ecs/classes/Component";
  * @author HydraFire <github.com/HydraFire>
  */
 
-export class Deactive extends Component<any> {}
+export class Inactive extends Component<any> {}

--- a/packages/engine/src/game/types/GameComponents.ts
+++ b/packages/engine/src/game/types/GameComponents.ts
@@ -1,5 +1,5 @@
 // Action Components
-import { HaveBeenInteracted } from "../actions/HaveBeenInteracted";
+import { HasHadInteraction } from "../actions/HasHadInteraction";
 import { GameObjectCollisionTag } from "../actions/GameObjectCollisionTag";
 import { BallMoving } from "../actions/BallMoving";
 import { BallStopped } from "../actions/BallStopped";
@@ -14,20 +14,20 @@ import { PanelUp } from '../templates/gameDefault/components/PanelUpTagComponent
 import { YourTurn } from '../templates/Golf/components/YourTurnTagComponent';
 import { Goal } from '../templates/Golf/components/GoalTagComponent';
 import { Active } from "../templates/gameDefault/components/ActiveTagComponent";
-import { Deactive } from "../templates/gameDefault/components/DeactiveTagComponent";
+import { Inactive } from "../templates/gameDefault/components/InactiveTagComponent";
 /**
  * @author HydraFire <github.com/HydraFire>
  */
 // its for adding new Action in State in One Plase, please don't splite this
 enum gameActions {
-    HaveBeenInteracted = 'HaveBeenInteracted',
+    HasHadInteraction = 'HasHadInteraction',
     GameObjectCollisionTag = 'GameObjectCollisionTag',
     BallMoving = 'BallMoving',
     BallStopped = 'BallStopped'
 }
 
 export const Action = {
-    [gameActions.HaveBeenInteracted]: HaveBeenInteracted,
+    [gameActions.HasHadInteraction]: HasHadInteraction,
     [gameActions.GameObjectCollisionTag]: GameObjectCollisionTag,
     [gameActions.BallMoving]: BallMoving,
     [gameActions.BallStopped]: BallStopped
@@ -35,7 +35,7 @@ export const Action = {
 // its for adding new Action in State in One Plase, please don't splite this
 enum gameStates {
     Active = 'Active',
-    Deactive = 'Deactive',
+    Inactive = 'Inactive',
     Open = 'Open',
     Closed = 'Closed',
     ButtonUp = 'ButtonUp',
@@ -49,7 +49,7 @@ enum gameStates {
 
 export const State = {
     [gameStates.Active]: Active,
-    [gameStates.Deactive]: Deactive,
+    [gameStates.Inactive]: Inactive,
     [gameStates.Open]: Open,
     [gameStates.Closed]: Closed,
     [gameStates.ButtonUp]: ButtonUp,

--- a/packages/engine/src/interaction/prefabs/NetworkRigidBody.ts
+++ b/packages/engine/src/interaction/prefabs/NetworkRigidBody.ts
@@ -39,7 +39,7 @@ export function createNetworkRigidBody( args:{ parameters?: any, networkId?: num
     }
   });
   if (!isClient) {
-    Network.instance.createObjects.push({
+    Network.instance.worldState.createObjects.push({
         networkId: networkComponent.networkId,
         ownerId: networkComponent.ownerId,
         prefabType: PrefabType.RigidBody,

--- a/packages/engine/src/interaction/systems/InteractiveSystem.ts
+++ b/packages/engine/src/interaction/systems/InteractiveSystem.ts
@@ -25,7 +25,7 @@ import { InteractiveFocused } from "../components/InteractiveFocused";
 import { Interactor } from "../components/Interactor";
 import { SubFocused } from "../components/SubFocused";
 import { InteractBehaviorArguments } from "../types/InteractionTypes";
-import { HaveBeenInteracted } from "../../game/actions/HaveBeenInteracted";
+import { HasHadInteraction } from "../../game/actions/HasHadInteraction";
 import { addActionComponent } from '../../game/functions/functionsActions';
 import { EquipperComponent } from "../components/EquipperComponent";
 import { EquippedStateUpdateSchema } from "../enums/EquippedEnums";
@@ -89,7 +89,7 @@ export const interactOnServer: Behavior = (entity: Entity, args: { side: ParityV
     const interactionCheck = interactable.onInteractionCheck(entity, focusedArrays[0][0], focusedArrays[0][2]);
 
     if (interactable.data.interactionType === "gameobject") {
-      addActionComponent(focusedArrays[0][0], HaveBeenInteracted, { args, entityNetworkId: getComponent(entity, NetworkObject).networkId });
+      addActionComponent(focusedArrays[0][0], HasHadInteraction, { args, entityNetworkId: getComponent(entity, NetworkObject).networkId });
       return;
     }
     // Not Game Object

--- a/packages/engine/src/networking/classes/Network.ts
+++ b/packages/engine/src/networking/classes/Network.ts
@@ -51,31 +51,16 @@ export class Network {
   schema: NetworkSchema
   /** Clients connected over this network. */
   clients: NetworkClientList = {}
-  /** Newly connected clients over this network in this frame. */
-  clientsConnected = []
-  /** Disconnected client in this frame. */
-  clientsDisconnected = []
   /** List of data producer nodes. */
   dataProducers = new Map<string, any>()
   /** List of data consumer nodes. */
   dataConsumers = new Map<string, any>()
 
-  /** Current game state */
-  gameState: GameStateUpdateMessage[] = []
   clientGameAction: ClientGameActionMessage[] = []
 
   /** Game mode mapping schema */
   loadedGames: Entity[] = []; // its for network
 
-  /** Game actions that happened this frame */
-  gameStateActions: GameStateActionMessage[] = []
-
-  /** Newly created Network Objects in this frame. */
-  createObjects = []
-  /** Destroyed Network Objects in this frame. */
-  editObjects = []
-  /** Destroyed Network Objects in this frame. */
-  destroyObjects = []
   /** Map of Network Objects. */
   networkObjects: NetworkObjectList = {}
   localClientEntity: Entity = null

--- a/packages/engine/src/networking/interfaces/WorldState.ts
+++ b/packages/engine/src/networking/interfaces/WorldState.ts
@@ -61,7 +61,7 @@ export interface PacketNetworkClientInputInterface extends PacketNetworkInputInt
 export interface NetworkClientDataInterface {
   /** Id of the user. */
   userId: string,
-  avatarDetail: any,
+  avatarDetail?: any,
 }
 
 /** Interface to remove network object. */

--- a/packages/engine/src/networking/systems/ServerNetworkIncomingSystem.ts
+++ b/packages/engine/src/networking/systems/ServerNetworkIncomingSystem.ts
@@ -61,30 +61,6 @@ export class ServerNetworkIncomingSystem extends System {
   execute = (delta: number): void => {
     // Create a new worldstate frame for next tick
     Network.instance.tick++;
-    Network.instance.worldState = {
-      clientsConnected: Network.instance.clientsConnected,
-      clientsDisconnected: Network.instance.clientsDisconnected,
-      createObjects: Network.instance.createObjects,
-      editObjects: Network.instance.editObjects,
-      destroyObjects: Network.instance.destroyObjects,
-      gameState: Network.instance.gameState,//.length > 0 ? JSON.stringify(Network.instance.gameState) : [],
-      gameStateActions: Network.instance.gameStateActions
-    };
-
-    Network.instance.transformState = {
-      tick: Network.instance.tick,
-      time: 0,
-      transforms: [],
-      ikTransforms: [],
-    };
-
-    Network.instance.clientsConnected = [];
-    Network.instance.clientsDisconnected = [];
-    Network.instance.createObjects = [];
-    Network.instance.editObjects = [];
-    Network.instance.destroyObjects = [];
-    Network.instance.gameState = [];
-    Network.instance.gameStateActions = [];
 
     // Set input values on server to values sent from clients
     // Parse incoming message queue

--- a/packages/engine/src/networking/systems/ServerNetworkOutgoingSystem.ts
+++ b/packages/engine/src/networking/systems/ServerNetworkOutgoingSystem.ts
@@ -128,6 +128,14 @@ export class ServerNetworkOutgoingSystem extends System {
       } else {
         Network.instance.transport.sendReliableData(bufferReliable);
       }
+
+      Network.instance.worldState.clientsConnected = [];
+      Network.instance.worldState.clientsDisconnected = [];
+      Network.instance.worldState.createObjects = [];
+      Network.instance.worldState.editObjects = [];
+      Network.instance.worldState.destroyObjects = [];
+      Network.instance.worldState.gameState = [];
+      Network.instance.worldState.gameStateActions = [];
     }
 
     const bufferUnreliable = TransformStateModel.toBuffer(Network.instance.transformState);
@@ -136,6 +144,13 @@ export class ServerNetworkOutgoingSystem extends System {
     } catch (error) {
       console.warn("Couldn't send data: ", error)
     }
+
+    Network.instance.transformState = {
+      tick: Network.instance.tick,
+      time: Date.now(),
+      transforms: [],
+      ikTransforms: [],
+    };
   }
 
   /** System queries. */

--- a/packages/engine/src/physics/components/ColliderComponent.ts
+++ b/packages/engine/src/physics/components/ColliderComponent.ts
@@ -12,13 +12,13 @@ export class ColliderComponent extends Component<ColliderComponent> {
   body: Body
   type: string
   mass: number
-  position: Vector3
+  position: Vector3 = new Vector3()
   /**
    * The velocity as calculated by either the physics engine or the physics system for manually inteprolated objects
    */
-  velocity: Vector3
-  quaternion: Quaternion
-  scale: Vector3
+  velocity: Vector3 = new Vector3()
+  quaternion: Quaternion  = new Quaternion()
+  scale: Vector3 = new Vector3()
   mesh: any
   vertices: any
   indices: any
@@ -31,10 +31,10 @@ ColliderComponent._schema = {
   body: { type: Types.Ref, default: null },
   type: { type: Types.String, default: 'box' },
   mass: { type: Types.Number, default: 0 },
-  position: { type: Types.Ref, default: new Vector3() },
-  velocity: { type: Types.Ref, default: new Vector3() },
-  quaternion: { type: Types.Ref, default: new Quaternion() },
-  scale: { type: Types.Ref, default: new Vector3() },
+  position: { type: Types.Ref, default: null },
+  velocity: { type: Types.Ref, default: null },
+  quaternion: { type: Types.Ref, default: null },
+  scale: { type: Types.Ref, default: null },
   mesh: { type: Types.Ref, default: null},
   vertices: { type: Types.Ref, default: null},
   indices: { type: Types.Ref, default: null},

--- a/packages/engine/src/physics/systems/PhysicsSystem.ts
+++ b/packages/engine/src/physics/systems/PhysicsSystem.ts
@@ -2,7 +2,7 @@ import { Not } from '../../ecs/functions/ComponentFunctions';
 import { Engine } from '../../ecs/classes/Engine';
 import { EngineEvents } from '../../ecs/classes/EngineEvents';
 import { System, SystemAttributes } from '../../ecs/classes/System';
-import { getComponent, getMutableComponent, hasComponent } from '../../ecs/functions/EntityFunctions';
+import { getComponent, getMutableComponent } from '../../ecs/functions/EntityFunctions';
 import { SystemUpdateType } from '../../ecs/functions/SystemUpdateType';
 import { LocalInputReceiver } from "../../input/components/LocalInputReceiver";
 import { Network } from '../../networking/classes/Network';
@@ -13,13 +13,10 @@ import { TransformComponent } from '../../transform/components/TransformComponen
 import { ColliderComponent } from '../components/ColliderComponent';
 import { InterpolationComponent } from "../components/InterpolationComponent";
 import { isClient } from '../../common/functions/isClient';
-import { BodyType, ColliderHitEvent, CollisionEvents, PhysXConfig, PhysXInstance } from "three-physx";
+import { BodyType, PhysXConfig, PhysXInstance } from "three-physx";
 import { findInterpolationSnapshot } from '../behaviors/findInterpolationSnapshot';
 import { UserControlledColliderComponent } from '../components/UserControllerObjectComponent';
-import { GameObject } from "../../game/components/GameObject";
-import { addActionComponent } from '../../game/functions/functionsActions';
-import { StaticReadUsage, Vector3 } from 'three';
-import { Action, State } from '../../game/types/GameComponents';
+import { Vector3 } from 'three';
 
 /**
  * @author HydraFire <github.com/HydraFire>
@@ -86,42 +83,6 @@ export class PhysicsSystem extends System {
 
     this.queryResults.collider.all?.forEach(entity => {
       const collider = getMutableComponent<ColliderComponent>(entity, ColliderComponent);
-      // iterate on all collisions since the last update
-      // collider.body.collisionEvents.forEach((event) => {
-
-        // if (hasComponent(entity, GameObject)) {
-          //  const { type, bodySelf, bodyOther, shapeSelf, shapeOther } = event;
-          //  isClient ? console.warn(type, bodySelf, bodyOther, shapeSelf, shapeOther):'';
-          // addActionComponent(entity, HasHadCollision);
-          //    console.warn(event, entity);
-    //    }
-
-        // TODO: figure out how we expose specific behaviors like this
-    //  })
-  //    collider.collisions = []; // clear for next loop
-
-
-      if (collider.body.type === BodyType.DYNAMIC) {
-        if (hasComponent(entity, GameObject) && getComponent(entity, GameObject).role === 'GolfBall') {
-
-
-          if(collider.body.transform.linearVelocity.length() > 1) {
-
-            if(hasComponent(entity, State.Active)) {
-              console.warn('actionMoving')
-              addActionComponent(entity, Action.BallMoving);
-            }
-           } else if(collider.body.transform.linearVelocity.length() > 0.3) {
-             if(hasComponent(entity, State.Deactive)) {
-              console.warn('stop')
-               addActionComponent(entity, Action.BallStopped);
-             }
-            }
-            
-
-        }
-      }
-
       const transform = getComponent(entity, TransformComponent);
       if (collider.body.type === BodyType.KINEMATIC) {
         collider.velocity.subVectors(collider.body.transform.translation, transform.position);

--- a/packages/engine/src/transform/components/TransformComponent.ts
+++ b/packages/engine/src/transform/components/TransformComponent.ts
@@ -12,10 +12,10 @@ export class TransformComponent extends Component<TransformComponent> {
   scale: Vector3
 
   static _schema = {
-    position: { default: new Vector3(), type: Types.Ref },
-    rotation: { default: new Quaternion(), type: Types.Ref },
-    velocity: { default: new Vector3(), type: Types.Ref },
-    scale: { default: new Vector3(1,1,1), type: Types.Ref }
+    position: { type: Types.Ref },
+    rotation: { type: Types.Ref },
+    velocity: { type: Types.Ref },
+    scale: { type: Types.Ref }
   }
 
   constructor () {

--- a/packages/engine/src/vehicle/prefabs/NetworkVehicle.ts
+++ b/packages/engine/src/vehicle/prefabs/NetworkVehicle.ts
@@ -251,7 +251,7 @@ export function createNetworkVehicle( args:{ parameters?: any, networkId?: strin
     }
   });
   if (!isClient) {
-    Network.instance.createObjects.push({
+    Network.instance.worldState.createObjects.push({
         networkId: networkComponent.networkId,
         ownerId: networkComponent.ownerId,
         prefabType: PrefabType.Vehicle,

--- a/packages/gameserver/src/NetworkFunctions.ts
+++ b/packages/gameserver/src/NetworkFunctions.ts
@@ -118,7 +118,7 @@ export function validateNetworkObjects(): void {
 
             const disconnectedClient = Object.assign({}, Network.instance.clients[userId]);
 
-            Network.instance.clientsDisconnected.push({ userId });
+            Network.instance.worldState.clientsDisconnected.push({ userId });
             console.log('Disconnected Client:', disconnectedClient.userId);
             if (disconnectedClient?.instanceRecvTransport)
                 disconnectedClient.instanceRecvTransport.close();
@@ -143,7 +143,7 @@ export function validateNetworkObjects(): void {
                 // Get the entity attached to the NetworkObjectComponent and remove it
                 logger.info("Removed entity ", (obj.component.entity as Entity).id, " for user ", userId);
                 const removeMessage = { networkId: obj.component.networkId };
-                Network.instance.destroyObjects.push(removeMessage);
+                Network.instance.worldState.destroyObjects.push(removeMessage);
                 removeEntity(obj.component.entity);
                 delete Network.instance.networkObjects[obj.id];
             });
@@ -162,7 +162,7 @@ export function validateNetworkObjects(): void {
 
         // If it does, tell clients to destroy it
         const removeMessage = { networkId: networkObject.component.networkId };
-        Network.instance.destroyObjects.push(removeMessage);
+        Network.instance.worldState.destroyObjects.push(removeMessage);
 
         // get network object
         const entity = networkObject.component.entity;
@@ -207,7 +207,7 @@ export async function handleConnectToWorld(socket, data, callback, userId, user,
     };
 
     // Push to our worldstate to send out to other users
-    Network.instance.clientsConnected.push({ userId, avatarDetail });
+    Network.instance.worldState.clientsConnected.push({ userId, avatarDetail });
     // Create a new worldtate object that we can fill
     const worldState: WorldStateInterface = {
         clientsConnected: [],
@@ -250,7 +250,7 @@ function disconnectClientIfConnected(socket, userId: string): void {
         // If it does, tell clients to destroy it
         console.log('destroyObjects.push({ networkId: networkObject.component.networkId', networkObject.component.networkId);
         if (typeof networkObject.component.networkId === "number") {
-            Network.instance.destroyObjects.push({ networkId: networkObject.component.networkId });
+            Network.instance.worldState.destroyObjects.push({ networkId: networkObject.component.networkId });
         } else {
             console.error('networkObject.component.networkId is invalid', networkObject);
             logger.error('networkObject.component.networkId is invalid');
@@ -345,7 +345,7 @@ export async function handleDisconnect(socket): Promise<any> {
             logger.info("Culling object:", networkObject.component.networkId, "owned by disconnecting client", networkObject.ownerId);
 
             // If it does, tell clients to destroy it
-            Network.instance.destroyObjects.push({ networkId: networkObject.component.networkId });
+            Network.instance.worldState.destroyObjects.push({ networkId: networkObject.component.networkId });
 
             // get network object
             const entity = Network.instance.networkObjects[key].component.entity;
@@ -358,7 +358,7 @@ export async function handleDisconnect(socket): Promise<any> {
         });
 
 
-        Network.instance.clientsDisconnected.push({ userId });
+        Network.instance.worldState.clientsDisconnected.push({ userId });
         logger.info('Disconnecting clients for user ' + userId);
         if (disconnectedClient?.instanceRecvTransport) disconnectedClient.instanceRecvTransport.close();
         if (disconnectedClient?.instanceSendTransport) disconnectedClient.instanceSendTransport.close();


### PR DESCRIPTION
- Fix network bug related to sending worldState, all state changes now run through `Network.instance.worldState` (example Network`.instance.createObjects` is now `Network.instance.worldState.createObjects`) instead of being added on both in different places 
- Ball velocity is now handled properly, and for the most part works across clients
- Some renaming of entities in functions to be more clear - this is a practice that should be adopted in more places
- Renaming to have components make grammatical sense