### PR TITLE
Fixed a bug with feathers channels and separated client media streams.

### DIFF
--- a/packages/client/src/components/MediaIconsBox/index.tsx
+++ b/packages/client/src/components/MediaIconsBox/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Mic, MicOff, Videocam, VideocamOff } from '@material-ui/icons'
 import FaceIcon from '@material-ui/icons/Face'
 import { connect } from 'react-redux'
@@ -47,6 +47,8 @@ const mapDispatchToProps = (dispatch): any => ({
 const MediaIconsBox = (props) => {
   const { authState, locationState, mediastream, changeFaceTrackingState } = props
   const [xrSupported, setXRSupported] = useState(false)
+  const [hasAudioDevice, setHasAudioDevice] = useState(false)
+  const [hasVideoDevice, setHasVideoDevice] = useState(false)
 
   const user = authState.get('user')
   const currentLocation = locationState.get('currentLocation').get('location')
@@ -60,19 +62,27 @@ const MediaIconsBox = (props) => {
   const isCamVideoEnabled = mediastream.get('isCamVideoEnabled')
   const isCamAudioEnabled = mediastream.get('isCamAudioEnabled')
 
+  useEffect(() => {
+    navigator.mediaDevices
+      .enumerateDevices()
+      .then((devices) => {
+        devices.forEach((device) => {
+          if (device.kind === 'audioinput') setHasAudioDevice(true)
+          if (device.kind === 'videoinput') setHasVideoDevice(true)
+        })
+      })
+      .catch((err) => console.log('could not get media devices', err))
+  }, [])
+
   const onEngineLoaded = () => {
     EngineEvents.instance.once(EngineEvents.EVENTS.JOINED_WORLD, () => setXRSupported(Engine.xrSupported))
     document.removeEventListener('ENGINE_LOADED', onEngineLoaded)
   }
   document.addEventListener('ENGINE_LOADED', onEngineLoaded)
 
-  const checkMediaStream = async (partyId: string): Promise<boolean> => {
-    return await configureMediaTransports(partyId)
-  }
-
   const handleFaceClick = async () => {
     const partyId = currentLocation?.locationSettings?.instanceMediaChatEnabled === true ? 'instance' : user.partyId
-    if (await checkMediaStream(partyId)) {
+    if (await configureMediaTransports(['video', 'audio'], partyId)) {
       changeFaceTrackingState(!isFaceTrackingEnabled)
       if (!isFaceTrackingEnabled) {
         startFaceTracking()
@@ -95,7 +105,7 @@ const MediaIconsBox = (props) => {
   }
   const handleMicClick = async () => {
     const partyId = currentLocation?.locationSettings?.instanceMediaChatEnabled === true ? 'instance' : user.partyId
-    if (await checkMediaStream(partyId)) {
+    if (await configureMediaTransports(['audio'], partyId)) {
       if (MediaStreams.instance?.camAudioProducer == null) await createCamAudioProducer(partyId)
       else {
         const audioPaused = MediaStreams.instance.toggleAudioPaused()
@@ -109,7 +119,7 @@ const MediaIconsBox = (props) => {
 
   const handleCamClick = async () => {
     const partyId = currentLocation?.locationSettings?.instanceMediaChatEnabled === true ? 'instance' : user.partyId
-    if (await checkMediaStream(partyId)) {
+    if (await configureMediaTransports(['video'], partyId)) {
       if (MediaStreams.instance?.camVideoProducer == null) await createCamVideoProducer(partyId)
       else {
         const videoPaused = MediaStreams.instance.toggleVideoPaused()
@@ -130,7 +140,7 @@ const MediaIconsBox = (props) => {
 
   return (
     <section className={styles.drawerBox}>
-      {instanceMediaChatEnabled ? (
+      {instanceMediaChatEnabled && hasAudioDevice ? (
         <button
           type="button"
           id="UserAudio"
@@ -140,7 +150,7 @@ const MediaIconsBox = (props) => {
           <MicIcon />
         </button>
       ) : null}
-      {videoEnabled ? (
+      {videoEnabled && hasVideoDevice ? (
         <>
           <button
             type="button"

--- a/packages/client/src/components/VideoChat/index.tsx
+++ b/packages/client/src/components/VideoChat/index.tsx
@@ -30,8 +30,9 @@ const VideoChat = (props: Props) => {
   const user = authState.get('user')
   const currentLocation = locationState.get('currentLocation').get('location')
   const gsProvision = async () => {
-    if (mediaStreamSystem.mediaStream == null) {
+    if (mediaStreamSystem.videoStream == null) {
       await configureMediaTransports(
+        ['video', 'audio'],
         currentLocation?.locationSettings?.instanceMediaChatEnabled === true ? 'instance' : user.partyId
       )
       console.log('Send camera streams called from gsProvision')
@@ -41,8 +42,8 @@ const VideoChat = (props: Props) => {
   }
   return (
     <Fab color="primary" aria-label="VideoChat" onClick={gsProvision}>
-      {mediaStreamSystem.mediaStream == null && <VideoCall />}
-      {mediaStreamSystem.mediaStream != null && <CallEnd />}
+      {mediaStreamSystem.videoStream == null && <VideoCall />}
+      {mediaStreamSystem.videoStream != null && <CallEnd />}
     </Fab>
   )
 }

--- a/packages/client/src/pages/map/MapMediaIconsBox.tsx
+++ b/packages/client/src/pages/map/MapMediaIconsBox.tsx
@@ -4,7 +4,7 @@ import { selectLocationState } from '@xrengine/client-core/src/social/reducers/l
 import { selectAuthState } from '@xrengine/client-core/src/user/reducers/auth/selector'
 import { Network } from '@xrengine/engine/src/networking/classes/Network'
 import { MediaStreams } from '@xrengine/engine/src/networking/systems/MediaStreamSystem'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { changeFaceTrackingState, updateCamAudioState, updateCamVideoState } from '../../reducers/mediastream/service'
@@ -35,6 +35,8 @@ const mapDispatchToProps = (dispatch): any => ({
 
 const MediaIconsBox = (props) => {
   const { authState, locationState, mediastream } = props
+  const [hasAudioDevice, setHasAudioDevice] = useState(false)
+  const [hasVideoDevice, setHasVideoDevice] = useState(false)
 
   const user = authState.get('user')
   const currentLocation = locationState.get('currentLocation').get('location')
@@ -47,14 +49,22 @@ const MediaIconsBox = (props) => {
   const isCamVideoEnabled = mediastream.get('isCamVideoEnabled')
   const isCamAudioEnabled = mediastream.get('isCamAudioEnabled')
 
+  useEffect(() => {
+    navigator.mediaDevices
+      .enumerateDevices()
+      .then((devices) => {
+        devices.forEach((device) => {
+          if (device.kind === 'audioinput') setHasAudioDevice(true)
+          if (device.kind === 'videoinput') setHasVideoDevice(true)
+        })
+      })
+      .catch((err) => console.log('could not get media devices', err))
+  }, [])
+
   const onEngineLoaded = () => {
     document.removeEventListener('ENGINE_LOADED', onEngineLoaded)
   }
   document.addEventListener('ENGINE_LOADED', onEngineLoaded)
-
-  const checkMediaStream = async (partyId: string): Promise<boolean> => {
-    return await configureMediaTransports(partyId)
-  }
 
   const checkEndVideoChat = async () => {
     if (
@@ -67,7 +77,7 @@ const MediaIconsBox = (props) => {
   }
   const handleMicClick = async () => {
     const partyId = currentLocation?.locationSettings?.instanceMediaChatEnabled === true ? 'instance' : user.partyId
-    if (await checkMediaStream(partyId)) {
+    if (await configureMediaTransports(['audio'], partyId)) {
       if (MediaStreams.instance?.camAudioProducer == null) await createCamAudioProducer(partyId)
       else {
         const audioPaused = MediaStreams.instance.toggleAudioPaused()
@@ -81,7 +91,7 @@ const MediaIconsBox = (props) => {
 
   const handleCamClick = async () => {
     const partyId = currentLocation?.locationSettings?.instanceMediaChatEnabled === true ? 'instance' : user.partyId
-    if (await checkMediaStream(partyId)) {
+    if (await configureMediaTransports(['video'], partyId)) {
       if (MediaStreams.instance?.camVideoProducer == null) await createCamVideoProducer(partyId)
       else {
         const videoPaused = MediaStreams.instance.toggleVideoPaused()
@@ -99,7 +109,7 @@ const MediaIconsBox = (props) => {
 
   return (
     <section className={styles.drawerBox}>
-      {instanceMediaChatEnabled ? (
+      {instanceMediaChatEnabled && hasAudioDevice ? (
         <button
           type="button"
           id="UserAudio"
@@ -109,7 +119,7 @@ const MediaIconsBox = (props) => {
           <MicIcon />
         </button>
       ) : null}
-      {videoEnabled ? (
+      {videoEnabled && hasVideoDevice ? (
         <>
           <button
             type="button"

--- a/packages/client/src/transports/SocketWebRTCClientTransport.ts
+++ b/packages/client/src/transports/SocketWebRTCClientTransport.ts
@@ -276,7 +276,6 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
             MediaStreams.instance?.camAudioProducer?.id
           ]
           if (
-            // (MediaStreamSystem.mediaStream !== null) &&
             producerId != null &&
             channelType === self.channelType &&
             selfProducerIds.indexOf(producerId) < 0

--- a/packages/engine/src/input/behaviors/WebcamInputBehaviors.ts
+++ b/packages/engine/src/input/behaviors/WebcamInputBehaviors.ts
@@ -55,7 +55,7 @@ export const startFaceTracking = async () => {
     faceTrackingTimers.push(interval)
   })
 
-  faceVideo.srcObject = MediaStreams.instance.mediaStream
+  faceVideo.srcObject = MediaStreams.instance.videoStream
   faceVideo.muted = true
   faceVideo.play()
 }
@@ -119,7 +119,7 @@ export const startLipsyncTracking = () => {
   userSpeechAnalyzer.smoothingTimeConstant = 0.5
   userSpeechAnalyzer.fftSize = FFT_SIZE
 
-  const inputStream = audioContext.createMediaStreamSource(MediaStreams.instance.mediaStream)
+  const inputStream = audioContext.createMediaStreamSource(MediaStreams.instance.audioStream)
   inputStream.connect(userSpeechAnalyzer)
 
   const audioProcessor = audioContext.createScriptProcessor(FFT_SIZE * 2, 1, 1)

--- a/packages/engine/src/networking/constants/VideoConstants.ts
+++ b/packages/engine/src/networking/constants/VideoConstants.ts
@@ -7,8 +7,11 @@ export const VIDEO_CONSTRAINTS = {
 }
 
 /** localMediaConstraints is passed to the getUserMedia object to request a lower video quality than the maximum. */
-export const localMediaConstraints = {
-  audio: true,
+export const localAudioConstraints = {
+  audio: true
+}
+
+export const localVideoConstraints = {
   video: {
     width: VIDEO_CONSTRAINTS.hd.width,
     height: VIDEO_CONSTRAINTS.hd.height,

--- a/packages/server/src/channels.ts
+++ b/packages/server/src/channels.ts
@@ -8,10 +8,12 @@ export default (app: Application): void => {
   }
 
   app.on('login', (authResult: any, { connection }: any) => {
-    if (connection) app.channel(`userIds/${connection['identity-provider']?.userId as string}`).join(connection)
+    const identityProvider = authResult['identity-provider'] || connection['identity-provider']
+    if (identityProvider) app.channel(`userIds/${identityProvider.userId as string}`).join(connection)
   })
 
   app.on('logout', (authResult: any, { connection }: any) => {
-    if (connection) app.channel(`userIds/${connection['identity-provider']?.userId as string}`).leave(connection)
+    const identityProvider = authResult['identity-provider'] || connection['identity-provider']
+    if (identityProvider) app.channel(`userIds/${identityProvider.userId as string}`).leave(connection)
   })
 }


### PR DESCRIPTION
In server/src/channels.ts, the identity-provider was not always showing up on the connection input.
This was causing users to not subscribe to their own feathers channel, and weren't getting any updates.
Since the identity-provider was appearing on the authResult, made identityProvider sourced from either
input.

Testing uncovered that mic-only devices couldn't start their media streams since the codebase was always
requesting both audio and video, and the MediaDevices API will reject a request if one requested device
is not present. In MediaStreamSystem.ts, made separate videoStream and audioStream properties to replace
mediaStream property. Associated functionality now only deals with the device/stream that it needs, i.e.
audio functionality deals only with audioStream. Semi-duplicated some functions so that there are separate
handlers for audio and video.

Updated A/V control buttons so that each is only displayed if there's a device to capture that stream.