### PR TITLE
Updated instance server provisioning logic.

### DIFF
--- a/packages/client/src/components/Scene/location.tsx
+++ b/packages/client/src/components/Scene/location.tsx
@@ -337,7 +337,7 @@ export const EnginePage = (props: Props) => {
       const newValues = {
         open: true,
         title: 'World disconnected',
-        body: 'You\'ve lost your connection with the world. We\'ll try to reconnect before the following time runs out, otherwise you\'ll be forwarded to a different instance',
+        body: 'You\'ve lost your connection with the world. We\'ll try to reconnect before the following time runs out, otherwise you\'ll be forwarded to a different instance.',
         action: window.location.reload,
         parameters: [],
         timeout: 30000


### PR DESCRIPTION
Previously, gameserver provisioning was placing users on the least-full allocated GS.
With pre-allocated GSes, though, this would cause a lot of people to be put on (near)-
empty servers for events, which is not ideal. This has been changed to try to place users
on the most-full gameserver that's under 80% of the capacity for that location,
and the most-full period if all are pressured.