### PR TITLE
Update volumetric player for ARC

### DIFF
--- a/packages/client-core/package.json
+++ b/packages/client-core/package.json
@@ -97,7 +97,7 @@
     "use-debounce": "7.0.0",
     "use-http": "1.0.21",
     "uuid": "8.3.2",
-    "volumetric": "0.2.24",
+    "volumetric": "0.2.25",
     "yup": "0.32.9"
   },
   "devDependencies": {

--- a/packages/client-core/src/socialmedia/components/WebXRPlugin/index.tsx
+++ b/packages/client-core/src/socialmedia/components/WebXRPlugin/index.tsx
@@ -503,8 +503,6 @@ export const WebXRPlugin = ({
           // }
           // }
         }
-
-        // render()
       })
 
       // @ts-ignore

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -61,7 +61,7 @@
     "three-physx": "^0.0.33",
     "twitch-m3u8": "^1.1.4",
     "vite": "2.4.2",
-    "volumetric": "https://github.com/XRFoundation/UniversalVolumetric"
+    "volumetric": "0.2.25"
   },
   "devDependencies": {
     "@rollup/plugin-json": "4.1.0",

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -47,7 +47,7 @@
     "redux": "4.1.0",
     "sass": "1.35.2",
     "styled-components": "5.3.0",
-    "volumetric": "https://github.com/XRFoundation/UniversalVolumetric",
+    "volumetric": "0.2.25",
     "webxr-native": "0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated volumetric package, with some minor performance optimizations and edge-case playback fixes. The main GPU performance bottleneck at this point is reading from the video texture in order to get the current frame. There isn't that much we can do about that until APIs like requestVideoFrameCallback are supported on iOS. 