### PR TITLE
Fixed Harmony triggering on instance CONNECT_TO_WORLD.

### DIFF
--- a/packages/client/src/components/Harmony/index.tsx
+++ b/packages/client/src/components/Harmony/index.tsx
@@ -507,8 +507,8 @@ const Harmony = (props: Props): any => {
         setComposingMessage('');
     };
 
-    const connectToWorldHandler = async (): Promise<void> => {
-        // if (lastConnectToWorldIdRef.current !== activeAVChannelIdRef.current) {
+    const connectToWorldHandler = async ({ instance }: { instance: boolean }): Promise<void> => {
+        if (instance !== true) {
             setLastConnectToWorldId(activeAVChannelIdRef.current);
             await toggleAudio(activeAVChannelIdRef.current);
             await toggleVideo(activeAVChannelIdRef.current);
@@ -516,7 +516,7 @@ const Harmony = (props: Props): any => {
             updateCamVideoState();
             updateCamAudioState();
             EngineEvents.instance.dispatchEvent({ type: EngineEvents.EVENTS.SCENE_LOADED });
-        // }
+        }
     };
 
     const createEngineListeners = (): void => {
@@ -696,6 +696,7 @@ const Harmony = (props: Props): any => {
     };
 
     const toggleAudio = async (channelId) => {
+        console.log('toggleAudio');
         await checkMediaStream('channel', channelId);
 
         if (MediaStreamSystem.instance?.camAudioProducer == null) await createCamAudioProducer('channel', channelId);
@@ -708,6 +709,7 @@ const Harmony = (props: Props): any => {
     };
 
     const toggleVideo = async (channelId) => {
+        console.log('toggleVideo');
         await checkMediaStream('channel', channelId);
         if (MediaStreamSystem.instance?.camVideoProducer == null) await createCamVideoProducer('channel', channelId);
         else {

--- a/packages/client/src/transports/SocketWebRTCClientTransport.ts
+++ b/packages/client/src/transports/SocketWebRTCClientTransport.ts
@@ -176,7 +176,7 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
       }
       const { worldState, routerRtpCapabilities } = ConnectToWorldResponse as any;
 
-      EngineEvents.instance.dispatchEvent({ type: EngineEvents.EVENTS.CONNECT_TO_WORLD, worldState: WorldStateModel.fromBuffer(worldState) });
+      EngineEvents.instance.dispatchEvent({ type: EngineEvents.EVENTS.CONNECT_TO_WORLD, worldState: WorldStateModel.fromBuffer(worldState), instance: instance === true });
 
       // Send heartbeat every second
       const heartbeat = setInterval(() => {


### PR DESCRIPTION
Harmony, now always rendered in locations, was mistakenly going through its CONNECT_TO_WORLD handler
on instance connections. Made ClientTransport pass instance === true when dispatching CONNECT_TO_WORLD,
and Harmony only starts up when instance is false.