### PR TITLE
Updated ServerTransport to use more than one worker/router.

### DIFF
--- a/packages/client/src/components/Harmony/index.tsx
+++ b/packages/client/src/components/Harmony/index.tsx
@@ -99,7 +99,6 @@ import { SocketWebRTCClientTransport } from '../../transports/SocketWebRTCClient
 // @ts-ignore
 import styles from './style.module.scss';
 import WarningRefreshModal from "../AlertModals/WarningRetryModal";
-import { ClientNetworkSystem } from '@xrengine/engine/src/networking/systems/ClientNetworkSystem';
 import { resetEngine } from "@xrengine/engine/src/ecs/functions/EngineFunctions";
 const engineRendererCanvasId = 'engine-renderer-canvas';
 
@@ -534,12 +533,6 @@ const Harmony = (props: Props): any => {
         });
     };
 
-    const onChannelScroll = (e): void => {
-        if ((e.target.scrollHeight - e.target.scrollTop) === e.target.clientHeight) {
-            nextChannelPage();
-        }
-    };
-
     const onMessageScroll = (e): void => {
         if (e.target.scrollTop === 0 && (e.target.scrollHeight > e.target.clientHeight) && messageScrollInit !== true && (activeChannel.skip + activeChannel.limit) < activeChannel.total) {
             setMessageScrollUpdate(true);
@@ -718,14 +711,7 @@ const Harmony = (props: Props): any => {
         }
     };
 
-    const openChat = (targetObjectType: string, targetObject: any): void => {
-        setTimeout(() => {
-            updateChatTarget(targetObjectType, targetObject);
-            updateMessageScrollInit(true);
-        }, 100);
-    };
-
-    const handleAccordionSelect = (accordionType: string) => (event: React.ChangeEvent<{}>, isExpanded: boolean) => {
+    const handleAccordionSelect = (accordionType: string) => () => {
         if (accordionType === selectedAccordion) {
             setSelectedAccordion('');
         } else {
@@ -798,10 +784,6 @@ const Harmony = (props: Props): any => {
             if (channel.channelType === 'party') return 'Current party';
             if (channel.channelType === 'user') return channel.user1.id === selfUser.id ? channel.user2.name : channel.user1.name;
         } else return 'Current Layer';
-    }
-
-    function calcWidth(): 12 | 6 | 4 | 3 {
-        return layerUsers.length === 1 ? 12 : layerUsers.length <= 4 ? 6 : layerUsers.length <= 9 ? 4 : 3;
     }
 
 
@@ -893,7 +875,7 @@ const Harmony = (props: Props): any => {
                 })} />
                 {party != null && party.id != null && party.id !== '' && <ListItemIcon className={styles.groupEdit} onClick={(e) => openDetails(e, 'party', party)}><Settings /></ListItemIcon>}
             </div>
-            {selfUser.instanceId != null && <div className={classNames({
+            {selfUser?.instanceId != null && <div className={classNames({
                 [styles.instanceButton]: true,
                 [styles.activeChat]: isActiveChat('instance', selfUser.instanceId)
             })}
@@ -911,7 +893,7 @@ const Harmony = (props: Props): any => {
                 })} />
             </div>}
         </div>
-        {selfUser.userRole !== 'guest' &&
+        {selfUser?.userRole !== 'guest' &&
             <Accordion expanded={selectedAccordion === 'user'} onChange={handleAccordionSelect('user')} className={styles['MuiAccordion-root']}>
                 <AccordionSummary
                     id="friends-header"
@@ -962,7 +944,7 @@ const Harmony = (props: Props): any => {
                 </AccordionDetails>
             </Accordion>
         }
-        {selfUser.userRole !== 'guest' &&
+        {selfUser?.userRole !== 'guest' &&
             <Accordion expanded={selectedAccordion === 'group'} onChange={handleAccordionSelect('group')} className={styles['MuiAccordion-root']}>
                 <AccordionSummary
                     id="groups-header"
@@ -1300,7 +1282,7 @@ const Harmony = (props: Props): any => {
                             </ListItem>;
                         })
                         }
-                        {targetChannelId.length === 0 && targetObject.id != null &&
+                        {targetChannelId != null && targetChannelId.length === 0 && targetObject.id != null &&
                             <div className={styles['first-message-placeholder']}>
                                 <div>{targetChannelId}</div>
                             Start a chat with {(targetObjectType === 'user' || targetObjectType === 'group') ? targetObject.name : targetObjectType === 'instance' ? 'your current layer' : 'your current party'}

--- a/packages/engine/src/initializeEngine.ts
+++ b/packages/engine/src/initializeEngine.ts
@@ -73,27 +73,28 @@ const configureClient = async (options: InitializeOptions) => {
         EngineEvents.instance.dispatchEvent({ type: EngineEvents.EVENTS.ENABLE_SCENE, renderer: enableRenderer, physics: true });
       });
 
-      if (options.renderer.disabled) return;
+      if (options.renderer.disabled !== true) {
 
-      Engine.camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 10000);
-      Engine.scene.add(Engine.camera);
+          Engine.camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 10000);
+          Engine.scene.add(Engine.camera);
 
-      /** @todo for when we fix bundling */
-      // if((window as any).safariWebBrowser) {
-        //   physicsWorker = new Worker(options.physxWorkerPath);
-      // } else {
-      //     // @ts-ignore
-      //     const { default: PhysXWorker } = await import('@xrengine/engine/src/physics/functions/loadPhysX.ts?worker&inline');
-      //     physicsWorker = new PhysXWorker();
-      // }
+          /** @todo for when we fix bundling */
+          // if((window as any).safariWebBrowser) {
+          //   physicsWorker = new Worker(options.physxWorkerPath);
+          // } else {
+          //     // @ts-ignore
+          //     const { default: PhysXWorker } = await import('@xrengine/engine/src/physics/functions/loadPhysX.ts?worker&inline');
+          //     physicsWorker = new PhysXWorker();
+          // }
 
-      new AnimationManager();
-      await Promise.all([
-          AnimationManager.instance.getDefaultModel(),
-          AnimationManager.instance.getAnimations(),
-      ]);
+          new AnimationManager();
+          await Promise.all([
+              AnimationManager.instance.getDefaultModel(),
+              AnimationManager.instance.getAnimations(),
+          ]);
 
-      Engine.workers.push(options.physxWorker);
+          Engine.workers.push(options.physxWorker);
+      }
     }
 
     registerClientSystems(options, useOffscreen, canvas);

--- a/packages/engine/src/networking/systems/MediaStreamSystem.ts
+++ b/packages/engine/src/networking/systems/MediaStreamSystem.ts
@@ -145,7 +145,6 @@ export class MediaStreamSystem extends System {
 
   /** Execute the media stream system. */
   public execute = async (): Promise<void> => {
-    // console.log('tick at', new Date());
     if (Network.instance.mediasoupOperationQueue.getBufferLength() > 0 && this.executeInProgress === false) {
       console.log('Executing mediasoup operation');
       this.executeInProgress = true;

--- a/packages/gameserver/src/NetworkFunctions.ts
+++ b/packages/gameserver/src/NetworkFunctions.ts
@@ -1,7 +1,7 @@
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine';
 import { EngineEvents } from '@xrengine/engine/src/ecs/classes/EngineEvents';
 import { Entity } from '@xrengine/engine/src/ecs/classes/Entity';
-import { getComponent, getMutableComponent, removeEntity } from "@xrengine/engine/src/ecs/functions/EntityFunctions";
+import { getMutableComponent, removeEntity } from "@xrengine/engine/src/ecs/functions/EntityFunctions";
 import { Network } from "@xrengine/engine/src/networking//classes/Network";
 import { MessageTypes } from '@xrengine/engine/src/networking/enums/MessageTypes';
 import { WorldStateInterface } from '@xrengine/engine/src/networking/interfaces/WorldState';
@@ -228,7 +228,7 @@ export async function handleConnectToWorld(socket, data, callback, userId, user,
     // Return initial world state to client to set things up
     callback({
         worldState: WorldStateModel.toBuffer(worldState),
-        routerRtpCapabilities: transport.routers.instance.rtpCapabilities
+        routerRtpCapabilities: transport.routers.instance[0].rtpCapabilities
     });
 }
 
@@ -312,7 +312,7 @@ export async function handleJoinWorld(socket, data, callback, userId, user): Pro
     // Return initial world state to client to set things up
     callback({
         worldState: WorldStateModel.toBuffer(worldState),
-        routerRtpCapabilities: transport.routers.instance.rtpCapabilities
+        routerRtpCapabilities: transport.routers.instance[0].rtpCapabilities
     });
 }
 

--- a/packages/gameserver/src/WebRTCFunctions.ts
+++ b/packages/gameserver/src/WebRTCFunctions.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import { MediaStreamSystem } from "@xrengine/engine/src/networking/systems/MediaStreamSystem";
 import { Network } from "@xrengine/engine/src/networking//classes/Network";
 import { MessageTypes } from "@xrengine/engine/src/networking/enums/MessageTypes";
@@ -25,25 +26,31 @@ export async function startWebRTC(): Promise<void> {
     networkTransport = Network.instance.transport as any;
     logger.info("Starting WebRTC Server");
     // Initialize roomstate
-    networkTransport.worker = await createWorker({
-        logLevel: 'debug',
-        rtcMinPort: localConfig.mediasoup.worker.rtcMinPort,
-        rtcMaxPort: localConfig.mediasoup.worker.rtcMaxPort,
-        // dtlsCertificateFile: serverConfig.server.certPath,
-        // dtlsPrivateKeyFile: serverConfig.server.keyPath,
-        logTags: ['sctp']
-    });
+    const cores = os.cpus();
+    networkTransport.routers = { instance: [] };
+    for (let i = 0; i < cores.length; i++) {
+        const newWorker = await createWorker({
+            logLevel: 'debug',
+            rtcMinPort: localConfig.mediasoup.worker.rtcMinPort,
+            rtcMaxPort: localConfig.mediasoup.worker.rtcMaxPort,
+            // dtlsCertificateFile: serverConfig.server.certPath,
+            // dtlsPrivateKeyFile: serverConfig.server.keyPath,
+            logTags: ['sctp']
+        });
 
-    networkTransport.worker.on("died", () => {
-        console.error("mediasoup worker died (this should never happen)");
-        process.exit(1);
-    });
+        newWorker.on("died", () => {
+            console.error("mediasoup worker died (this should never happen)");
+            process.exit(1);
+        });
 
-    logger.info("Created Mediasoup worker");
+        logger.info("Created Mediasoup worker");
 
-    const mediaCodecs = localConfig.mediasoup.router.mediaCodecs as RtpCodecCapability[];
-    networkTransport.routers = { instance: await networkTransport.worker.createRouter({ mediaCodecs }) };
-    logger.info("Worker created router");
+        const mediaCodecs = localConfig.mediasoup.router.mediaCodecs as RtpCodecCapability[];
+        const newRouter = await newWorker.createRouter({ mediaCodecs });
+        networkTransport.routers.instance.push(newRouter);
+        logger.info("Worker created router");
+        networkTransport.workers.push(newWorker);
+    }
 }
 
 export const sendCurrentProducers = (socket: SocketIO.Socket, channelType: string, channelId?: string) => async (
@@ -140,7 +147,7 @@ export async function closeProducer(producer): Promise<void> {
     if (Network.instance.clients[producer.appData.peerId]) delete Network.instance.clients[producer.appData.peerId].media[producer.appData.mediaTag];
 }
 
-export async function closeProducerAndAllPipeProducers(producer, peerId): Promise<void> {
+export async function closeProducerAndAllPipeProducers(producer): Promise<void> {
     if (producer != null) {
         console.log("closing producer and all pipe producer " + producer.id, producer.appData);
 
@@ -176,13 +183,20 @@ export async function createWebRtcTransport({ peerId, direction, sctpCapabilitie
     const { listenIps, initialAvailableOutgoingBitrate } = localConfig.mediasoup.webRtcTransport;
     const mediaCodecs = localConfig.mediasoup.router.mediaCodecs as RtpCodecCapability[];
     if (channelType !== 'instance') {
-        if (networkTransport.routers[`${channelType}:${channelId}`] == null)
-            networkTransport.routers[`${channelType}:${channelId}`] = await networkTransport.worker.createRouter({ mediaCodecs });
+        if (networkTransport.routers[`${channelType}:${channelId}`] == null) {
+            networkTransport.routers[`${channelType}:${channelId}`] = [];
+            await Promise.all(networkTransport.workers.map(async worker => {
+                const newRouter = await worker.createRouter({mediaCodecs});
+                networkTransport.routers[`${channelType}:${channelId}`].push(newRouter);
+                return Promise.resolve();
+            }));
+        }
         logger.info("Worker created router for channel " + `${channelType}:${channelId}`);
     }
 
-    const router = channelType === 'instance' ? networkTransport.routers.instance : networkTransport.routers[`${channelType}:${channelId}`];
-    const newTransport = await router.createWebRtcTransport({
+    const routerList = channelType === 'instance' ? networkTransport.routers.instance : networkTransport.routers[`${channelType}:${channelId}`];
+    const sortedRouterList = routerList.sort((a, b) => a._transports.size - b._transports.size);
+    const newTransport = await sortedRouterList[0].createWebRtcTransport({
         listenIps: listenIps,
         enableUdp: true,
         enableTcp: false,
@@ -294,6 +308,14 @@ export async function handleWebRtcProduceData(socket, data, callback): Promise<a
     networkTransport.dataProducers.push(dataProducer);
     logger.info(`user ${userId} producing data`);
     Network.instance.clients[userId].dataProducers.set(label, dataProducer);
+
+    const currentRouter = networkTransport.routers.instance.find(router => router._internal.routerId === transport._internal.routerId);
+
+    await Promise.all(networkTransport.routers.instance.map(async router => {
+        if (router._internal.routerId !== transport._internal.routerId) return currentRouter.pipeToRouter({ dataProducerId: dataProducer.id, router: router });
+        else return Promise.resolve();
+    }));
+
     // if our associated transport closes, close ourself, too
     dataProducer.on("transportclose", () => {
         networkTransport.dataProducers.splice(networkTransport.dataProducers.indexOf(dataProducer), 1);
@@ -312,7 +334,6 @@ export async function handleWebRtcProduceData(socket, data, callback): Promise<a
 
 export async function handleWebRtcTransportClose(socket, data, callback): Promise<any> {
     networkTransport = Network.instance.transport as any;
-    const userId = getUserIdFromSocketId(socket.id);
     const { transportId } = data;
     const transport = Network.instance.transports[transportId];
     if (transport != null) await closeTransport(transport).catch(err => logger.error(err));
@@ -320,7 +341,6 @@ export async function handleWebRtcTransportClose(socket, data, callback): Promis
 }
 
 export async function handleWebRtcTransportConnect(socket, data, callback): Promise<any> {
-    const userId = getUserIdFromSocketId(socket.id);
     const { transportId, dtlsParameters } = data,
         transport = Network.instance.transports[transportId];
     await transport.connect({ dtlsParameters }).catch(err => {
@@ -332,9 +352,8 @@ export async function handleWebRtcTransportConnect(socket, data, callback): Prom
 }
 
 export async function handleWebRtcCloseProducer(socket, data, callback): Promise<any> {
-    const userId = getUserIdFromSocketId(socket.id);
     const { producerId } = data, producer = MediaStreamSystem.instance?.producers.find(p => p.id === producerId);
-    await closeProducerAndAllPipeProducers(producer, userId).catch(err => logger.error(err));
+    await closeProducerAndAllPipeProducers(producer).catch(err => logger.error(err));
     callback({ closed: true });
 }
 
@@ -352,7 +371,15 @@ export async function handleWebRtcSendTrack(socket, data, callback): Promise<any
         appData: { ...appData, peerId: userId, transportId }
     });
 
-    producer.on("transportclose", () => closeProducerAndAllPipeProducers(producer, userId));
+    const routers = appData.channelType === 'instance' ? networkTransport.routers.instance : networkTransport.routers[`${appData.channelType}:${appData.channelId}`];
+    const currentRouter = routers.find(router => router._internal.routerId === transport._internal.routerId);
+
+    await Promise.all(routers.map(async router => {
+        if (router._internal.routerId !== transport._internal.routerId) return currentRouter.pipeToRouter({ producerId: producer.id, router: router });
+        else return Promise.resolve();
+    }));
+
+    producer.on("transportclose", () => closeProducerAndAllPipeProducers(producer));
 
     if(!MediaStreamSystem.instance?.producers) console.warn("Media stream producers is undefined");
     MediaStreamSystem.instance?.producers?.push(producer);
@@ -383,7 +410,7 @@ export async function handleWebRtcReceiveTrack(socket, data, callback): Promise<
     const producer = MediaStreamSystem.instance.producers.find(
         p => p._appData.mediaTag === mediaTag && p._appData.peerId === mediaPeerId && (channelType === 'instance' ? p._appData.channelType === channelType : p._appData.channelType === channelType && p._appData.channelId === channelId)
     );
-    const router = channelType === 'instance' ? networkTransport.routers.instance : networkTransport.routers[`${channelType}:${channelId}`];
+    const router = channelType === 'instance' ? networkTransport.routers.instance[0] : networkTransport.routers[`${channelType}:${channelId}`][0];
     if (producer == null || !router.canConsume({ producerId: producer.id, rtpCapabilities })) {
         const msg = `client cannot consume ${mediaPeerId}:${mediaTag}`;
         console.error(`recv-track: ${userId} ${msg}`);
@@ -504,7 +531,7 @@ export async function handleWebRtcResumeProducer(socket, data, callback): Promis
     const userId = getUserIdFromSocketId(socket.id);
     const { producerId } = data,
         producer = MediaStreamSystem.instance?.producers.find(p => p.id === producerId);
-    logger.info("resume-producer", producer.appData);
+    logger.info("resume-producer", producer?.appData);
     if (producer != null) {
         Network.instance.mediasoupOperationQueue.add({
             object: producer,
@@ -514,7 +541,7 @@ export async function handleWebRtcResumeProducer(socket, data, callback): Promis
         if (userId != null && Network.instance.clients[userId] != null) {
             Network.instance.clients[userId].media[producer.appData.mediaTag].paused = false;
             Network.instance.clients[userId].media[producer.appData.mediaTag].globalMute = false;
-            const hostClient = Object.entries(Network.instance.clients).find(([name, client]) => {
+            const hostClient = Object.entries(Network.instance.clients).find(([, client]) => {
                 return client.media[producer.appData.mediaTag]?.producerId === producerId;
             });
             hostClient[1].socket.emit(MessageTypes.WebRTCResumeProducer.toString(), producer.id);
@@ -536,7 +563,7 @@ export async function handleWebRtcPauseProducer(socket, data, callback): Promise
             Network.instance.clients[userId].media[producer.appData.mediaTag].paused = true;
             Network.instance.clients[userId].media[producer.appData.mediaTag].globalMute = globalMute || false;
             if (globalMute === true) {
-                const hostClient = Object.entries(Network.instance.clients).find(([name, client]) => {
+                const hostClient = Object.entries(Network.instance.clients).find(([, client]) => {
                     return client.media[producer.appData.mediaTag]?.producerId === producerId;
                 });
                 hostClient[1].socket.emit(MessageTypes.WebRTCPauseProducer.toString(), producer.id, true);
@@ -559,8 +586,13 @@ export async function handleWebRtcInitializeRouter(socket, data, callback): Prom
         const mediaCodecs = localConfig.mediasoup.router.mediaCodecs as RtpCodecCapability[];
         const networkTransport = Network.instance.transport as any;
         if (networkTransport.routers[`${channelType}:${channelId}`] == null) {
-            console.log('Making new router');
-            networkTransport.routers[`${channelType}:${channelId}`] = await networkTransport.worker.createRouter({mediaCodecs});
+            console.log('Making new routers for channel');
+            networkTransport.routers[`${channelType}:${channelId}`] = [];
+            await Promise.all(networkTransport.workers.map(async worker => {
+                const newRouter = await worker.createRouter({mediaCodecs});
+                networkTransport.routers[`${channelType}:${channelId}`].push(newRouter);
+                return Promise.resolve();
+            }));
         }
     }
     callback({initialized: true});


### PR DESCRIPTION
Mediasoup can only handle about 500 consumers per worker. We were only creating a single worker,
so only using a single core. Updated SocketWebRTCServerTransport.ts to hold multiple workers.
WebRTCFunction:startWebRTC() now creates a worker per core on the host machine, and an instance
router per worker. Any time a transport is being made, it's made on the router with the fewest
transports. Producers are piped from the router they're on to all of the other routers so that
they can be consumed on any router.

Fixed an issue in new engine/src/initializeEngine.ts that was skipping registerClientSystems if
options.renderer.disable was true.

Made some selfUser.<field> checks conditional on selfUser.