### PR TITLE
Switched some checks of NODE_ENV to check if Kubernetes is enabled.

### DIFF
--- a/packages/gameserver/src/channels.ts
+++ b/packages/gameserver/src/channels.ts
@@ -40,7 +40,7 @@ export default (app: Application): void => {
                         console.log('Creating new GS or updating current one');
                         console.log(status.state);
                         console.log((app as any).instance);
-                        if (status.state === 'Ready' || ((process.env.NODE_ENV === 'development' && status.state === 'Shutdown') || (process.env.NODE_ENV === 'development' && ((app as any).instance == null || (app as any).instance.locationId !== locationId || (app as any).instance.channelId !== channelId)))) {
+                        if (status.state === 'Ready' || ((config.kubernetes.enabled === false && status.state === 'Shutdown') || (config.kubernetes.enabled === false && ((app as any).instance == null || (app as any).instance.locationId !== locationId || (app as any).instance.channelId !== channelId)))) {
                             logger.info('Starting new instance');
                             const localIp = await getLocalServerIp();
                             const selfIpAddress = `${(status.address as string)}:${(status.portsList[0].port as string)}`;

--- a/packages/gameserver/src/index.ts
+++ b/packages/gameserver/src/index.ts
@@ -46,7 +46,7 @@ process.on('unhandledRejection', (error, promise) => {
 // SSL setup
   const certPath = config.server.certPath;
   const certKeyPath = config.server.keyPath;
-  const useSSL = !config.noSSL && (config.localBuild || process.env.NODE_ENV !== 'production') && fs.existsSync(certKeyPath);
+  const useSSL = !config.noSSL && (config.localBuild || !config.kubernetes.enabled) && fs.existsSync(certKeyPath);
 
   const certOptions = {
     key: useSSL ? fs.readFileSync(certKeyPath) : null,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -42,13 +42,7 @@ process.on('unhandledRejection', (error, promise) => {
     const certPath = config.server.certPath;
     const certKeyPath = config.server.keyPath;
 
-    console.log('!config.noSSL', !config.noSSL);
-    console.log('config.localBuild', config.localBuild);
-    console.log('NODE_ENV', process.env.NODE_ENV);
-    console.log('certKeyPath', certKeyPath);
-    console.log('certKeyPath exists', fs.existsSync(certKeyPath));
-    const useSSL = !config.noSSL && (config.localBuild || process.env.NODE_ENV !== 'production') && fs.existsSync(certKeyPath);
-    console.log('useSSL');
+    const useSSL = !config.noSSL && (config.localBuild || !config.kubernetes.enabled) && fs.existsSync(certKeyPath);
 
     const certOptions = {
         key: useSSL ? fs.readFileSync(certKeyPath) : null,


### PR DESCRIPTION
There's a weird condition in our deployment where, inside the node process,
process.env.NODE_ENV is 'development' despite being set in multiple places
to 'production'. After a bug fix, this was causing SSL to be turned on for
the server and gameserver in production when it shouldn't have been.

Some of the checks for process.env.NODE_ENV === development, or !== production,
have been switched to check whether Kubernetes is enabled instead, which should
not have any oddities around it.