### PR TITLE
Some fixes for Arc.

### DIFF
--- a/packages/client-core/src/admin/components/ArMediaConsole.tsx
+++ b/packages/client-core/src/admin/components/ArMediaConsole.tsx
@@ -221,8 +221,8 @@ const ArMediaConsole = (props: Props) => {
                         <TableCell className={styles.tcell} align="center">
                           <CardMedia
                             className={styles.previewImage}
-                            image={row.previewUrl.toString()}
-                            title={row.title.toString()}
+                            image={row.previewUrl?.toString()}
+                            title={row.title?.toString()}
                           />
                         </TableCell>
                         <TableCell className={styles.tcell} align="center">

--- a/packages/client-core/src/admin/components/FeedConsole.tsx
+++ b/packages/client-core/src/admin/components/FeedConsole.tsx
@@ -197,8 +197,8 @@ const FeedConsole = (props: Props) => {
                       <TableCell className={styles.tcell} align="center">
                         <CardMedia
                           className={styles.previewImage}
-                          image={row.previewUrl.toString()}
-                          title={row.title.toString()}
+                          image={row.previewUrl?.toString()}
+                          title={row.title?.toString()}
                         />
                       </TableCell>
                       <TableCell className={styles.tcell}>

--- a/packages/server-core/src/media/upload-media/upload-media.hooks.ts
+++ b/packages/server-core/src/media/upload-media/upload-media.hooks.ts
@@ -1,5 +1,6 @@
 import * as authentication from '@feathersjs/authentication'
 import { disallow } from 'feathers-hooks-common'
+import { SYNC } from 'feathers-sync'
 
 import addThumbnailFileId from '@xrengine/server-core/src/hooks/add-thumbnail-file-id'
 import addUriToFile from '@xrengine/server-core/src/hooks/add-uri-to-file'
@@ -35,6 +36,7 @@ export default {
       addThumbnailFileId(),
       removePreviousThumbnail(),
       createOwnedFile(),
+      (context) => (context[SYNC] = false),
       setResponseStatus(200)
     ],
     update: [],

--- a/packages/social/src/pages/login.tsx
+++ b/packages/social/src/pages/login.tsx
@@ -19,14 +19,12 @@ const mapDispatchToProps = (dispatch: Dispatch): any => ({
 })
 
 export const IndexPage = (props: Props): any => {
-  //   const {
-  //     doLoginAuto
-  //   } = props;
+  const { doLoginAuto } = props
   const { t } = useTranslation()
 
-  // useEffect(() => {
-  //     doLoginAuto(true);
-  // }, []);
+  useEffect(() => {
+    doLoginAuto(true)
+  }, [])
 
   // <Button className="right-bottom" variant="contained" color="secondary" aria-label="scene" onClick={(e) => { setSceneVisible(!sceneIsVisible); e.currentTarget.blur(); }}>scene</Button>
 


### PR DESCRIPTION
Even on local, syncing via feathers-sync after file uploads was causing JS heap out
of memory errors. Disabled sync on upload-media.hooks after:create so it's never
syncing.

Uncommented doLoginAuto in social/src/pages/login.tsx.

Added a couple conditional checks on CardMedia image and title; was throwing errors
after upload when there wasn't yet a previewUrl to stringify.