### PR TITLE
Fixed bug with starting consumers on initial click.

### DIFF
--- a/packages/engine/src/audio/systems/AudioSystem.ts
+++ b/packages/engine/src/audio/systems/AudioSystem.ts
@@ -3,6 +3,8 @@ import { SoundEffect } from '../components/SoundEffect'
 import { BackgroundMusic } from '../components/BackgroundMusic'
 import { PlaySoundEffect } from '../components/PlaySoundEffect'
 import { getMutableComponent } from '../../ecs/functions/EntityFunctions'
+import { PositionalAudioSystem } from './PositionalAudioSystem'
+import { EngineEvents } from '../../ecs/classes/EngineEvents'
 
 /** System class which provides methods for Audio system. */
 export class AudioSystem extends System {
@@ -81,6 +83,9 @@ export class AudioSystem extends System {
     if (this.audioReady) return
     console.log('starting audio')
     this.audioReady = true
+    EngineEvents.instance.dispatchEvent({
+      type: PositionalAudioSystem.EVENTS.START_SUSPENDED_CONTEXTS
+    })
     window.AudioContext = window.AudioContext || (window as any).webkitAudioContext
     if (window.AudioContext) {
       this.context = new window.AudioContext()

--- a/packages/engine/src/audio/systems/PositionalAudioSystem.ts
+++ b/packages/engine/src/audio/systems/PositionalAudioSystem.ts
@@ -10,6 +10,7 @@ import { PositionalAudioComponent } from '../components/PositionalAudioComponent
 import { Entity } from '../../ecs/classes/Entity'
 import { PositionalAudio } from 'three'
 import { applyAvatarAudioSettings, applyMediaAudioSettings } from '../../scene/behaviors/handleAudioSettings'
+import { EngineEvents } from '../../ecs/classes/EngineEvents'
 
 const SHOULD_CREATE_SILENT_AUDIO_ELS = typeof navigator !== 'undefined' && /chrome/i.test(navigator.userAgent)
 function createSilentAudioEl(streamsLive) {
@@ -23,6 +24,9 @@ function createSilentAudioEl(streamsLive) {
 
 /** System class which provides methods for Positional Audio system. */
 export class PositionalAudioSystem extends System {
+  static EVENTS = {
+    START_SUSPENDED_CONTEXTS: 'POSITIONAL_AUDIO_EVENT_START_SUSPENDED_CONTEXTS'
+  }
   avatarAudioStream: Map<Entity, any>
 
   /** Constructs Positional Audio System. */
@@ -30,6 +34,13 @@ export class PositionalAudioSystem extends System {
     super()
     Engine.useAudioSystem = true
     Engine.spatialAudio = true
+
+    EngineEvents.instance.addEventListener(PositionalAudioSystem.EVENTS.START_SUSPENDED_CONTEXTS, () => {
+      for (const entity of this.queryResults.avatar_audio.all) {
+        const positionalAudio = getComponent(entity, PositionalAudioComponent)
+        if (positionalAudio?.value?.context?.state === 'suspended') positionalAudio.value.context.resume()
+      }
+    })
     this.reset()
   }
 
@@ -38,6 +49,7 @@ export class PositionalAudioSystem extends System {
   }
 
   dispose(): void {
+    EngineEvents.instance.removeAllListenersForEvent(PositionalAudioSystem.EVENTS.START_SUSPENDED_CONTEXTS)
     super.dispose()
     this.reset()
   }


### PR DESCRIPTION
There was a gap in logic where, if a consumer existed before the initial click on a client's
screen, it was never getting resumed. The call to resume it was only coming when the AudioContext
was first created. An EngineEvent was added that AudioSystem now dispatches during startAudio(),
and PositionalAudioSystem now listens for that and tries to resume all suspended
queryResults.avatar_audio's.