### PR TITLE
Updated kick handling to better notify user.

### DIFF
--- a/packages/client/src/components/AlertModals/WarningRetryModal.tsx
+++ b/packages/client/src/components/AlertModals/WarningRetryModal.tsx
@@ -18,6 +18,7 @@ interface Props {
     parameters: any[];
     timeout: number;
     closeEffect?: any;
+    noCountdown?: boolean;
 }
 
 const mapStateToProps = (state: any): any => {
@@ -34,6 +35,7 @@ const WarningRetryModal = (props: Props): any => {
         open,
         title,
         body,
+        noCountdown,
         action,
         parameters,
         timeout,
@@ -50,7 +52,7 @@ const WarningRetryModal = (props: Props): any => {
     };
 
     useEffect(() => {
-        if (open === true) {
+        if (open === true && noCountdown !== true) {
             setTimeRemaining(timeout / 1000);
         } else {
             clearInterval(countdown as any);
@@ -107,10 +109,10 @@ const WarningRetryModal = (props: Props): any => {
                         </div>
                         <div className={styles['modal-body']}>
                             {body}
-                            <div>
+                            { noCountdown !== true && <div>
                                 { timeRemaining } seconds
-                            </div>
-                            <div className={styles.footer}>Closing this modal will cancel the countdown</div>
+                            </div>}
+                            { noCountdown !== true && <div className={styles.footer}>Closing this modal will cancel the countdown</div> }
                         </div>
                     </div>
                 </Fade>

--- a/packages/client/src/components/Scene/location.tsx
+++ b/packages/client/src/components/Scene/location.tsx
@@ -77,7 +77,8 @@ const initialRefreshModalValues = {
   body: '',
   action: async() => {},
   parameters: [],
-  timeout: 10000
+  timeout: 10000,
+  noCountdown: false
 };
 
 const canvasStyle = {
@@ -203,6 +204,8 @@ export const EnginePage = (props: Props) => {
   const [warningRefreshModalValues, setWarningRefreshModalValues] = useState(initialRefreshModalValues);
   const [noGameserverProvision, setNoGameserverProvision] = useState(false);
   const [instanceDisconnected, setInstanceDisconnected] = useState(false);
+  const [instanceKicked, setInstanceKicked] = useState(false);
+  const [instanceKickedMessage, setInstanceKickedMessage] = useState('');
   const [isInputEnabled, setInputEnabled] = useState(true);
   const [porting, setPorting] = useState(false);
   const [newSpawnPos, setNewSpawnPos] = useState(null);
@@ -220,7 +223,13 @@ export const EnginePage = (props: Props) => {
     } else {
       doLoginAuto(true);
       EngineEvents.instance.addEventListener(SocketWebRTCClientTransport.EVENTS.PROVISION_INSTANCE_NO_GAMESERVERS_AVAILABLE, () => setNoGameserverProvision(true));
-      EngineEvents.instance.addEventListener(SocketWebRTCClientTransport.EVENTS.INSTANCE_DISCONNECTED, () => setInstanceDisconnected(true));
+      EngineEvents.instance.addEventListener(SocketWebRTCClientTransport.EVENTS.INSTANCE_DISCONNECTED, () => {
+        if (Network.instance.transport.left === false) setInstanceDisconnected(true);
+      });
+      EngineEvents.instance.addEventListener(SocketWebRTCClientTransport.EVENTS.INSTANCE_KICKED, ({ message }) => {
+        setInstanceKickedMessage(message);
+        setInstanceKicked(true);
+      });
       EngineEvents.instance.addEventListener(SocketWebRTCClientTransport.EVENTS.INSTANCE_RECONNECTED, () => setWarningRefreshModalValues(initialRefreshModalValues));
       EngineEvents.instance.addEventListener(EngineEvents.EVENTS.RESET_ENGINE, async (ev: any) => {
         if (ev.instance === true) {
@@ -347,6 +356,20 @@ export const EnginePage = (props: Props) => {
       setInstanceDisconnected(false);
     }
   }, [instanceDisconnected]);
+
+  useEffect(() => {
+    if (instanceKicked === true) {
+      const newValues = {
+        open: true,
+        title: 'You\'ve been kicked from the world',
+        body: 'You were kicked from this world for the following reason: ' + instanceKickedMessage,
+        noCountdown: true
+      };
+      //@ts-ignore
+      setWarningRefreshModalValues(newValues);
+      setInstanceDisconnected(false);
+    }
+  }, [instanceKicked]);
 
   const reinit = () => {
     const currentLocation = locationState.get('currentLocation').get('location');
@@ -589,6 +612,7 @@ export const EnginePage = (props: Props) => {
             action={warningRefreshModalValues.action}
             parameters={warningRefreshModalValues.parameters}
             timeout={warningRefreshModalValues.timeout}
+            noCountdown={warningRefreshModalValues.noCountdown}
         />
         <EmoteMenu />
       </>

--- a/packages/client/src/transports/SocketWebRTCClientTransport.ts
+++ b/packages/client/src/transports/SocketWebRTCClientTransport.ts
@@ -19,6 +19,7 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
     PROVISION_INSTANCE_NO_GAMESERVERS_AVAILABLE: 'CORE_PROVISION_INSTANCE_NO_GAMESERVERS_AVAILABLE',
     PROVISION_CHANNEL_NO_GAMESERVERS_AVAILABLE: 'CORE_PROVISION_CHANNEL_NO_GAMESERVERS_AVAILABLE',
     INSTANCE_DISCONNECTED: 'CORE_INSTANCE_DISCONNECTED',
+    INSTANCE_KICKED: 'CORE_INSTANCE_KICKED',
     INSTANCE_RECONNECTED: 'CORE_INSTANCE_RECONNECTED',
     CHANNEL_DISCONNECTED: 'CORE_CHANNEL_DISCONNECTED',
     CHANNEL_RECONNECTED: 'CORE_CHANNEL_RECONNECTED'
@@ -26,6 +27,7 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
 
   mediasoupDevice: mediasoupClient.Device
   leaving = false
+  left = false
   instanceRecvTransport: MediaSoupTransport
   instanceSendTransport: MediaSoupTransport
   channelRecvTransport: MediaSoupTransport
@@ -211,12 +213,12 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
         if ((socket as any).instance === true) await endVideoChat({ endConsumers: true });
       });
 
-      socket.on(MessageTypes.Kick.toString(), async () => {
+      socket.on(MessageTypes.Kick.toString(), async (message) => {
         // console.log("TODO: SNACKBAR HERE");
         clearInterval(heartbeat);
         await endVideoChat({ endConsumers: true });
-        await leave((socket as any).instance === true);
-        socket.close();
+        await leave((socket as any).instance === true, true);
+        EngineEvents.instance.dispatchEvent({ type: SocketWebRTCClientTransport.EVENTS.INSTANCE_KICKED, message: message });
         console.log("Client has been kicked from the world");
       });
 

--- a/packages/gameserver/src/NetworkFunctions.ts
+++ b/packages/gameserver/src/NetworkFunctions.ts
@@ -256,7 +256,7 @@ function disconnectClientIfConnected(socket, userId: string): void {
     if (Network.instance.clients[userId] !== undefined &&
       Network.instance.clients[userId].socketId !== socket.id) {
         console.log("Client already exists, kicking the old client and disconnecting");
-        Network.instance.clients[userId].socket?.emit(MessageTypes.Kick.toString());
+        Network.instance.clients[userId].socket?.emit(MessageTypes.Kick.toString(), 'You joined this world on another device');
         Network.instance.clients[userId].socket?.disconnect();
     }
 


### PR DESCRIPTION
Being kicked from an instance due to a second connection wasn't being handled/displayed well.
Updated WarningRetryModal.tsx to allow for not retrying if noCountdown is passed in as true.
gameserver Kick emission now includes a message, which the client passes to the modal.

Updated SocketWebRTCClientFunctions.ts:leave to optionally be passed a 'kick' variable,
which if true will bypass trying to call LeaveWorld (it will not get a response, so no
reason to attempt it). Also updated the LeaveWorld request to use Promise.race() with a
10-second timeout so that it doesn't hang there.

Added a field 'left' to ClientTransport so that some disconnect handlers can not attempt
to re-connect; leave() is an intentional action that says the transport is done for good.