### PR TITLE
Fixed some issues with editor.

### DIFF
--- a/packages/client-core/src/world/components/editor/EditorContainer.tsx
+++ b/packages/client-core/src/world/components/editor/EditorContainer.tsx
@@ -223,7 +223,8 @@ class EditorContainer extends Component<EditorContainerProps, EditorContainerSta
       this.setState({
         queryParams
       })
-      const projectId = queryParams.get('projectId')
+      const pathParams = this.state.pathParams
+      const projectId = pathParams.get('projectId')
       let templateUrl = null
 
       if (projectId === 'new' && !queryParams.has('sceneId')) {
@@ -626,11 +627,14 @@ class EditorContainer extends Component<EditorContainerProps, EditorContainerSta
     await new Promise((resolve) => setTimeout(resolve, 5))
     try {
       const editor = this.state.editor
-      await this.createProject()
+      const newProject = await this.createProject()
       editor.sceneModified = false
       this.updateModifiedState()
 
       this.hideDialog()
+      const pathParams = this.state.pathParams
+      pathParams.set('projectId', newProject.project_id)
+      this.setState({ pathParams: pathParams })
     } catch (error) {
       console.error(error)
 
@@ -778,6 +782,9 @@ class EditorContainer extends Component<EditorContainerProps, EditorContainerSta
         )
 
         this.setState({ project: newProject })
+        const pathParams = this.state.pathParams
+        pathParams.set('projectId', newProject.project_id)
+        this.setState({ pathParams: pathParams })
       } else {
         await this.createProject()
       }

--- a/packages/engine/src/editor/nodes/SceneNode.ts
+++ b/packages/engine/src/editor/nodes/SceneNode.ts
@@ -441,7 +441,7 @@ export default class SceneNode extends EditorNodeMixin(Scene) {
     const sceneJson = {
       version: 4,
       root: this.uuid,
-      metadata: JSON.parse(JSON.stringify(this.metadata)),
+      metadata: this.parseMetadataToObject(this.metadata),
       entities: {
         [this.uuid]: {
           name: this.name,
@@ -633,6 +633,9 @@ export default class SceneNode extends EditorNodeMixin(Scene) {
   }
   setMetadata(newMetadata) {
     const existingMetadata = this.metadata || {}
-    this.metadata = Object.assign(existingMetadata, newMetadata)
+    this.metadata = Object.assign(this.parseMetadataToObject(existingMetadata), newMetadata)
+  }
+  parseMetadataToObject(metadata) {
+    return typeof metadata === 'string' ? this.parseMetadataToObject(JSON.parse(metadata)) : metadata
   }
 }

--- a/packages/engine/src/map/index.ts
+++ b/packages/engine/src/map/index.ts
@@ -14,8 +14,8 @@ export const addMap = async function (scene: THREE.Scene, renderer: THREE.WebGLR
     const center = [parseFloat(args.startLongitude) || -84.388, parseFloat(args.startLatitude) || 33.749]
     const features = await fetchTiles(center)
     const mesh = buildMesh(features, center, renderer)
-    mesh.position.multiplyScalar(args.scale ? args.scale.x : .1)
-    mesh.scale.multiplyScalar(args.scale ? args.scale.x : .1)
+    mesh.position.multiplyScalar(args.scale ? args.scale.x : 0.1)
+    mesh.scale.multiplyScalar(args.scale ? args.scale.x : 0.1)
 
     scene.add(mesh)
   } else {

--- a/packages/engine/src/map/types.ts
+++ b/packages/engine/src/map/types.ts
@@ -1,2 +1,1 @@
-
 export type ILayerName = 'building' | 'road'

--- a/packages/engine/src/scene/behaviors/loadGLTFModel.ts
+++ b/packages/engine/src/scene/behaviors/loadGLTFModel.ts
@@ -36,7 +36,7 @@ export const loadGLTFModel = (
             console.log('generate navmesh')
             let polygons = []
             res.traverse((child) => {
-              child.visible = false;
+              child.visible = false
               if (typeof child.geometry !== 'undefined' && child.geometry instanceof BufferGeometry) {
                 const childPolygons = parseGeometry({
                   position: child.geometry.attributes.position.array,


### PR DESCRIPTION
EditorContainer was trying to get the projectId from queryParams, but it's not in a query param, but
rather the end of the path. It also wasn't updating its own copy of state.pathParams when the projectId
changed after duplicating a scene (and possibly also updating the current scene).

There was also a bug where the metadata of a scene was being continually re-JSON.stringified, leading
to increasingly long stringified metadata. Made SceneNode.ts parse metadata down to an object and saved
in that format.