### PR TITLE
Fixed several bugs and improved content-packs.

### DIFF
--- a/packages/client-core/src/admin/components/AdminHelpers.tsx
+++ b/packages/client-core/src/admin/components/AdminHelpers.tsx
@@ -29,7 +29,7 @@ export function EnhancedTableHead(props: EnhancedTableProps) {
             className={styles.tcell}
             key={headCell.id}
             align="center"
-            padding={headCell.disablePadding ? 'none' : 'default'}
+            padding={headCell.disablePadding ? 'none' : 'normal'}
             sortDirection={orderBy === headCell.id ? order : false}
           >
             <TableSortLabel

--- a/packages/client-core/src/admin/components/Analytics/ApiLinks.tsx
+++ b/packages/client-core/src/admin/components/Analytics/ApiLinks.tsx
@@ -121,7 +121,7 @@ function EnhancedTableHead(props: EnhancedTableProps) {
           <TableCell
             key={headCell.id}
             align={headCell.numeric ? 'right' : 'left'}
-            padding={headCell.disablePadding ? 'none' : 'default'}
+            padding={headCell.disablePadding ? 'none' : 'normal'}
             sortDirection={orderBy === headCell.id ? order : false}
           >
             <TableSortLabel
@@ -272,11 +272,11 @@ export default function ApiLinks() {
     setSelected(newSelected)
   }
 
-  const handleChangePage = (event: unknown, newPage: number) => {
+  const handlePageChange = (event: unknown, newPage: number) => {
     setPage(newPage)
   }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setRowsPerPage(parseInt(event.target.value, 10))
     setPage(0)
   }
@@ -353,8 +353,8 @@ export default function ApiLinks() {
           count={rows.length}
           rowsPerPage={rowsPerPage}
           page={page}
-          onChangePage={handleChangePage}
-          onChangeRowsPerPage={handleChangeRowsPerPage}
+          onPageChange={handlePageChange}
+          onRowsPerPageChange={handleRowsPerPageChange}
         />
       </Paper>
     </div>

--- a/packages/client-core/src/admin/components/Avatars/Avatars.module.scss
+++ b/packages/client-core/src/admin/components/Avatars/Avatars.module.scss
@@ -194,3 +194,14 @@
     }
   }
 }
+
+.checkbox {
+  color: white;
+}
+
+.open-modal {
+  position: fixed;
+  left: 45%;
+  z-index: 1300;
+  top: 10px;
+}

--- a/packages/client-core/src/admin/components/Avatars/Avatars.tsx
+++ b/packages/client-core/src/admin/components/Avatars/Avatars.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import Button from '@material-ui/core/Button'
+import Checkbox from '@material-ui/core/Checkbox'
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
 import TableContainer from '@material-ui/core/TableContainer'
