### PR TITLE
Removing Agones allocation from preload-location.ts.

### DIFF
--- a/packages/gameserver/src/channels.ts
+++ b/packages/gameserver/src/channels.ts
@@ -141,6 +141,7 @@ export default (app: Application): void => {
                         } else {
                             try {
                                 const instance = await app.service('instance').get((app as any).instance.id);
+                                await agonesSDK.allocate();
                                 await app.service('instance').patch((app as any).instance.id, {
                                     currentUsers: (instance.currentUsers as number) + 1
                                 });

--- a/packages/gameserver/src/preload-location.ts
+++ b/packages/gameserver/src/preload-location.ts
@@ -55,7 +55,6 @@ export default async function (locationName) {
         } as any;
         (app as any).isChannelInstance = false;
         const instanceResult = await app.service('instance').create(newInstance);
-        await agonesSDK.allocate();
         (app as any).instance = instanceResult;
 
         if ((app as any).gsSubdomainNumber != null) {


### PR DESCRIPTION
Allocating preloaded servers leads Agones to endlessly spin up more servers
until it hits the nodegroup maximum.