### PR TITLE
Fix build on Apple Silicon

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -113,7 +113,7 @@
     "sequelize": "6.6.2",
     "serve-favicon": "2.5.0",
     "slugify": "1.5.3",
-    "ts-eager": "1.1.3",
+    "ts-eager": "2.0.2",
     "universal-analytics": "0.4.23",
     "uuid": "8.3.2",
     "winston": "3.3.3",


### PR DESCRIPTION
The old version of `ts-eager` was the only thing currently blocking Apple Silicon support. Upgrading to the latest version of `ts-eager` seems to work fine. 