### PR TITLE
Add .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ First, make sure you have [NodeJS](https://nodejs.org/) and [npm](https://www.np
 #### 1.  Install your dependencies 
 ```
 cd path/to/xrengine
-npm install --legacy-peer-deps
+npm install
 ```
 
 You should not need to use sudo in any case.


### PR DESCRIPTION
Add .npmrc with legacy-peer-deps=true
Reduce setup friction.
Remove the need for specifying --legacy-peer-deps when doing `npm i`