### PR TITLE
Character transform now rooted at feet

### DIFF
--- a/packages/engine/src/bot/golfHooks.ts
+++ b/packages/engine/src/bot/golfHooks.ts
@@ -118,7 +118,7 @@ export function swingClub() {
   return new Promise<void>((resolve) => {
     tweenXRInputSource({
       objectName: 'rightController',
-      time: 20, // 1 second
+      time: 10,
       positionFrom: new Vector3(0.5, 1, 0.04),
       positionTo: new Vector3(-0.5, 1, 0.04),
       quaternionFrom: eulerToQuaternion(-1.54, 0, 0),

--- a/packages/engine/src/bot/setupBotHooks.ts
+++ b/packages/engine/src/bot/setupBotHooks.ts
@@ -1,6 +1,7 @@
 import { Quaternion, Vector3 } from 'three'
 import { Engine } from '../ecs/classes/Engine'
 import { EngineEvents } from '../ecs/classes/EngineEvents'
+import { System } from '../ecs/classes/System'
 import { getComponent, hasComponent } from '../ecs/functions/EntityFunctions'
 import { GamePlayer } from '../game/components/GamePlayer'
 import { getGameFromName } from '../game/functions/functions'
@@ -13,6 +14,12 @@ import { sendXRInputData, swingClub, updateController, updateHead, tweenXRInputS
 
 export const setupBotHooks = (): void => {
   globalThis.botHooks = BotHooks
+  globalThis.Engine = Engine
+  globalThis.EngineEvents = EngineEvents
+  globalThis.Network = Network
+  Engine.activeSystems.getAll().forEach((system: System) => {
+    globalThis[system.name] = system.constructor
+  })
 }
 
 export const BotHooks = {
@@ -166,11 +173,7 @@ export function moveControllerStick(args) {
 // === ENGINE === //
 
 export function getPlayerPosition() {
-  const pos = getComponent(Network.instance.localClientEntity, TransformComponent)?.position
-  if (!pos) return
-  // transform is centered on collider
-  pos.y -= 0.9
-  return pos
+  return getComponent(Network.instance.localClientEntity, TransformComponent)?.position
 }
 
 export function getBallPosition() {

--- a/packages/engine/src/camera/components/FollowCameraComponent.ts
+++ b/packages/engine/src/camera/components/FollowCameraComponent.ts
@@ -30,8 +30,6 @@ export class FollowCameraComponent extends Component<FollowCameraComponent> {
   ry2: number
   /** Distance to which interactive objects from the camera will be highlighted. **Default** value is 5. */
   farDistance: number
-  /** Stores the shoulder offset amount */
-  offset: Vector3
   /** Rotation around Y axis */
   theta: number
   /** Rotation around Z axis */
@@ -58,7 +56,6 @@ FollowCameraComponent._schema = {
   rx2: { type: Types.Number, default: 0.1 },
   ry2: { type: Types.Number, default: 0.1 },
   farDistance: { type: Types.Number, default: 5 },
-  offset: { type: Types.Vector3Type, default: new Vector3(0, 1, 0) },
   theta: { type: Types.Number, default: 0 },
   phi: { type: Types.Number, default: 0 },
   shoulderSide: { type: Types.Boolean, default: true },

--- a/packages/engine/src/camera/systems/CameraSystem.ts
+++ b/packages/engine/src/camera/systems/CameraSystem.ts
@@ -82,16 +82,17 @@ const followCameraBehavior = (entity: Entity) => {
 
   const phi = followCamera.mode === CameraModes.TopDown ? 85 : followCamera.phi
 
-  const shoulderOffsetWorld = followCamera.offset.clone().applyQuaternion(actorTransform.rotation)
-  const targetPosition = vec3.copy(actorTransform.position).add(shoulderOffsetWorld)
+  vec3.set(followCamera.shoulderSide ? -0.25 : 0.25, actor.actorHeight, 0)
+  vec3.applyQuaternion(actorTransform.rotation)
+  vec3.add(actorTransform.position)
 
   // Raycast for camera
   const cameraTransform: TransformComponent = getMutableComponent(
     CameraSystem.instance.activeCamera,
     TransformComponent
   )
-  const raycastDirection = new Vector3().subVectors(cameraTransform.position, targetPosition).normalize()
-  followCamera.raycastQuery.origin.copy(targetPosition)
+  const raycastDirection = new Vector3().subVectors(cameraTransform.position, vec3).normalize()
+  followCamera.raycastQuery.origin.copy(vec3)
   followCamera.raycastQuery.direction.copy(raycastDirection)
 
   const closestHit = followCamera.raycastQuery.hits[0]
@@ -106,13 +107,13 @@ const followCameraBehavior = (entity: Entity) => {
   }
 
   cameraDesiredTransform.position.set(
-    targetPosition.x + camDist * Math.sin(followCamera.theta * PI_2Deg) * Math.cos(phi * PI_2Deg),
-    targetPosition.y + camDist * Math.sin(phi * PI_2Deg),
-    targetPosition.z + camDist * Math.cos(followCamera.theta * PI_2Deg) * Math.cos(phi * PI_2Deg)
+    vec3.x + camDist * Math.sin(followCamera.theta * PI_2Deg) * Math.cos(phi * PI_2Deg),
+    vec3.y + camDist * Math.sin(phi * PI_2Deg),
+    vec3.z + camDist * Math.cos(followCamera.theta * PI_2Deg) * Math.cos(phi * PI_2Deg)
   )
 
   direction.copy(cameraDesiredTransform.position)
-  direction = direction.sub(targetPosition).normalize()
+  direction = direction.sub(vec3).normalize()
 
   mx.lookAt(direction, empty, upVector)
   cameraDesiredTransform.rotation.setFromRotationMatrix(mx)

--- a/packages/engine/src/character/CharacterControllerSystem.ts
+++ b/packages/engine/src/character/CharacterControllerSystem.ts
@@ -111,9 +111,9 @@ export class CharacterControllerSystem extends System {
       playerCollider.raycastQuery = PhysicsSystem.instance.addRaycastQuery(
         new RaycastQuery({
           type: SceneQueryType.Closest,
-          origin: new Vector3(0, actor.actorHeight, 0),
+          origin: new Vector3(0, 0, 0),
           direction: new Vector3(0, -1, 0),
-          maxDistance: actor.actorHalfHeight + 0.05,
+          maxDistance: 0.05,
           collisionMask: DefaultCollisionMask | CollisionGroups.Portal
         })
       )
@@ -158,10 +158,11 @@ export class CharacterControllerSystem extends System {
       // TODO: implement scene lower bounds parameter
       if (!isClient && collider.controller.transform.translation.y < -10) {
         const { position, rotation } = ServerSpawnSystem.instance.getRandomSpawnPoint()
-        position.y += actor.actorHalfHeight
+        const pos = position.clone()
+        pos.y += actor.actorHalfHeight
         console.log('player has fallen through the floor, teleporting them to', position)
         collider.controller.updateTransform({
-          translation: position,
+          translation: pos,
           rotation
         })
         sendClientObjectUpdate(entity, NetworkObjectUpdateType.ForceTransformUpdate, [
@@ -177,7 +178,7 @@ export class CharacterControllerSystem extends System {
 
       transform.position.set(
         collider.controller.transform.translation.x,
-        collider.controller.transform.translation.y,
+        collider.controller.transform.translation.y - actor.actorHalfHeight,
         collider.controller.transform.translation.z
       )
 
@@ -268,8 +269,6 @@ export class CharacterControllerSystem extends System {
       const xrInputSourceComponent = getMutableComponent(entity, XRInputSourceComponent)
       const actor = getMutableComponent(entity, CharacterComponent)
       const object3DComponent = getComponent(entity, Object3DComponent)
-
-      xrInputSourceComponent.controllerGroup.position.setY(-actor.actorHalfHeight)
 
       xrInputSourceComponent.controllerGroup.add(
         xrInputSourceComponent.controllerLeft,

--- a/packages/engine/src/character/CharacterInputSchema.ts
+++ b/packages/engine/src/character/CharacterInputSchema.ts
@@ -131,7 +131,6 @@ const switchShoulderSide: Behavior = (entity: Entity, args: any, detla: number):
   const cameraFollow = getMutableComponent<FollowCameraComponent>(entity, FollowCameraComponent)
   if (cameraFollow) {
     cameraFollow.shoulderSide = !cameraFollow.shoulderSide
-    cameraFollow.offset.x = -cameraFollow.offset.x
   }
 }
 
@@ -165,7 +164,6 @@ const switchCameraMode = (entity: Entity, args: any = { pointerLock: false, mode
   switch (args.mode) {
     case CameraModes.FirstPerson:
       {
-        cameraFollow.offset.set(0, 1, 0)
         cameraFollow.phi = 0
         cameraFollow.locked = true
         setVisible(entity, false)
@@ -174,7 +172,6 @@ const switchCameraMode = (entity: Entity, args: any = { pointerLock: false, mode
 
     case CameraModes.ShoulderCam:
       {
-        cameraFollow.offset.set(cameraFollow.shoulderSide ? -0.25 : 0.25, 1, 0)
         setVisible(entity, true)
       }
       break
@@ -182,14 +179,12 @@ const switchCameraMode = (entity: Entity, args: any = { pointerLock: false, mode
     default:
     case CameraModes.ThirdPerson:
       {
-        cameraFollow.offset.set(cameraFollow.shoulderSide ? -0.25 : 0.25, 1, 0)
         setVisible(entity, true)
       }
       break
 
     case CameraModes.TopDown:
       {
-        cameraFollow.offset.set(0, 1, 0)
         setVisible(entity, true)
       }
       break

--- a/packages/engine/src/character/behaviors/characterCorrectionBehavior.ts
+++ b/packages/engine/src/character/behaviors/characterCorrectionBehavior.ts
@@ -11,6 +11,7 @@ import { findInterpolationSnapshot } from '../../physics/behaviors/findInterpola
 import { ControllerColliderComponent } from '../components/ControllerColliderComponent'
 import { SnapshotData } from '../../networking/types/SnapshotDataTypes'
 import { Vector3 } from 'three'
+import { CharacterComponent } from '../components/CharacterComponent'
 
 /**
  * @author HydraFire <github.com/HydraFire>
@@ -23,13 +24,14 @@ import { Vector3 } from 'three'
 const vec3 = new Vector3()
 
 export const characterCorrectionBehavior: Behavior = (entity: Entity, snapshots: SnapshotData, delta: number): void => {
-  const collider = getComponent<ControllerColliderComponent>(entity, ControllerColliderComponent)
+  const collider = getComponent(entity, ControllerColliderComponent)
+  const actor = getComponent(entity, CharacterComponent)
   const networkId = getComponent(entity, NetworkObject).networkId
 
   snapshots.new.push({
     networkId,
     x: collider.controller.transform.translation.x,
-    y: collider.controller.transform.translation.y,
+    y: collider.controller.transform.translation.y - actor.actorHalfHeight,
     z: collider.controller.transform.translation.z,
     qX: 0, // physx controllers dont have rotation
     qY: 0,
@@ -51,7 +53,7 @@ export const characterCorrectionBehavior: Behavior = (entity: Entity, snapshots:
     collider.controller.updateTransform({
       translation: {
         x: currentSnapshot.x,
-        y: currentSnapshot.y,
+        y: currentSnapshot.y + actor.actorHalfHeight,
         z: currentSnapshot.z
       }
     })

--- a/packages/engine/src/character/behaviors/characterInterpolationBehavior.ts
+++ b/packages/engine/src/character/behaviors/characterInterpolationBehavior.ts
@@ -6,7 +6,6 @@ import { ControllerColliderComponent } from '../components/ControllerColliderCom
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { CharacterComponent } from '../components/CharacterComponent'
 import type { SnapshotData, StateInterEntity } from '../../networking/types/SnapshotDataTypes'
-import { Vector3 } from 'three'
 import { AnimationComponent } from '../components/AnimationComponent'
 
 /**
@@ -36,7 +35,7 @@ export const characterInterpolationBehavior: Behavior = (
   collider.controller.updateTransform({
     translation: {
       x: interpolation.x,
-      y: interpolation.y,
+      y: interpolation.y + actor.actorHalfHeight,
       z: interpolation.z
     }
   })

--- a/packages/engine/src/character/prefabs/NetworkPlayerCharacter.ts
+++ b/packages/engine/src/character/prefabs/NetworkPlayerCharacter.ts
@@ -105,11 +105,11 @@ const initializeCharacter: Behavior = (entity): void => {
   // The visuals group is centered for easy actor tilting
   const obj3d = new Group()
   obj3d.name = 'Actor (tiltContainer)' + entity.id
+  obj3d.position.setY(actor.actorHalfHeight)
 
   // // Model container is used to reliably ground the actor, as animation can alter the position of the model itself
   actor.modelContainer = new Group()
   actor.modelContainer.name = 'Actor (modelContainer)' + entity.id
-  actor.modelContainer.position.setY(-actor.actorHalfHeight)
   obj3d.add(actor.modelContainer)
 
   const animationComponent = addComponent(entity, AnimationComponent, {
@@ -158,6 +158,7 @@ export const teleportPlayer = (playerEntity: Entity, position: Vector3, rotation
     translation: pos,
     rotation
   })
+  playerCollider.controller.velocity.setScalar(0)
 }
 
 export function createNetworkPlayer(args: {
@@ -166,6 +167,7 @@ export function createNetworkPlayer(args: {
   networkId?: number
   entity?: Entity
 }): NetworkObject {
+  console.log(args)
   const position = new Vector3()
   const rotation = new Quaternion()
   if (args.parameters) {

--- a/packages/engine/src/game/templates/Golf/behaviors/setupPlayerInput.ts
+++ b/packages/engine/src/game/templates/Golf/behaviors/setupPlayerInput.ts
@@ -29,7 +29,7 @@ export const setupPlayerInput = (entityPlayer: Entity) => {
           const ballEntity = game.gameObjects['GolfBall'].find((e) => getComponent(e, NetworkObject)?.ownerId === uuid)
           const ballTransform = getComponent(ballEntity, TransformComponent)
           const position = ballTransform.position
-          console.log('teleporting to', position)
+          console.log('teleporting to', position.x, position.y, position.z)
           teleportPlayer(entity, position, new Quaternion())
         }
       }

--- a/packages/engine/src/physics/behaviors/handleForceTransform.ts
+++ b/packages/engine/src/physics/behaviors/handleForceTransform.ts
@@ -1,3 +1,5 @@
+import { actionProcessing } from '../../../../client-core'
+import { CharacterComponent } from '../../character/components/CharacterComponent'
 import { ControllerColliderComponent } from '../../character/components/ControllerColliderComponent'
 import { Entity } from '../../ecs/classes/Entity'
 import { getComponent } from '../../ecs/functions/EntityFunctions'
@@ -25,8 +27,9 @@ export const handleForceTransform = (editObject: NetworkObjectEditInterface): vo
 
   const controllerComponent = getComponent(entity, ControllerColliderComponent)
   if (controllerComponent) {
+    const actor = getComponent(entity, CharacterComponent)
     controllerComponent.controller?.updateTransform({
-      translation: { x, y, z },
+      translation: { x, y: y + actor.actorHalfHeight, z },
       rotation: { x: qX, y: qY, z: qZ, w: qW }
     })
   }

--- a/packages/engine/src/scene/systems/ServerSpawnSystem.ts
+++ b/packages/engine/src/scene/systems/ServerSpawnSystem.ts
@@ -29,7 +29,9 @@ export class ServerSpawnSystem extends System {
       // Get new spawn point (round robin)
       this.lastSpawnIndex = (this.lastSpawnIndex + 1) % this.spawnPoints.length
       return {
-        position: spawnTransform.position.clone().add(randomPositionCentered(spawnTransform.scale)),
+        position: spawnTransform.position
+          .clone()
+          .add(randomPositionCentered(new Vector3(spawnTransform.scale.x, 0, spawnTransform.scale.z))),
         rotation: spawnTransform.rotation.clone()
       }
     }

--- a/packages/engine/src/vehicle/VehicleInputSchema.ts
+++ b/packages/engine/src/vehicle/VehicleInputSchema.ts
@@ -137,7 +137,6 @@ const switchCameraMode = (entity: Entity, args: any = { pointerLock: false, mode
   switch (args.mode) {
     case CameraModes.FirstPerson:
       {
-        cameraFollow.offset.set(0, 1, 0)
         cameraFollow.phi = 0
         cameraFollow.locked = true
         //setVisible(actor, false);
@@ -145,21 +144,18 @@ const switchCameraMode = (entity: Entity, args: any = { pointerLock: false, mode
       break
     /*
     case CameraModes.ShoulderCam: {
-      cameraFollow.offset.set(cameraFollow.shoulderSide ? -0.25 : 0.25, 1, 0);
     //  setVisible(actor, true);
     } break;
 */
     default:
     case CameraModes.ThirdPerson:
       {
-        cameraFollow.offset.set(cameraFollow.shoulderSide ? -0.25 : 0.25, 1, 0)
         //  setVisible(actor, true);
       }
       break
 
     case CameraModes.TopDown:
       {
-        cameraFollow.offset.set(0, 1, 0)
         //setVisible(actor, true);
       }
       break

--- a/packages/engine/src/xr/functions/WebXRFunctions.ts
+++ b/packages/engine/src/xr/functions/WebXRFunctions.ts
@@ -181,7 +181,7 @@ export const getHandPosition = (entity: Entity, hand: ParityValue = ParityValue.
     }
   }
   // TODO: replace (-0.5, 0, 0) with animation hand position once new animation rig is in
-  return vec3.set(-0.5, 0, 0).applyQuaternion(transform.rotation).add(transform.position)
+  return vec3.set(-0.5, 1, 0).applyQuaternion(transform.rotation).add(transform.position)
 }
 
 /**
@@ -232,7 +232,7 @@ export const getHandTransform = (
   }
   return {
     // TODO: replace (-0.5, 0, 0) with animation hand position once new animation rig is in
-    position: vec3.set(-0.5, 0, 0).applyQuaternion(transform.rotation).add(transform.position),
+    position: vec3.set(-0.5, 1, 0).applyQuaternion(transform.rotation).add(transform.position),
     rotation: quat.setFromUnitVectors(forward, actor.viewVector)
   }
 }

--- a/packages/engine/tests/golf/golf.test.ts
+++ b/packages/engine/tests/golf/golf.test.ts
@@ -3,8 +3,8 @@ import { Euler, MathUtils, Quaternion, Vector3 } from 'three'
 import XREngineBot from '../../../bot/src/bot'
 
 const maxTimeout = 60 * 1000
-const headless = false
-const bot = new XREngineBot({ name: 'bot-1', headless, autoLog: true })
+const headless = true
+const bot = new XREngineBot({ name: 'bot-1', headless, autoLog: false })
 
 const domain = process.env.APP_HOST
 // TODO: load GS & client from static world file instead of having to run independently
@@ -79,10 +79,11 @@ describe('Golf tests', () => {
       leftControllerInputValue,
       rightControllerInputValue
     } = await bot.runHook("getXRInputPosition")
+    console.log(headInputValue.x, headInputValue.y, headInputValue.z)
 
     compareArrays(
       [headInputValue.x, headInputValue.y, headInputValue.z],
-      [0, 0.7, 0],
+      [0, 1.6, 0],
       0.01
     )
     compareArrays(
@@ -124,7 +125,7 @@ describe('Golf tests', () => {
     // wait for turn, then move to ball position
     await bot.awaitHookPromise("getIsYourTurn")
     await bot.keyPress('KeyK', 200)
-    await bot.delay(500)
+    await bot.delay(1000)
 
     // should be at ball position
     expect(

--- a/packages/gameserver/src/NetworkFunctions.ts
+++ b/packages/gameserver/src/NetworkFunctions.ts
@@ -317,7 +317,6 @@ export async function handleJoinWorld(socket, data, callback, userId, user): Pro
   const networkObject = createNetworkPlayer({ ownerId: userId, parameters: spawnPos })
 
   const actor = getComponent(networkObject.entity, CharacterComponent)
-  spawnPos.position.y += actor.actorHalfHeight
 
   const transform = getComponent(networkObject.entity, TransformComponent)
   transform.position.copy(spawnPos.position)


### PR DESCRIPTION
This PR is to move the transform of the character to be rooted at the avatar's feet instead of the middle of the collider. This improves some mismatches of values with WebXR and generally makes more sense.