### PR TITLE
Added ability to pre-load location on gameserver.

### DIFF
--- a/packages/gameserver/src/app.ts
+++ b/packages/gameserver/src/app.ts
@@ -61,7 +61,6 @@ if (config.gameserver.enabled) {
           }
         })
     );
-    
 
     app.set('paginate', config.server.paginate);
     app.set('authentication', config.authentication);
@@ -95,7 +94,7 @@ if (config.gameserver.enabled) {
     }, (io) => {
       io.use((socket, next) => {
         console.log('GOT SOCKET IO HANDSHAKE', socket.handshake.query);
-        awaitEngineLoaded().then(() =>{ 
+        awaitEngineLoaded().then(() =>{
           (socket as any).feathers.socketQuery = socket.handshake.query;
           (socket as any).socketQuery = socket.handshake.query;
           next();
@@ -143,7 +142,7 @@ if (config.gameserver.enabled) {
       agonesSDK.connect();
       agonesSDK.ready().catch((err) => {
         throw new Error('\x1b[33mError: Agones is not running!. If you are in local development, please run xrengine/scripts/sh start-agones.sh and restart server\x1b[0m');
-      });    
+      });
 
       (app as any).agonesSDK = agonesSDK;
       setInterval(() => agonesSDK.health(), 1000);

--- a/packages/gameserver/src/index.ts
+++ b/packages/gameserver/src/index.ts
@@ -5,6 +5,7 @@ import logger from '@xrengine/server-core/src/logger';
 import config from '@xrengine/server-core/src/appconfig';
 import psList from 'ps-list';
 import { exec } from 'child_process';
+import preloadLocation from './preload-location';
 
 /**
  * @param status
@@ -76,6 +77,10 @@ process.on('unhandledRejection', (error, promise) => {
   const server = useSSL ? https.createServer(certOptions, app as any).listen(port) : await app.listen(port);
 
   if (useSSL === true) app.setup(server);
+
+  if (config.gameserver.locationName != null) {
+    preloadLocation(config.gameserver.locationName);
+  }
 
   process.on('unhandledRejection', (reason, p) =>
       logger.error('Unhandled Rejection at: Promise ', p, reason)

--- a/packages/gameserver/src/preload-location.ts
+++ b/packages/gameserver/src/preload-location.ts
@@ -1,0 +1,86 @@
+import { WorldScene } from "@xrengine/engine/src/scene/functions/SceneLoading";
+import { EngineEvents } from '@xrengine/engine/src/ecs/classes/EngineEvents';
+import app from "./app";
+import config from "@xrengine/server-core/src/appconfig";
+import getLocalServerIp from "@xrengine/server-core/src/util/get-local-server-ip";
+
+
+export default async function (locationName) {
+    setTimeout(async () => {
+        let service, serviceId;
+        const locationResult = await app.service('location').find({
+            query: {
+                slugifiedName: locationName
+            }
+        });
+        if (locationResult.total === 0) return;
+        const location = locationResult.data[0];
+        const scene = await app.get('sequelizeClient').models.collection.findOne({
+            query: {
+                sid: location.sceneId
+            }
+        });
+        if (scene == null) return
+        const projectRegex = /\/([A-Za-z0-9]+)\/([a-f0-9-]+)$/;
+        const projectResult = await app.service('project').get(scene.sid);
+        const projectUrl = projectResult.project_url;
+        const regexResult = projectUrl.match(projectRegex);
+        if (regexResult) {
+            service = regexResult[1];
+            serviceId = regexResult[2];
+        }
+        const result = await app.service(service).get(serviceId);
+
+        let entitiesLeft = -1;
+        let lastEntitiesLeft = -1;
+        const loadingInterval = setInterval(() => {
+            if (entitiesLeft >= 0 && lastEntitiesLeft !== entitiesLeft) {
+                lastEntitiesLeft = entitiesLeft;
+                console.log(entitiesLeft + ' entites left...');
+            }
+        }, 1000);
+
+        WorldScene.load(result, async() => {
+            clearInterval(loadingInterval);
+            const agonesSDK = (app as any).agonesSDK;
+            const gsResult = await agonesSDK.getGameServer();
+            const {status} = gsResult;
+            const localIp = await getLocalServerIp();
+            const selfIpAddress = `${(status.address as string)}:${(status.portsList[0].port as string)}`;
+            const newInstance = {
+                currentUsers: 0,
+                sceneId: location.sid,
+                ipAddress: config.gameserver.mode === 'local' ? `${localIp.ipAddress}:3031` : selfIpAddress,
+                locationId: location.id
+            } as any;
+            (app as any).isChannelInstance = false;
+            const instanceResult = await app.service('instance').create(newInstance);
+            await agonesSDK.allocate();
+            (app as any).instance = instanceResult;
+
+            if ((app as any).gsSubdomainNumber != null) {
+                const gsSubProvision = await app.service('gameserver-subdomain-provision').find({
+                    query: {
+                        gs_number: (app as any).gsSubdomainNumber
+                    }
+                });
+
+                if (gsSubProvision.total > 0) {
+                    const provision = gsSubProvision.data[0];
+                    await app.service('gameserver-subdomain-provision').patch(provision.id, {
+                        instanceId: instanceResult.id
+                    });
+                }
+            }
+            EngineEvents.instance.dispatchEvent({
+                type: EngineEvents.EVENTS.ENABLE_SCENE,
+                renderer: true,
+                physics: true
+            });
+
+        }, async (left) => {
+            entitiesLeft = left;
+        });
+        console.log('Pre-loaded location', location.id);
+    }, 500);
+}

--- a/packages/server-core/src/appconfig.ts
+++ b/packages/server-core/src/appconfig.ts
@@ -90,7 +90,8 @@ const gameserver = {
   domain: process.env.GAMESERVER_DOMAIN || 'gameserver.theoverlay.io',
   releaseName: process.env.RELEASE_NAME,
   port: process.env.GAMESERVER_PORT,
-  mode: process.env.SERVER_MODE
+  mode: process.env.SERVER_MODE,
+  locationName: process.env.PRELOAD_LOCATION_NAME
 };
 
 /**


### PR DESCRIPTION
For events, it is useful to have a number of gameservers already set to a location, as loading
complex scenes can take an appreciable amount of time.

If ENV_VAR PRELOAD_LOCATION_NAME is set on a gameserver, it will automatically load that location
and allocate itself with 0 users on startup. New users for that location will be provisioned to
one of the preloaded servers.