### PR TITLE
Fixed bug in set-loggedin-user-in-query.ts

### DIFF
--- a/packages/server-core/src/hooks/party-user-permission-authenticate.ts
+++ b/packages/server-core/src/hooks/party-user-permission-authenticate.ts
@@ -1,12 +1,12 @@
 import { HookContext } from '@feathersjs/feathers'
 import { extractLoggedInUserFromParams } from '../user/auth-management/auth-management.utils'
-import { BadRequest, Forbidden } from '@feathersjs/errors'
+import { BadRequest } from '@feathersjs/errors'
 import _ from 'lodash'
 
 // This will attach the owner ID in the contact while creating/updating list item
 export default () => {
   return async (context: HookContext): Promise<any> => {
-    const { id, params, app } = context
+    const { params, app } = context
     const loggedInUser = extractLoggedInUserFromParams(params)
     const partyId = params.query.partyId
     const userId = params.query.userId || loggedInUser.userId
@@ -24,7 +24,6 @@ export default () => {
       )
       if (partyUserResult.total === 0) {
         console.log('INVALID PARTY ID')
-        console.log(params)
         throw new BadRequest('Invalid party ID in party-user-permission')
       }
     }

--- a/packages/server-core/src/hooks/set-loggedin-user-in-query.ts
+++ b/packages/server-core/src/hooks/set-loggedin-user-in-query.ts
@@ -9,7 +9,7 @@ export default (propertyName: string) => {
     const loggedInUser = extractLoggedInUserFromParams(context.params)
     context.params.query = {
       ...context.params.query,
-      [propertyName]: loggedInUser?.userId || 'userId'
+      [propertyName]: loggedInUser?.userId || null
     }
 
     return context

--- a/packages/server-core/src/networking/instance/instance.class.ts
+++ b/packages/server-core/src/networking/instance/instance.class.ts
@@ -26,13 +26,9 @@ export class Instance extends Service {
     const skip = params.query?.$skip ? params.query.$skip : 0
     const limit = params.query?.$limit ? params.query.$limit : 10
 
-    console.log(action)
-
     if (action === 'admin') {
-      const loggedInUser = extractLoggedInUserFromParams(params)
-      console.log(loggedInUser)
-
       //TODO: uncomment here
+      // const loggedInUser = extractLoggedInUserFromParams(params)
       // const user = await super.get(loggedInUser.userId);
       // console.log(user);
       // if (user.userRole !== 'admin') throw new Forbidden ('Must be system admin to execute this action');

--- a/packages/server-core/src/social/group-user/group-user.hooks.ts
+++ b/packages/server-core/src/social/group-user/group-user.hooks.ts
@@ -63,8 +63,6 @@ export default {
     remove: [
       async (context: HookContext): Promise<HookContext> => {
         const { app, params, result } = context
-        console.log('Group user removal result:')
-        console.log(result)
         const user = await app.service('user').get(result.userId)
         await app.service('message').create({
           targetObjectId: result.groupId,

--- a/packages/server-core/src/social/location-ban/location-ban.service.ts
+++ b/packages/server-core/src/social/location-ban/location-ban.service.ts
@@ -48,8 +48,6 @@ export default function (app: Application): void {
           userId: user.id
         }
       })
-      console.log('Banned party-user')
-      console.log(partyUser)
       if (partyUser.total > 0) {
         const { query, ...paramsCopy } = params as any
         paramsCopy.skipAuth = true

--- a/packages/server-core/src/user/identity-provider/identity-provider.class.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.class.ts
@@ -7,10 +7,6 @@ import { random } from 'lodash'
 import getFreeInviteCode from '../../util/get-free-invite-code'
 import { AuthenticationService } from '@feathersjs/authentication'
 
-interface Data {
-  userId: string
-}
-
 /**
  * A class for identity-provider service
  *
@@ -163,7 +159,6 @@ export class IdentityProvider extends Service {
       // this.app.service('authentication')
       result.accessToken = await authService.createAccessToken({}, { subject: result.id.toString() })
     }
-    console.log(result)
     return result
   }
 }

--- a/packages/server-core/src/world/project/generate-collection.hook.ts
+++ b/packages/server-core/src/world/project/generate-collection.hook.ts
@@ -26,8 +26,6 @@ export default (options: any) => {
     // After creating of project, remove the owned_file of project json
 
     // Find the project owned_file from database
-    console.log(context.data)
-
     const ownedFile = await StaticResourceModel.findOne({
       where: {
         id: context.data.ownedFileId

--- a/packages/server-core/src/world/publish-project/publish-project.class.ts
+++ b/packages/server-core/src/world/publish-project/publish-project.class.ts
@@ -63,7 +63,6 @@ export class PublishProject implements ServiceMethods<Data> {
   async create(data: any, params: Params): Promise<Data> {
     const CollectionModel = (this.app.service('collection') as any).Model
     const projectId = params?.query?.projectId
-    console.log(params?.query)
 
     // const loggedInUser = extractLoggedInUserFromParams(params)
     const provider = new StorageProvider()


### PR DESCRIPTION
set-loggedin-user-in-query.ts was using default propertyName value of 'userId'.
This will cause failures all the time since nothing has a userId of 'userId'.
Switched default value to null, which will produce desired behavior.

Removed a number of unneeded console.log's.