### PR TITLE
Updated chart to optionally get release name from config value.

### DIFF
--- a/packages/ops/xrengine/Chart.yaml
+++ b/packages/ops/xrengine/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.0
+version: 3.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/packages/ops/xrengine/templates/api-server-deployment.yaml
+++ b/packages/ops/xrengine/templates/api-server-deployment.yaml
@@ -24,6 +24,10 @@ spec:
       serviceAccountName: {{ include "xrengine.api.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
+      {{- $releaseName := .Release.Name }}
+      {{ if not (empty .Values.release) }}
+      {{- $releaseName = .Values.release.name | default .Release.Name }}
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -61,16 +65,16 @@ spec:
             - name: REDIS_ENABLED
               value: "true"
             - name: REDIS_ADDRESS
-              value: "$({{ .Release.Name | upper }}_REDIS_MASTER_SERVICE_HOST)"
+              value: "$({{ $releaseName | upper }}_REDIS_MASTER_SERVICE_HOST)"
             - name: REDIS_PORT
-              value: "$({{ .Release.Name | upper }}_REDIS_MASTER_SERVICE_PORT)"
+              value: "$({{ $releaseName | upper }}_REDIS_MASTER_SERVICE_PORT)"
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-redis
+                  name: {{ $releaseName }}-redis
                   key: redis-password
             - name: RELEASE_NAME
-              value: {{ .Release.Name }}
+              value: {{ $releaseName }}
           ports:
             - name: http
               containerPort: 3030
@@ -93,13 +97,13 @@ spec:
           command: [ 'sh', '-c', 'until (printf "AUTH $REDIS_PASSWORD\r\nPING\r\n";) | nc $REDIS_ADDRESS $REDIS_PORT ; do echo waiting for redis-master; sleep 2; done' ]
           env:
             - name: REDIS_ADDRESS
-              value: "$({{ .Release.Name | upper }}_REDIS_MASTER_SERVICE_HOST)"
+              value: "$({{ $releaseName | upper }}_REDIS_MASTER_SERVICE_HOST)"
             - name: REDIS_PORT
-              value: "$({{ .Release.Name | upper }}_REDIS_MASTER_SERVICE_PORT)"
+              value: "$({{ $releaseName | upper }}_REDIS_MASTER_SERVICE_PORT)"
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-redis
+                  name: {{ $releaseName }}-redis
                   key: redis-password
       {{- with .Values.api.nodeSelector }}
       nodeSelector:

--- a/packages/ops/xrengine/templates/client-deployment.yaml
+++ b/packages/ops/xrengine/templates/client-deployment.yaml
@@ -24,6 +24,10 @@ spec:
       serviceAccountName: {{ include "xrengine.client.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.client.podSecurityContext | nindent 8 }}
+      {{- $releaseName := .Release.Name }}
+      {{ if not (empty .Values.release) }}
+      {{- $releaseName = .Values.release.name | default .Release.Name }}
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -40,7 +44,7 @@ spec:
             - name: KUBERNETES
               value: "true"
             - name: RELEASE_NAME
-              value: {{ .Release.Name }}
+              value: {{ $releaseName }}
           ports:
             - name: http
               containerPort: 3000

--- a/packages/ops/xrengine/templates/game-server-configmap.yaml
+++ b/packages/ops/xrengine/templates/game-server-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.api.enabled -}}
+{{- if .Values.gameserver.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/packages/ops/xrengine/templates/game-server-fleet.yaml
+++ b/packages/ops/xrengine/templates/game-server-fleet.yaml
@@ -474,6 +474,10 @@ spec:
       template:
         spec:
           serviceAccountName: {{ include "xrengine.gameserver.serviceAccountName" . }}
+          {{- $releaseName := .Release.Name }}
+          {{ if not (empty .Values.release) }}
+            {{- $releaseName = .Values.release.name | default .Release.Name }}
+          {{ end }}
           containers:
             - name: {{ include "xrengine.gameserver.fullname" . }}
               image: "{{ .Values.gameserver.image.repository }}:{{ .Values.gameserver.image.tag }}"
@@ -515,29 +519,29 @@ spec:
                 - name: REDIS_ENABLED
                   value: "true"
                 - name: REDIS_ADDRESS
-                  value: "$({{ .Release.Name | upper }}_REDIS_MASTER_SERVICE_HOST)"
+                  value: "$({{ $releaseName | upper }}_REDIS_MASTER_SERVICE_HOST)"
                 - name: REDIS_PORT
-                  value: "$({{ .Release.Name | upper }}_REDIS_MASTER_SERVICE_PORT)"
+                  value: "$({{ $releaseName | upper }}_REDIS_MASTER_SERVICE_PORT)"
                 - name: REDIS_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: {{ .Release.Name }}-redis
+                      name: {{ $releaseName }}-redis
                       key: redis-password
                 - name: RELEASE_NAME
-                  value: {{ .Release.Name }}
+                  value: {{ $releaseName }}
           initContainers:
             - name: init-redis
               image: busybox:1.28
               command: ['sh', '-c', 'until (printf "AUTH $REDIS_PASSWORD\r\nPING\r\n";) | nc $REDIS_ADDRESS $REDIS_PORT ; do echo waiting for redis-master; sleep 2; done']
               env:
                 - name: REDIS_ADDRESS
-                  value: "$({{ .Release.Name | upper }}_REDIS_MASTER_SERVICE_HOST)"
+                  value: "$({{ $releaseName | upper }}_REDIS_MASTER_SERVICE_HOST)"
                 - name: REDIS_PORT
-                  value: "$({{ .Release.Name | upper }}_REDIS_MASTER_SERVICE_PORT)"
+                  value: "$({{ $releaseName | upper }}_REDIS_MASTER_SERVICE_PORT)"
                 - name: REDIS_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: {{ .Release.Name }}-redis
+                      name: {{ $releaseName }}-redis
                       key: redis-password
         {{- with .Values.gameserver.nodeSelector }}
           nodeSelector:

--- a/packages/ops/xrengine/templates/media-server-deployment.yaml
+++ b/packages/ops/xrengine/templates/media-server-deployment.yaml
@@ -24,6 +24,10 @@ spec:
       serviceAccountName: {{ include "xrengine.media.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.media.podSecurityContext | nindent 8 }}
+      {{- $releaseName := .Release.Name }}
+      {{ if not (empty .Values.release) }}
+      {{- $releaseName = .Values.release.name | default .Release.Name }}
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -64,16 +68,16 @@ spec:
             - name: REDIS_ENABLED
               value: "true"
             - name: REDIS_ADDRESS
-              value: "$({{ .Release.Name | upper }}_REDIS_MASTER_SERVICE_HOST)"
+              value: "$({{ $releaseName | upper }}_REDIS_MASTER_SERVICE_HOST)"
             - name: REDIS_PORT
-              value: "$({{ .Release.Name | upper }}_REDIS_MASTER_SERVICE_PORT)"
+              value: "$({{ $releaseName | upper }}_REDIS_MASTER_SERVICE_PORT)"
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-redis
+                  name: {{ $releaseName }}-redis
                   key: redis-password
             - name: RELEASE_NAME
-              value: {{ .Release.Name }}
+              value: {{ $releaseName }}
           ports:
             - name: http
               containerPort: 3030
@@ -96,13 +100,13 @@ spec:
           command: [ 'sh', '-c', 'until (printf "AUTH $REDIS_PASSWORD\r\nPING\r\n";) | nc $REDIS_ADDRESS $REDIS_PORT ; do echo waiting for redis-master; sleep 2; done' ]
           env:
             - name: REDIS_ADDRESS
-              value: "$({{ .Release.Name | upper }}_REDIS_MASTER_SERVICE_HOST)"
+              value: "$({{ $releaseName | upper }}_REDIS_MASTER_SERVICE_HOST)"
             - name: REDIS_PORT
-              value: "$({{ .Release.Name | upper }}_REDIS_MASTER_SERVICE_PORT)"
+              value: "$({{ $releaseName | upper }}_REDIS_MASTER_SERVICE_PORT)"
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-redis
+                  name: {{ $releaseName }}-redis
                   key: redis-password
       {{- with .Values.media.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
In making gameservers pre-load locations, it was discovered that deploying
a GS fleet just for a single location wouldn't work since the redis connections
assumed that the redis deployment shared a release name, e.g. 'dev' connects to
'dev-redis'. Having another deployment 'rooftop' for rooftop GSes would try to
connect to 'rooftop-redis'.

Updated deployment files to define the releaseName from config value
.Values.release.name, and all sourcing from .Release.Name now references this
variable. If .Values.release does not exist, releaseName definition will fall
back to .Release.Name.

Fixed an errant reference to .Values.api.enabled in gameserver configmap.