### PR TITLE
Disable browser-handling of touch gestures

### DIFF
--- a/packages/client/src/components/Layout/Layout.tsx
+++ b/packages/client/src/components/Layout/Layout.tsx
@@ -139,8 +139,23 @@ const Layout = (props: Props): any => {
 
     window.addEventListener('resize', handleResize);
 
+    // disable all browser-handling of touch gestures (document panning/zooming)
+    // touch-action is non-inhered, so apply to all elements on the page
+    const sheet = document.createElement('style');
+    sheet.innerHTML = `
+      html {
+        overflow: hidden;
+        -webkit-user-select: none;
+      }
+      * { 
+        touch-action: none;
+      }
+    `;
+    document.head.appendChild(sheet);
+
     return _ => {
       window.removeEventListener('resize', handleResize);
+      document.head.removeChild(sheet);
     };
   }) as any);
 

--- a/packages/client/src/components/Layout/Layout.tsx
+++ b/packages/client/src/components/Layout/Layout.tsx
@@ -146,6 +146,7 @@ const Layout = (props: Props): any => {
       html {
         overflow: hidden;
         -webkit-user-select: none;
+        user-select: none;
       }
       * { 
         touch-action: none;


### PR DESCRIPTION
Globally prevent document panning/zooming (from any element on the page), and selection of non-input elements, whenever the Layout component is mounted.

This partially fixes UX on iOS/iPadOS (the camera zoom on iPad is currently too sensitive, and the touch controls are missing)