@@ -116,7 +117,7 @@ const Avatars = (props: Props) => {
               className={styles.tcell}
               key={headCell.id}
               align="right"
-              padding={headCell.disablePadding ? 'none' : 'default'}
+              padding={headCell.disablePadding ? 'none' : 'normal'}
               sortDirection={orderBy === headCell.id ? order : false}
             >
               <TableSortLabel
@@ -140,8 +141,7 @@ const Avatars = (props: Props) => {
   const [rowsPerPage, setRowsPerPage] = useState(PAGE_LIMIT)
   const [refetch, setRefetch] = useState(false)
   const [addToContentPackModalOpen, setAddToContentPackModalOpen] = useState(false)
-  const [selectedAvatar, setSelectedAvatar] = useState({})
-  const [selectedThumbnail, setSelectedThumbnail] = useState({})
+  const [selectedAvatars, setSelectedAvatars] = useState([])
 
   const handleRequestSort = (event: React.MouseEvent<unknown>, property) => {
     const isAsc = orderBy === property && order === 'asc'
@@ -158,27 +158,31 @@ const Avatars = (props: Props) => {
     setSelected([])
   }
 
-  const handleChangePage = (event: unknown, newPage: number) => {
+  const handlePageChange = (event: unknown, newPage: number) => {
     const incDec = page < newPage ? 'increment' : 'decrement'
     fetchAdminAvatars(incDec)
     setPage(newPage)
   }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setRowsPerPage(parseInt(event.target.value, 10))
     setPage(0)
   }
 
-  const openAddToContentPackModal = (avatar: any) => {
-    setSelectedAvatar(avatar)
-    setSelectedThumbnail(adminThumbnails.find((thumbnail) => thumbnail.name === avatar.name))
-    setAddToContentPackModalOpen(true)
-  }
+  const handleCheck = (e: any, row: any) => {
+    const newItem = {
+      avatar: row,
+      thumbnail: adminThumbnails.find((thumbnail) => thumbnail.name === row.name)
+    }
 
-  const closeAddToContentPackModal = () => {
-    setAddToContentPackModalOpen(false)
-    setSelectedAvatar({})
-    setSelectedThumbnail({})
+    const existingAvatarIndex = selectedAvatars.findIndex((avatar) => avatar.avatar.id === row.id)
+    if (e.target.checked === true) {
+      if (existingAvatarIndex >= 0) setSelectedAvatars(selectedAvatars.splice(existingAvatarIndex, 1, newItem))
+      else setSelectedAvatars(selectedAvatars.concat(newItem))
+    } else setSelectedAvatars(selectedAvatars.splice(existingAvatarIndex, 1))
+    setTimeout(() => {
+      console.log('selectedAvatars after', selectedAvatars)
+    }, 500)
   }
 
   const fetchTick = () => {
@@ -247,14 +251,12 @@ const Avatars = (props: Props) => {
                       </TableCell>
                       <TableCell className={styles.tcell} align="right">
                         {user.userRole === 'admin' && (
-                          <Button
-                            type="button"
-                            variant="contained"
+                          <Checkbox
+                            className={styles.checkbox}
+                            onChange={(e) => handleCheck(e, row)}
+                            name="stereoscopic"
                             color="primary"
-                            onClick={() => openAddToContentPackModal(row)}
-                          >
-                            Add to Content Pack
-                          </Button>
+                          />
                         )}
                       </TableCell>
                     </TableRow>
@@ -271,18 +273,26 @@ const Avatars = (props: Props) => {
             count={adminAvatarCount}
             rowsPerPage={rowsPerPage}
             page={page}
-            onChangePage={handleChangePage}
-            onChangeRowsPerPage={handleChangeRowsPerPage}
+            onPageChange={handlePageChange}
+            onRowsPerPageChange={handleRowsPerPageChange}
             className={styles.tablePagination}
           />
         </div>
         <AddToContentPackModal
           open={addToContentPackModalOpen}
-          avatar={selectedAvatar}
-          thumbnail={selectedThumbnail}
-          handleClose={closeAddToContentPackModal}
+          avatars={selectedAvatars}
+          handleClose={() => setAddToContentPackModalOpen(false)}
         />
       </Paper>
+      <Button
+        className={styles['open-modal']}
+        type="button"
+        variant="contained"
+        color="primary"
+        onClick={() => setAddToContentPackModalOpen(true)}
+      >
+        Add to Content Pack
+      </Button>
     </div>
   )
 }

--- a/packages/client-core/src/admin/components/ContentPack/AddToContentPackModal.tsx
+++ b/packages/client-core/src/admin/components/ContentPack/AddToContentPackModal.tsx
@@ -8,11 +8,10 @@ import { selectContentPackState } from '../../reducers/contentPack/selector'
 // @ts-ignore
 import styles from './ContentPack.module.scss'
 import {
-  addAvatarToContentPack,
-  addSceneToContentPack,
+  addAvatarsToContentPack,
+  addScenesToContentPack,
   createContentPack,
-  fetchContentPacks,
-  uploadAvatars
+  fetchContentPacks
 } from '../../reducers/contentPack/service'
 import { Add, Edit } from '@material-ui/icons'
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab'
@@ -32,14 +31,12 @@ import CircularProgress from '@material-ui/core/CircularProgress'
 interface Props {
   open: boolean
   handleClose: any
-  scene?: any
-  avatar?: any
-  thumbnail?: any
+  scenes?: any
+  avatars?: any
   adminState?: any
   contentPackState?: any
-  uploadAvatars?: any
-  addSceneToContentPack?: any
-  addAvatarToContentPack?: any
+  addScenesToContentPack?: any
+  addAvatarsToContentPack?: any
   createContentPack?: any
   fetchContentPacks?: any
 }
@@ -53,23 +50,21 @@ const mapStateToProps = (state: any): any => {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch): any => ({
-  addSceneToContentPack: bindActionCreators(addSceneToContentPack, dispatch),
-  addAvatarToContentPack: bindActionCreators(addAvatarToContentPack, dispatch),
+  addScenesToContentPack: bindActionCreators(addScenesToContentPack, dispatch),
+  addAvatarsToContentPack: bindActionCreators(addAvatarsToContentPack, dispatch),
   createContentPack: bindActionCreators(createContentPack, dispatch),
-  fetchContentPacks: bindActionCreators(fetchContentPacks, dispatch),
-  uploadAvatars: bindActionCreators(uploadAvatars, dispatch)
+  fetchContentPacks: bindActionCreators(fetchContentPacks, dispatch)
 })
 
 const AddToContentPackModal = (props: Props): any => {
   const {
-    addAvatarToContentPack,
-    addSceneToContentPack,
+    addAvatarsToContentPack,
+    addScenesToContentPack,
     createContentPack,
     open,
     handleClose,
-    avatar,
-    thumbnail,
-    scene,
+    avatars,
+    scenes,
     contentPackState,
     fetchContentPacks
   } = props
@@ -92,11 +87,11 @@ const AddToContentPackModal = (props: Props): any => {
     setCreateOrPatch(newValue)
   }
 
-  const addCurrentSceneToContentPack = async () => {
+  const addCurrentScenesToContentPack = async () => {
     try {
       setProcessing(true)
-      await addSceneToContentPack({
-        scene: scene,
+      await addScenesToContentPack({
+        scenes: scenes,
         contentPack: contentPackName
       })
       setProcessing(false)
@@ -108,12 +103,11 @@ const AddToContentPackModal = (props: Props): any => {
     }
   }
 
-  const addCurrentAvatarToContentPack = async () => {
+  const addCurrentAvatarsToContentPack = async () => {
     try {
       setProcessing(true)
-      await addAvatarToContentPack({
-        avatar: avatar,
-        thumbnail: thumbnail,
+      await addAvatarsToContentPack({
+        avatars: avatars,
         contentPack: contentPackName
       })
       setProcessing(false)
@@ -128,15 +122,14 @@ const AddToContentPackModal = (props: Props): any => {
   const createNewContentPack = async () => {
     try {
       setProcessing(true)
-      if (scene != null)
+      if (scenes != null)
         await createContentPack({
-          scene: scene,
+          scenes: scenes,
           contentPack: newContentPackName
         })
-      else if (avatar != null)
+      else if (avatars != null)
         await createContentPack({
-          avatar: avatar,
-          thumbnail: thumbnail,
+          avatars: avatars,
           contentPack: newContentPackName
         })
       setProcessing(false)
@@ -183,8 +176,8 @@ const AddToContentPackModal = (props: Props): any => {
           >
             <div className={styles['modal-header']}>
               <div />
-              {scene && scene.name && <div className={styles['title']}>{scene.name}</div>}
-              {avatar && avatar.name && <div className={styles['title']}>{avatar.name}</div>}
+              {scenes && <div className={styles['title']}>Adding {scenes.length} Scenes</div>}
+              {avatars && <div className={styles['title']}>Adding {avatars.length} Avatars</div>}
               <IconButton aria-label="close" className={styles.closeButton} onClick={handleClose}>
                 <CloseIcon />
               </IconButton>
@@ -225,7 +218,7 @@ const AddToContentPackModal = (props: Props): any => {
                     type="submit"
                     variant="contained"
                     color="primary"
-                    onClick={scene != null ? addCurrentSceneToContentPack : addCurrentAvatarToContentPack}
+                    onClick={scenes != null ? addCurrentScenesToContentPack : addCurrentAvatarsToContentPack}
                   >
                     Update Content Pack
                   </Button>
@@ -255,7 +248,7 @@ const AddToContentPackModal = (props: Props): any => {
             )}
             {processing === true && (
               <div className={styles.processing}>
-                <CircularProgress color="black" />
+                <CircularProgress color="primary" />
                 <div className={styles.text}>Processing</div>
               </div>
             )}

--- a/packages/client-core/src/admin/components/ContentPack/ContentPack.module.scss
+++ b/packages/client-core/src/admin/components/ContentPack/ContentPack.module.scss
@@ -164,6 +164,7 @@
       .container {
         display: flex;
         flex-direction: row;
+        flex-wrap: wrap;
 
         .avatar,
         .scene {

--- a/packages/client-core/src/admin/components/ContentPack/ContentPackDetailsModal.tsx
+++ b/packages/client-core/src/admin/components/ContentPack/ContentPackDetailsModal.tsx
@@ -139,8 +139,9 @@ const ContentPackDetailsModal = (props: Props): any => {
               </div>
             </div>
             {processing === true && (
-              <div>
-                <CircularProgress color="black" /> Processing{' '}
+              <div className={styles.processing}>
+                <CircularProgress color="primary" />
+                <div className={styles.text}>Processing</div>
               </div>
             )}
             {success === true && (

--- a/packages/client-core/src/admin/components/GroupsConsole.tsx
+++ b/packages/client-core/src/admin/components/GroupsConsole.tsx
@@ -71,7 +71,7 @@ export default function GroupsConsole() {
               className={styles.tcell}
               key={headCell.id}
               align="right"
-              padding={headCell.disablePadding ? 'none' : 'default'}
+              padding={headCell.disablePadding ? 'none' : 'normal'}
               sortDirection={orderBy === headCell.id ? order : false}
             >
               <TableSortLabel

--- a/packages/client-core/src/admin/components/Instance/InstanceModal.tsx
+++ b/packages/client-core/src/admin/components/Instance/InstanceModal.tsx
@@ -130,7 +130,7 @@ const InstanceModal = (props: Props): any => {
               className={styles.tcell}
               key={headCell.id}
               align="right"
-              padding={headCell.disablePadding ? 'none' : 'default'}
+              padding={headCell.disablePadding ? 'none' : 'normal'}
               sortDirection={orderBy === headCell.id ? order : false}
             >
               <TableSortLabel active={orderBy === headCell.id} direction={orderBy === headCell.id ? order : 'asc'}>

--- a/packages/client-core/src/admin/components/Instance/InstanceTable.tsx
+++ b/packages/client-core/src/admin/components/Instance/InstanceTable.tsx
@@ -51,10 +51,10 @@ const InstanceTable = (props: Props) => {
 
   const user = authState.get('user')
   const adminInstances = adminInstanceState.get('instances')
-  const handleChangePage = (event: unknown, newPage: number) => {
+  const handlePageChange = (event: unknown, newPage: number) => {
     setPage(newPage)
   }
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setRowsPerPage(+event.target.value)
     setPage(0)
   }
@@ -135,8 +135,8 @@ const InstanceTable = (props: Props) => {
         count={12}
         rowsPerPage={rowsPerPage}
         page={page}
-        onPageChange={handleChangePage}
-        onRowsPerPageChange={handleChangeRowsPerPage}
+        onPageChange={handlePageChange}
+        onRowsPerPageChange={handleRowsPerPageChange}
         className={classex.tableFooter}
       />
     </div>

--- a/packages/client-core/src/admin/components/InstanceConsole.tsx
+++ b/packages/client-core/src/admin/components/InstanceConsole.tsx
@@ -161,7 +161,7 @@ function InstanceConsole(props: Props) {
               className={styles.tcell}
               key={headCell.id}
               align="right"
-              padding={headCell.disablePadding ? 'none' : 'default'}
+              padding={headCell.disablePadding ? 'none' : 'normal'}
               sortDirection={orderBy === headCell.id ? order : false}
             >
               <TableSortLabel

--- a/packages/client-core/src/admin/components/Invite/RecievedInvite.tsx
+++ b/packages/client-core/src/admin/components/Invite/RecievedInvite.tsx
@@ -63,28 +63,28 @@ interface TablePaginationActionsProps {
   count: number
   page: number
   rowsPerPage: number
-  onChangePage: (event: React.MouseEvent<HTMLButtonElement>, newPage: number) => void
+  onPageChange: (event: React.MouseEvent<HTMLButtonElement>, newPage: number) => void
 }
 
 function TablePaginationActions(props: TablePaginationActionsProps) {
   const classes = useStyles1()
   const theme = useTheme()
-  const { count, page, rowsPerPage, onChangePage } = props
+  const { count, page, rowsPerPage, onPageChange } = props
 
   const handleFirstPageButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    onChangePage(event, 0)
+    onPageChange(event, 0)
   }
 
   const handleBackButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    onChangePage(event, page - 1)
+    onPageChange(event, page - 1)
   }
 
   const handleNextButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    onChangePage(event, page + 1)
+    onPageChange(event, page + 1)
   }
 
   const handleLastPageButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    onChangePage(event, Math.max(0, Math.ceil(count / rowsPerPage) - 1))
+    onPageChange(event, Math.max(0, Math.ceil(count / rowsPerPage) - 1))
   }
 
   return (
@@ -123,11 +123,11 @@ const RecievedInvite = (props: Props) => {
 
   const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage)
 
-  const handleChangePage = (event: React.MouseEvent<HTMLButtonElement> | null, newPage: number) => {
+  const handlePageChange = (event: React.MouseEvent<HTMLButtonElement> | null, newPage: number) => {
     setPage(newPage)
   }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setRowsPerPage(parseInt(event.target.value, 10))
     setPage(0)
   }
@@ -179,8 +179,8 @@ const RecievedInvite = (props: Props) => {
                 inputProps: { 'aria-label': 'rows per page' },
                 native: true
               }}
-              onChangePage={handleChangePage}
-              onChangeRowsPerPage={handleChangeRowsPerPage}
+              onPageChange={handlePageChange}
+              onRowsPerPageChange={handleRowsPerPageChange}
               ActionsComponent={TablePaginationActions}
             />
           </TableRow>

--- a/packages/client-core/src/admin/components/Invite/SentInvite.tsx
+++ b/packages/client-core/src/admin/components/Invite/SentInvite.tsx
@@ -71,28 +71,28 @@ interface TablePaginationActionsProps {
   count: number
   page: number
   rowsPerPage: number
-  onChangePage: (event: React.MouseEvent<HTMLButtonElement>, newPage: number) => void
+  onPageChange: (event: React.MouseEvent<HTMLButtonElement>, newPage: number) => void
 }
 
 function TablePaginationActions(props: TablePaginationActionsProps) {
   const classes = useStyles1()
   const theme = useTheme()
-  const { count, page, rowsPerPage, onChangePage } = props
+  const { count, page, rowsPerPage, onPageChange } = props
 
   const handleFirstPageButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    onChangePage(event, 0)
+    onPageChange(event, 0)
   }
 
   const handleBackButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    onChangePage(event, page - 1)
+    onPageChange(event, page - 1)
   }
 
   const handleNextButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    onChangePage(event, page + 1)
+    onPageChange(event, page + 1)
   }
 
   const handleLastPageButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    onChangePage(event, Math.max(0, Math.ceil(count / rowsPerPage) - 1))
+    onPageChange(event, Math.max(0, Math.ceil(count / rowsPerPage) - 1))
   }
 
   return (
@@ -139,11 +139,11 @@ const SentInvite = (props: Props) => {
 
   const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage)
 
-  const handleChangePage = (event: React.MouseEvent<HTMLButtonElement> | null, newPage: number) => {
+  const handlePageChange = (event: React.MouseEvent<HTMLButtonElement> | null, newPage: number) => {
     setPage(newPage)
   }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setRowsPerPage(parseInt(event.target.value, 10))
     setPage(0)
   }
@@ -201,8 +201,8 @@ const SentInvite = (props: Props) => {
                 inputProps: { 'aria-label': 'rows per page' },
                 native: true
               }}
-              onChangePage={handleChangePage}
-              onChangeRowsPerPage={handleChangeRowsPerPage}
+              onPageChange={handlePageChange}
+              onRowsPerPageChange={handleRowsPerPageChange}
               ActionsComponent={TablePaginationActions}
             />
           </TableRow>

--- a/packages/client-core/src/admin/components/Location/LocationTable.tsx
+++ b/packages/client-core/src/admin/components/Location/LocationTable.tsx
@@ -76,11 +76,11 @@ const LocationTable = (props: Props) => {
   const adminLocations = adminLocationState.get('locations').get('locations')
   const { t } = useTranslation()
 
-  const handleChangePage = (event: unknown, newPage: number) => {
+  const handlePageChange = (event: unknown, newPage: number) => {
     setPage(newPage)
   }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setRowsPerPage(+event.target.value)
     setPage(0)
   }
@@ -236,8 +236,8 @@ const LocationTable = (props: Props) => {
         count={12}
         rowsPerPage={rowsPerPage}
         page={page}
-        onPageChange={handleChangePage}
-        onRowsPerPageChange={handleChangeRowsPerPage}
+        onPageChange={handlePageChange}
+        onRowsPerPageChange={handleRowsPerPageChange}
         className={classex.tableFooter}
       />
       <Dialog

--- a/packages/client-core/src/admin/components/Party/PartyTable.tsx
+++ b/packages/client-core/src/admin/components/Party/PartyTable.tsx
@@ -39,7 +39,7 @@ const PartyTable = (props: PropsTable) => {
   const adminParty = adminPartyState.get('parties')
   const adminPartyData = adminParty.get('parties').data ? adminParty.get('parties').data : []
 
-  const handleChangePage = (event: unknown, newPage: number) => {
+  const handlePageChange = (event: unknown, newPage: number) => {
     setPage(newPage)
   }
 
@@ -68,7 +68,7 @@ const PartyTable = (props: PropsTable) => {
     }
   }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setRowsPerPage(+event.target.value)
     setPage(0)
   }
@@ -123,8 +123,8 @@ const PartyTable = (props: PropsTable) => {
         count={rows.length}
         rowsPerPage={rowsPerPage}
         page={page}
-        onPageChange={handleChangePage}
-        onRowsPerPageChange={handleChangeRowsPerPage}
+        onPageChange={handlePageChange}
+        onRowsPerPageChange={handleRowsPerPageChange}
         className={classex.tableFooter}
       />
     </div>

--- a/packages/client-core/src/admin/components/Scenes/Scenes.module.scss
+++ b/packages/client-core/src/admin/components/Scenes/Scenes.module.scss
@@ -167,3 +167,15 @@
 .locationModalButtons {
   justify-content: space-between;
 }
+
+.checkbox {
+  color: white !important;
+}
+
+.open-modal {
+  position: fixed;
+  left: 45%;
+  z-index: 1300;
+  top: 10px;
+}
+

--- a/packages/client-core/src/admin/components/Scenes/Scenes.tsx
+++ b/packages/client-core/src/admin/components/Scenes/Scenes.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import Button from '@material-ui/core/Button'
+import Checkbox from '@material-ui/core/Checkbox'
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
 import TableContainer from '@material-ui/core/TableContainer'
@@ -115,7 +116,7 @@ const Scenes = (props: Props) => {
               className={styles.tcell}
               key={headCell.id}
               align="right"
-              padding={headCell.disablePadding ? 'none' : 'default'}
+              padding={headCell.disablePadding ? 'none' : 'normal'}
               sortDirection={orderBy === headCell.id ? order : false}
             >
               <TableSortLabel
@@ -139,7 +140,7 @@ const Scenes = (props: Props) => {
   const [rowsPerPage, setRowsPerPage] = useState(PAGE_LIMIT)
   const [refetch, setRefetch] = useState(false)
   const [addToContentPackModalOpen, setAddToContentPackModalOpen] = useState(false)
-  const [selectedScene, setSelectedScene] = useState({})
+  const [selectedScenes, setSelectedScenes] = useState([])
 
   const handleRequestSort = (event: React.MouseEvent<unknown>, property) => {
     const isAsc = orderBy === property && order === 'asc'
@@ -156,25 +157,15 @@ const Scenes = (props: Props) => {
     setSelected([])
   }
 
-  const handleChangePage = (event: unknown, newPage: number) => {
+  const handlePageChange = (event: unknown, newPage: number) => {
     const incDec = page < newPage ? 'increment' : 'decrement'
     fetchAdminScenes(incDec)
     setPage(newPage)
   }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setRowsPerPage(parseInt(event.target.value, 10))
     setPage(0)
-  }
-
-  const openAddToContentPackModal = (scene: any) => {
-    setSelectedScene(scene)
-    setAddToContentPackModalOpen(true)
-  }
-
-  const closeAddToContentPackModal = () => {
-    setAddToContentPackModalOpen(false)
-    setSelectedScene({})
   }
 
   const fetchTick = () => {
@@ -182,6 +173,14 @@ const Scenes = (props: Props) => {
       setRefetch(true)
       fetchTick()
     }, 5000)
+  }
+
+  const handleCheck = (e: any, row: any) => {
+    const existingSceneIndex = selectedScenes.findIndex((scene) => scene.id === row.id)
+    if (e.target.checked === true) {
+      if (existingSceneIndex >= 0) setSelectedScenes(selectedScenes.splice(existingSceneIndex, 1, row))
+      else setSelectedScenes(selectedScenes.concat(row))
+    } else setSelectedScenes(selectedScenes.splice(existingSceneIndex, 1))
   }
 
   useEffect(() => {
@@ -240,14 +239,12 @@ const Scenes = (props: Props) => {
                       </TableCell>
                       <TableCell className={styles.tcell} align="right">
                         {user.userRole === 'admin' && (
-                          <Button
-                            type="button"
-                            variant="contained"
+                          <Checkbox
+                            className={styles.checkbox}
+                            onChange={(e) => handleCheck(e, row)}
+                            name="stereoscopic"
                             color="primary"
-                            onClick={() => openAddToContentPackModal(row)}
-                          >
-                            Add to Content Pack
-                          </Button>
+                          />
                         )}
                       </TableCell>
                     </TableRow>
@@ -264,17 +261,26 @@ const Scenes = (props: Props) => {
             count={adminScenesCount}
             rowsPerPage={rowsPerPage}
             page={page}
-            onChangePage={handleChangePage}
-            onChangeRowsPerPage={handleChangeRowsPerPage}
+            onPageChange={handlePageChange}
+            onRowsPerPageChange={handleRowsPerPageChange}
             className={styles.tablePagination}
           />
         </div>
         <AddToContentPackModal
           open={addToContentPackModalOpen}
-          scene={selectedScene}
-          handleClose={closeAddToContentPackModal}
+          scenes={selectedScenes}
+          handleClose={() => setAddToContentPackModalOpen(false)}
         />
       </Paper>
+      <Button
+        className={styles['open-modal']}
+        type="button"
+        variant="contained"
+        color="primary"
+        onClick={() => setAddToContentPackModalOpen(true)}
+      >
+        Add to Content Pack
+      </Button>
     </div>
   )
 }

--- a/packages/client-core/src/admin/components/Users/UserTable.tsx
+++ b/packages/client-core/src/admin/components/Users/UserTable.tsx
@@ -43,11 +43,11 @@ const UserTable = (props: Props) => {
   const [userAdmin, setUserAdmin] = React.useState('')
   const user = authState.get('user')
   const adminUsers = adminUserState.get('users').get('users')
-  const handleChangePage = (event: unknown, newPage: number) => {
+  const handlePageChange = (event: unknown, newPage: number) => {
     setPage(newPage)
   }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setRowsPerPage(+event.target.value)
     setPage(0)
   }
@@ -183,8 +183,8 @@ const UserTable = (props: Props) => {
         count={count || 12}
         rowsPerPage={rowsPerPage}
         page={page}
-        onPageChange={handleChangePage}
-        onRowsPerPageChange={handleChangeRowsPerPage}
+        onPageChange={handlePageChange}
+        onRowsPerPageChange={handleRowsPerPageChange}
         className={classx.tableFooter}
       />
       <Dialog

--- a/packages/client-core/src/admin/components/index.tsx
+++ b/packages/client-core/src/admin/components/index.tsx
@@ -129,7 +129,7 @@ function EnhancedTableHead(props: EnhancedTableProps) {
             className={styles.tcell}
             key={headCell.id}
             align="center"
-            padding={headCell.disablePadding ? 'none' : 'default'}
+            padding={headCell.disablePadding ? 'none' : 'normal'}
             sortDirection={orderBy === headCell.id ? order : false}
           >
             <TableSortLabel
@@ -350,7 +350,7 @@ const AdminConsole = (props: Props) => {
     setInstanceModalOpen(true)
   }
 
-  const handleChangePage = (event: unknown, newPage: number) => {
+  const handlePageChange = (event: unknown, newPage: number) => {
     const incDec = page < newPage ? 'increment' : 'decrement'
     switch (selectedTab) {
       case 'locations':
@@ -366,7 +366,7 @@ const AdminConsole = (props: Props) => {
     setPage(newPage)
   }
 
-  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleRowsPerPageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setRowsPerPage(parseInt(event.target.value, 10))
     setPage(0)
   }
@@ -679,8 +679,8 @@ const AdminConsole = (props: Props) => {
             count={selectCount}
             rowsPerPage={rowsPerPage}
             page={page}
-            onChangePage={handleChangePage}
-            onChangeRowsPerPage={handleChangeRowsPerPage}
+            onPageChange={handlePageChange}
+            onRowsPerPageChange={handleRowsPerPageChange}
             className={styles.tablePagination}
           />
         </div>

--- a/packages/client-core/src/admin/reducers/admin/avatar/reducers.ts
+++ b/packages/client-core/src/admin/reducers/admin/avatar/reducers.ts
@@ -49,7 +49,6 @@ const adminReducer = (state = immutableState, action: any): any => {
       updateMap.set('fetched', true)
       updateMap.set('updateNeeded', false)
       updateMap.set('lastFetched', new Date())
-      console.log('updated avatars map', updateMap)
       return state.set('avatars', updateMap)
   }
 

--- a/packages/client-core/src/admin/reducers/contentPack/service.ts
+++ b/packages/client-core/src/admin/reducers/contentPack/service.ts
@@ -60,22 +60,16 @@ export function createContentPack(data: any) {
   }
 }
 
-export function addSceneToContentPack(data: any) {
+export function addScenesToContentPack(data: any) {
   return async (dispatch: Dispatch, getState: any) => {
     await client.service('content-pack').patch(null, data)
     dispatch(patchedContentPack())
   }
 }
 
-export function addAvatarToContentPack(data: any) {
+export function addAvatarsToContentPack(data: any) {
   return async (dispatch: Dispatch) => {
-    const result = await client.service('content-pack').patch(null, {
-      avatar: data.avatar,
-      thumbnail: data.thumbnail,
-      contentPack: data.contentPack
-    })
-    console.log('addAvatar result:')
-    console.log(result)
+    const result = await client.service('content-pack').patch(null, data)
     dispatch(patchedContentPack())
   }
 }

--- a/packages/client-core/src/user/components/UserMenu/menus/LocationMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/LocationMenu.tsx
@@ -52,7 +52,7 @@ const LocationMenu = ({ changeActiveLocation }) => {
       })
   }
 
-  const handleChangePage = (_, page) => {
+  const handlePageChange = (_, page) => {
     fetchLocations(page, ROWS_PER_PAGE)
     setPage(page)
   }
@@ -140,7 +140,7 @@ const LocationMenu = ({ changeActiveLocation }) => {
               rowsPerPage={ROWS_PER_PAGE}
               rowsPerPageOptions={[ROWS_PER_PAGE]}
               page={page}
-              onChangePage={handleChangePage}
+              onPageChange={handlePageChange}
               size="small"
               className={styles.tablePagination}
             />

--- a/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
@@ -158,7 +158,7 @@ const ProfileMenu = (props: Props): any => {
     if (changeActiveMenu != null) changeActiveMenu(null)
     else if (setProfileMenuOpen != null) setProfileMenuOpen(false)
     await logoutUser()
-    window.location.reload()
+    // window.location.reload()
   }
 
   const handleWalletLoginClick = async (e) => {

--- a/packages/client-core/src/user/reducers/auth/service.ts
+++ b/packages/client-core/src/user/reducers/auth/service.ts
@@ -55,7 +55,8 @@ export function doLoginAuto(allowGuest?: boolean, forceClientAuthReset?: boolean
   return async (dispatch: Dispatch): Promise<any> => {
     try {
       const authData = getStoredState('auth')
-      let accessToken = authData && authData.authUser ? authData.authUser.accessToken : undefined
+      let accessToken =
+        forceClientAuthReset !== true && authData && authData.authUser ? authData.authUser.accessToken : undefined
 
       if (allowGuest !== true && accessToken == null) {
         return

--- a/packages/server-core/src/entities/content-pack/content-pack-helper.ts
+++ b/packages/server-core/src/entities/content-pack/content-pack-helper.ts
@@ -15,11 +15,6 @@ const getAssetS3Key = (value: string) => value.replace('/assets', '')
 const getAvatarKey = (packName: string, key: string) => `content-pack/${packName}/${key}`
 const getAvatarThumbnailKey = (packName: string, key: string) => `content-pack/${packName}/${key}`
 
-const replaceRelativePath = (value: string) => {
-  const stripped = value.replace('/assets', '')
-  return `https://${config.aws.cloudfront.domain}${stripped}`
-}
-
 const getThumbnailKey = (value: string) => {
   const regexExec = thumbnailRegex.exec(value)
   return `${regexExec[0]}`
@@ -123,10 +118,12 @@ export function assembleScene(scene: any, contentPack: string): any {
 export async function populateScene(
   sceneId: string,
   scene: any,
+  manifestUrl: any,
   app: Application,
   thumbnailUrl?: string
 ): Promise<any> {
   const promises = []
+  const rootPackUrl = manifestUrl.replace('/manifest.json', '')
   const existingSceneResult = await (app.service('collection') as any).Model.findOne({
     where: {
       sid: sceneId
@@ -211,7 +208,7 @@ export async function populateScene(
     value.components.forEach(async (component) => {
       for (const [key, value] of Object.entries(component.props)) {
         if (typeof value === 'string' && /^\/assets/.test(value) === true) {
-          component.props[key] = replaceRelativePath(value)
+          component.props[key] = rootPackUrl + value
           // Insert Download/S3 upload
           const contentType = getContentType(component.props[key])
           const downloadResult = await axios.get(component.props[key], {

--- a/packages/server-core/src/entities/content-pack/content-pack.class.ts
+++ b/packages/server-core/src/entities/content-pack/content-pack.class.ts
@@ -103,7 +103,7 @@ export class ContentPack implements ServiceMethods<Data> {
     }
 
     let uploadPromises = []
-    const { scene, contentPack, avatar, thumbnail } = data as any
+    const { scenes, contentPack, avatars } = data as any
     await new Promise((resolve, reject) => {
       s3.provider.getObjectAcl(
         {
@@ -128,80 +128,97 @@ export class ContentPack implements ServiceMethods<Data> {
       avatars: [],
       scenes: []
     }
-    if (scene != null) {
-      const thumbnailFind = await this.app.service('static-resource').find({
-        query: {
-          sid: scene.sid
-        }
-      })
-
-      const assembleResponse = assembleScene(scene, contentPack)
-      const worldFile = assembleResponse.worldFile
-      uploadPromises = assembleResponse.uploadPromises
-      if (typeof worldFile.metadata === 'string') worldFile.metadata = JSON.parse(worldFile.metadata)
-      const worldFileKey = getWorldFileKey(contentPack, worldFile.metadata.name)
-      let thumbnailLink
-      if (thumbnailFind.total > 0) {
-        const thumbnail = thumbnailFind.data[0]
-        const url = thumbnail.url
-        const thumbnailDownload = await axios.get(url, { responseType: 'arraybuffer' })
-        await new Promise((resolve, reject) => {
-          s3.provider.putObject(
-            {
-              ACL: 'public-read',
-              Body: thumbnailDownload.data,
-              Bucket: s3.bucket,
-              ContentType: 'jpeg',
-              Key: getThumbnailKey(contentPack, url)
-            },
-            (err, data) => {
-              if (err) {
-                console.error(err)
-                reject(err)
-              } else {
-                resolve(data)
+    const promises = []
+    if (scenes != null) {
+      for (const scene of scenes) {
+        promises.push(
+          new Promise(async (resolve) => {
+            const thumbnailFind = await this.app.service('static-resource').find({
+              query: {
+                sid: scene.sid
               }
+            })
+
+            const assembleResponse = assembleScene(scene, contentPack)
+            const worldFile = assembleResponse.worldFile
+            uploadPromises = assembleResponse.uploadPromises
+            if (typeof worldFile.metadata === 'string') worldFile.metadata = JSON.parse(worldFile.metadata)
+            const worldFileKey = getWorldFileKey(contentPack, worldFile.metadata.name)
+            let thumbnailLink
+            if (thumbnailFind.total > 0) {
+              const thumbnail = thumbnailFind.data[0]
+              const url = thumbnail.url
+              const thumbnailDownload = await axios.get(url, { responseType: 'arraybuffer' })
+              await new Promise((resolve, reject) => {
+                s3.provider.putObject(
+                  {
+                    ACL: 'public-read',
+                    Body: thumbnailDownload.data,
+                    Bucket: s3.bucket,
+                    ContentType: 'jpeg',
+                    Key: getThumbnailKey(contentPack, url)
+                  },
+                  (err, data) => {
+                    if (err) {
+                      console.error(err)
+                      reject(err)
+                    } else {
+                      resolve(data)
+                    }
+                  }
+                )
+              })
+              thumbnailLink = getThumbnailUrl(contentPack, url)
             }
-          )
-        })
-        thumbnailLink = getThumbnailUrl(contentPack, url)
-      }
-      await new Promise((resolve, reject) => {
-        s3.provider.putObject(
-          {
-            ACL: 'public-read',
-            Body: Buffer.from(JSON.stringify(worldFile)),
-            Bucket: s3.bucket,
-            ContentType: 'application/json',
-            Key: worldFileKey
-          },
-          (err, data) => {
-            if (err) {
-              console.error(err)
-              reject(err)
-            } else {
-              resolve(data)
+            await new Promise((resolve, reject) => {
+              s3.provider.putObject(
+                {
+                  ACL: 'public-read',
+                  Body: Buffer.from(JSON.stringify(worldFile)),
+                  Bucket: s3.bucket,
+                  ContentType: 'application/json',
+                  Key: worldFileKey
+                },
+                (err, data) => {
+                  if (err) {
+                    console.error(err)
+                    reject(err)
+                  } else {
+                    resolve(data)
+                  }
+                }
+              )
+            })
+            const newScene = {
+              sid: scene.sid,
+              name: scene.name,
+              worldFile: getWorldFileUrl(contentPack, worldFile.metadata.name)
             }
-          }
+            if (thumbnailLink != null) (newScene as any).thumbnail = thumbnailLink
+            body.scenes.push(newScene)
+            resolve(true)
+          })
         )
-      })
-      const newScene = {
-        sid: scene.sid,
-        name: scene.name,
-        worldFile: getWorldFileUrl(contentPack, worldFile.metadata.name)
       }
-      if (thumbnailLink != null) (newScene as any).thumbnail = thumbnailLink
-      body.scenes.push(newScene)
-    } else if (avatar != null) {
-      await uploadAvatar(avatar, thumbnail, contentPack)
-      const newAvatar = {
-        name: avatar.name,
-        avatar: getAvatarUrl(contentPack, avatar),
-        thumbnail: getAvatarThumbnailUrl(contentPack, thumbnail)
+    } else if (avatars != null) {
+      for (const avatarItem of avatars) {
+        promises.push(
+          new Promise(async (resolve) => {
+            const { avatar, thumbnail } = avatarItem
+            await uploadAvatar(avatar, thumbnail, contentPack)
+            const newAvatar = {
+              name: avatar.name,
+              avatar: getAvatarUrl(contentPack, avatar),
+              thumbnail: getAvatarThumbnailUrl(contentPack, thumbnail)
+            }
+            body.avatars.push(newAvatar)
+            resolve(true)
+          })
+        )
       }
-      body.avatars.push(newAvatar)
     }
 
+    await Promise.all(promises)
     await new Promise((resolve, reject) => {
       s3.provider.putObject(
         {
@@ -233,7 +250,7 @@ export class ContentPack implements ServiceMethods<Data> {
     for (const index in scenes) {
       const scene = scenes[index]
       const sceneResult = await axios.get(scene.worldFile)
-      promises.push(populateScene(scene.sid, sceneResult.data, this.app, scene.thumbnail))
+      promises.push(populateScene(scene.sid, sceneResult.data, manifestUrl, this.app, scene.thumbnail))
     }
     for (const index in avatars) promises.push(populateAvatar(avatars[index], this.app))
     await Promise.all(promises)
@@ -242,7 +259,7 @@ export class ContentPack implements ServiceMethods<Data> {
 
   async patch(id: NullableId, data: Data, params?: Params): Promise<Data> {
     let uploadPromises = []
-    const { scene, contentPack, avatar, thumbnail } = data as any
+    const { scenes, contentPack, avatars } = data as any
     const pack = await new Promise((resolve, reject) => {
       s3.provider.getObject(
         {
@@ -263,86 +280,103 @@ export class ContentPack implements ServiceMethods<Data> {
     })
     const body = JSON.parse((pack as any).Body.toString())
     const invalidationItems = [`/content-pack/${contentPack}/manifest.json`]
-    if (scene != null) {
-      const thumbnailFind = await this.app.service('static-resource').find({
-        query: {
-          sid: scene.sid
-        }
-      })
-
-      const assembleResponse = assembleScene(scene, contentPack)
-      const worldFile = assembleResponse.worldFile
-      uploadPromises = assembleResponse.uploadPromises
-      if (typeof worldFile.metadata === 'string') worldFile.metadata = JSON.parse(worldFile.metadata)
-      const worldFileKey = getWorldFileKey(contentPack, worldFile.metadata.name)
-      invalidationItems.push(`/${worldFileKey}`)
-      let thumbnailLink
-      if (thumbnailFind.total > 0) {
-        const thumbnail = thumbnailFind.data[0]
-        const url = thumbnail.url
-        const thumbnailDownload = await axios.get(url, { responseType: 'arraybuffer' })
-        const thumbnailKey = getThumbnailKey(contentPack, url)
-        await new Promise((resolve, reject) => {
-          s3.provider.putObject(
-            {
-              ACL: 'public-read',
-              Body: thumbnailDownload.data,
-              Bucket: s3.bucket,
-              ContentType: 'jpeg',
-              Key: thumbnailKey
-            },
-            (err, data) => {
-              if (err) {
-                console.error(err)
-                reject(err)
-              } else {
-                resolve(data)
+    const promises = []
+    if (scenes != null) {
+      for (const scene of scenes) {
+        promises.push(
+          new Promise(async (resolve) => {
+            const thumbnailFind = await this.app.service('static-resource').find({
+              query: {
+                sid: scene.sid
               }
+            })
+
+            const assembleResponse = assembleScene(scene, contentPack)
+            const worldFile = assembleResponse.worldFile
+            uploadPromises = assembleResponse.uploadPromises
+            if (typeof worldFile.metadata === 'string') worldFile.metadata = JSON.parse(worldFile.metadata)
+            const worldFileKey = getWorldFileKey(contentPack, worldFile.metadata.name)
+            invalidationItems.push(`/${worldFileKey}`)
+            let thumbnailLink
+            if (thumbnailFind.total > 0) {
+              const thumbnail = thumbnailFind.data[0]
+              const url = thumbnail.url
+              const thumbnailDownload = await axios.get(url, { responseType: 'arraybuffer' })
+              const thumbnailKey = getThumbnailKey(contentPack, url)
+              await new Promise((resolve, reject) => {
+                s3.provider.putObject(
+                  {
+                    ACL: 'public-read',
+                    Body: thumbnailDownload.data,
+                    Bucket: s3.bucket,
+                    ContentType: 'jpeg',
+                    Key: thumbnailKey
+                  },
+                  (err, data) => {
+                    if (err) {
+                      console.error(err)
+                      reject(err)
+                    } else {
+                      resolve(data)
+                    }
+                  }
+                )
+              })
+              thumbnailLink = getThumbnailUrl(contentPack, url)
+              invalidationItems.push(`/${thumbnailKey}`)
             }
-          )
-        })
-        thumbnailLink = getThumbnailUrl(contentPack, url)
-        invalidationItems.push(`/${thumbnailKey}`)
-      }
-      await new Promise((resolve, reject) => {
-        s3.provider.putObject(
-          {
-            ACL: 'public-read',
-            Body: Buffer.from(JSON.stringify(worldFile)),
-            Bucket: s3.bucket,
-            ContentType: 'application/json',
-            Key: worldFileKey
-          },
-          (err, data) => {
-            if (err) {
-              console.error(err)
-              reject(err)
-            } else {
-              resolve(data)
+            await new Promise((resolve, reject) => {
+              s3.provider.putObject(
+                {
+                  ACL: 'public-read',
+                  Body: Buffer.from(JSON.stringify(worldFile)),
+                  Bucket: s3.bucket,
+                  ContentType: 'application/json',
+                  Key: worldFileKey
+                },
+                (err, data) => {
+                  if (err) {
+                    console.error(err)
+                    reject(err)
+                  } else {
+                    resolve(data)
+                  }
+                }
+              )
+            })
+            body.scenes = body.scenes.filter((existingScene) => existingScene.sid !== scene.sid)
+            const newScene = {
+              sid: scene.sid,
+              name: scene.name,
+              worldFile: getWorldFileUrl(contentPack, worldFile.metadata.name)
             }
-          }
+            if (thumbnailLink != null) (newScene as any).thumbnail = thumbnailLink
+            body.scenes.push(newScene)
+            resolve(true)
+          })
         )
-      })
-      body.scenes = body.scenes.filter((existingScene) => existingScene.sid !== scene.sid)
-      const newScene = {
-        sid: scene.sid,
-        name: scene.name,
-        worldFile: getWorldFileUrl(contentPack, worldFile.metadata.name)
       }
-      if (thumbnailLink != null) (newScene as any).thumbnail = thumbnailLink
-      body.scenes.push(newScene)
-    } else if (avatar != null) {
-      await uploadAvatar(avatar, thumbnail, contentPack)
-      body.avatars = body.avatars.filter((existingAvatar) => existingAvatar.name !== avatar.name)
-      const newAvatar = {
-        name: avatar.name,
-        avatar: getAvatarUrl(contentPack, avatar),
-        thumbnail: getAvatarThumbnailUrl(contentPack, thumbnail)
+    } else if (avatars != null) {
+      for (const avatarItem of avatars) {
+        promises.push(
+          new Promise(async (resolve) => {
+            const { avatar, thumbnail } = avatarItem
+            await uploadAvatar(avatar, thumbnail, contentPack)
+            body.avatars = body.avatars.filter((existingAvatar) => existingAvatar.name !== avatar.name)
+            const newAvatar = {
+              name: avatar.name,
+              avatar: getAvatarUrl(contentPack, avatar),
+              thumbnail: getAvatarThumbnailUrl(contentPack, thumbnail)
+            }
+            invalidationItems.push(`/content-pack/${contentPack}/avatars/${avatar.name}.*`)
+            body.avatars.push(newAvatar)
+            resolve(true)
+          })
+        )
       }
-      invalidationItems.push(`/content-pack/${contentPack}/avatars/${avatar.name}.*`)
-      body.avatars.push(newAvatar)
     }
 
+    await Promise.all(promises)
     if (body.version) body.version++
     else body.version = 1
     await new Promise((resolve, reject) => {

--- a/packages/server-core/src/hooks/add-file-id.ts
+++ b/packages/server-core/src/hooks/add-file-id.ts
@@ -9,7 +9,8 @@ export default () => {
           sid: context.params.body.projectId
         }
       })
-      context.params.previousFileId = JSON.parse(ownedFileIds)[fileIdentifier]
+      const parsedOwnedFileIds = JSON.parse(ownedFileIds)
+      context.params.previousFileId = parsedOwnedFileIds != null ? parsedOwnedFileIds[fileIdentifier] : null
     }
     return context
   }

--- a/packages/server-core/src/media/static-resource/static-resource.seed.ts
+++ b/packages/server-core/src/media/static-resource/static-resource.seed.ts
@@ -27,7 +27,7 @@ export const staticResourceSeed = {
       sid: 'j9o2NLiD',
       name: null,
       description: null,
-      url: 'https://resources.theoverlay.io/19176bb0-24e8-11eb-8630-81b209daf73a.jpeg',
+      url: 'https://resources.theoverlay.io/c4efdc80-c9f0-11eb-b166-5b4d0f7861e6.jpeg',
       key: 'd0828450-24e4-11eb-8630-81b209daf73a.jpeg',
       mimeType: 'image/jpeg',
       metadata: null,

--- a/packages/server-core/src/user/identity-provider/identity-provider.class.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.class.ts
@@ -135,13 +135,18 @@ export class IdentityProvider extends Service {
 
     const code = await getFreeInviteCode(this.app)
     // if there is no user with userId, then we create a user and a identity provider.
+    const adminCount = await (this.app.service('user') as any).Model.count({
+      where: {
+        userRole: 'admin'
+      }
+    })
     const result = await super.create(
       {
         ...data,
         ...identityProvider,
         user: {
           id: userId,
-          userRole: type === 'guest' ? 'guest' : type === 'admin' ? 'admin' : 'user',
+          userRole: type === 'guest' ? 'guest' : type === 'admin' || adminCount === 0 ? 'admin' : 'user',
           inviteCode: type === 'guest' ? null : code,
           avatarId: DEFAULT_AVATARS[random(DEFAULT_AVATARS.length - 1)]
         }

--- a/packages/server-core/src/user/strategies/facebook.ts
+++ b/packages/server-core/src/user/strategies/facebook.ts
@@ -26,8 +26,13 @@ export class FacebookStrategy extends CustomOAuthStrategy {
     )
     const identityProvider = authResult['identity-provider']
     const user = await this.app.service('user').get(entity.userId)
+    const adminCount = await (this.app.service('user') as any).Model.count({
+      where: {
+        userRole: 'admin'
+      }
+    })
     await this.app.service('user').patch(entity.userId, {
-      userRole: user?.userRole === 'admin' ? 'admin' : 'user'
+      userRole: user?.userRole === 'admin' || adminCount === 0 ? 'admin' : 'user'
     })
     if (entity.type !== 'guest') {
       await this.app.service('identity-provider').remove(identityProvider.id)

--- a/packages/server-core/src/user/strategies/google.ts
+++ b/packages/server-core/src/user/strategies/google.ts
@@ -25,8 +25,13 @@ export class Googlestrategy extends CustomOAuthStrategy {
     )
     const identityProvider = authResult['identity-provider']
     const user = await this.app.service('user').get(entity.userId)
+    const adminCount = await (this.app.service('user') as any).Model.count({
+      where: {
+        userRole: 'admin'
+      }
+    })
     await this.app.service('user').patch(entity.userId, {
-      userRole: user?.userRole === 'admin' ? 'admin' : 'user'
+      userRole: user?.userRole === 'admin' || adminCount === 0 ? 'admin' : 'user'
     })
     if (entity.type !== 'guest') {
       await this.app.service('identity-provider').remove(identityProvider.id)

--- a/packages/server-core/src/user/strategies/linkedin.ts
+++ b/packages/server-core/src/user/strategies/linkedin.ts
@@ -27,8 +27,13 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
     )
     const identityProvider = authResult['identity-provider']
     const user = await this.app.service('user').get(entity.userId)
+    const adminCount = await (this.app.service('user') as any).Model.count({
+      where: {
+        userRole: 'admin'
+      }
+    })
     await this.app.service('user').patch(entity.userId, {
-      userRole: user?.userRole === 'admin' ? 'admin' : 'user'
+      userRole: user?.userRole === 'admin' || adminCount === 0 ? 'admin' : 'user'
     })
     if (entity.type !== 'guest') {
       await this.app.service('identity-provider').remove(identityProvider.id)

--- a/packages/server-core/src/user/strategies/twitter.ts
+++ b/packages/server-core/src/user/strategies/twitter.ts
@@ -27,8 +27,13 @@ export class TwitterStrategy extends CustomOAuthStrategy {
     )
     const identityProvider = authResult['identity-provider']
     const user = await this.app.service('user').get(entity.userId)
+    const adminCount = await (this.app.service('user') as any).Model.count({
+      where: {
+        userRole: 'admin'
+      }
+    })
     await this.app.service('user').patch(entity.userId, {
-      userRole: user?.userRole === 'admin' ? 'admin' : 'user'
+      userRole: user?.userRole === 'admin' || adminCount === 0 ? 'admin' : 'user'
     })
     if (entity.type !== 'guest') {
       await this.app.service('identity-provider').remove(identityProvider.id)


### PR DESCRIPTION
Updated process of adding avatars and scenes to content packs so
that multiple ones can be added at once.

Made it so that the first non-guest user to sign in is an admin.

Fixed a bug in add-file-id where a null value for ownedFileIds was failing
due to trying to read a value of null.

Downloading scenes was using the configured S3 bucket for component
URLs instead of the URL of the content-pack. This has been fixed by getting the
URL from the manifest URL.

Updated doLoginAuto so that forceClientAuthReset will skip using the old accessToken,
thus making logout actually work.

Changed a bunch of 'onChangePage' and 'onChangeRowsPerPage' to 'onPageChange' and
'onRowsPerPageChange' since warnings were being thrown about the former being deprecated
for the latter.