### PR TITLE
MAP-1: fix rotation and scale of navmesh

### DIFF
--- a/packages/engine/src/debug/systems/DebugHelpersSystem.ts
+++ b/packages/engine/src/debug/systems/DebugHelpersSystem.ts
@@ -324,9 +324,6 @@ export const DebugHelpersSystem = async (): Promise<System> => {
       const helper = new Group()
       helper.add(convexHelper)
       helper.add(graphHelper)
-      helper.visible = true
-      // TODO: remove this rotation, NavMesh should be rotated
-      helper.rotation.y = Math.PI
       console.log('navhelper', helper)
       Engine.scene.add(helper)
       DebugHelpers.helpersByEntity.navmesh.set(entity, helper)

--- a/packages/engine/src/map/GeoJSONFns.ts
+++ b/packages/engine/src/map/GeoJSONFns.ts
@@ -122,28 +122,6 @@ export function scaleAndTranslatePolygon(coords: Position[][], llCenter: Positio
   return [coords[0].map((position) => scaleAndTranslatePosition(position, llCenter, scale))]
 }
 
-export function convertGeometryToSceneCoordinates(geometry: Polygon | MultiPolygon, llCenter: Position) {
-  switch (geometry.type) {
-    case 'MultiPolygon':
-      geometry.coordinates = geometry.coordinates.map((coords) => convertPolygonToSceneCoordinates(coords, llCenter))
-      break
-    case 'Polygon':
-      geometry.coordinates = convertPolygonToSceneCoordinates(geometry.coordinates, llCenter)
-      break
-  }
-
-  return geometry
-}
-export function convertPolygonToSceneCoordinates(coords: Position[][], llCenter: Position) {
-  return [
-    coords[0].map((position) => {
-      const sceneCoord = llToScene(position, llCenter)
-      sceneCoord[0] = sceneCoord[0] * -1
-      return sceneCoord
-    })
-  ]
-}
-
 export function scaleAndTranslate(geometry: Polygon | MultiPolygon, llCenter: [number, number], scale = 1) {
   switch (geometry.type) {
     case 'MultiPolygon':

--- a/packages/engine/src/map/MeshBuilder.ts
+++ b/packages/engine/src/map/MeshBuilder.ts
@@ -26,12 +26,9 @@ import { DEFAULT_FEATURE_STYLES, getFeatureStyles } from './styles'
 import { toIndexed } from './toIndexed'
 import { ILayerName, TileFeaturesByLayer } from './types'
 import { getRelativeSizesOfGeometries } from '../common/functions/GeometryFunctions'
+import { METERS_PER_DEGREE_LL } from './constants'
 
 // TODO free resources used by canvases, bitmaps etc
-
-const ENABLE_DEBUG = false
-
-const METERS_PER_DEGREE_LL = 111139
 
 export function llToScene([lng, lat]: Position, [lngCenter, latCenter]: Position): Position {
   return [(lng - lngCenter) * METERS_PER_DEGREE_LL, (lat - latCenter) * METERS_PER_DEGREE_LL]

--- a/packages/engine/src/map/NavMeshBuilder.test.ts
+++ b/packages/engine/src/map/NavMeshBuilder.test.ts
@@ -50,16 +50,33 @@ describe('NavMeshBuilder', () => {
     return this
   }
 
+  test('_toYukaCoords', () => {
+    const sut = new NavMeshBuilder()
+    const result = sut._toYukaRing([
+      [1, 1],
+      [1, -1],
+      [-1, -1],
+      [-1, 1]
+    ])
+
+    expect(result).toEqual([
+      [1, -1],
+      [1, 1],
+      [-1, 1],
+      [-1, -1]
+    ])
+  })
+
   test('_toYukaPolygons', () => {
     jest.spyOn(YUKA.Polygon.prototype, 'fromContour').mockImplementation(fromContourMock)
     const sut = new NavMeshBuilder()
 
     let result = sut._toYukaPolygons(polygon, 0)
-    expect((result[0] as any).vec3s).toEqual(sut._toYukaVectors3(polygon.coordinates[0].reverse(), 0))
+    expect((result[0] as any).vec3s).toEqual(sut._toYukaVectors3(sut._toYukaRing(polygon.coordinates[0]), 0))
 
     result = sut._toYukaPolygons(multiPolygon, 0)
-    expect((result[0] as any).vec3s).toEqual(sut._toYukaVectors3(multiPolygon.coordinates[0][0].reverse(), 0))
-    expect((result[1] as any).vec3s).toEqual(sut._toYukaVectors3(multiPolygon.coordinates[1][0].reverse(), 0))
+    expect((result[0] as any).vec3s).toEqual(sut._toYukaVectors3(sut._toYukaRing(multiPolygon.coordinates[0][0]), 0))
+    expect((result[1] as any).vec3s).toEqual(sut._toYukaVectors3(sut._toYukaRing(multiPolygon.coordinates[1][0]), 0))
 
     result = sut._toYukaPolygons(polygonInteriorRing, 0)
     expect(result.length).toEqual(8)

--- a/packages/engine/src/map/NavMeshBuilder.ts
+++ b/packages/engine/src/map/NavMeshBuilder.ts
@@ -19,15 +19,21 @@ export class NavMeshBuilder {
     }
   }
 
+  /**
+   * takes a ring from a geojson polygon and applies some transformation(s) needed to create
+   * the functionally equivalent polygon in a Yuka NavMesh.
+   */
+  _toYukaRing(ring: Position[]) {
+    return ring.map((position) => [position[0], -position[1]])
+  }
+
   _coordsToYukaPolygons(coords: Position[][], elevation: number): YUKA.Polygon[] {
     /** array of non-overlapping polygons */
-    const flatCoords: Position[][] = coords.length > 1 ? this._tessellate(coords) : coords
-    return flatCoords.map((polygonCoords) => {
+    const exteriorRings: Position[][] = coords.length > 1 ? this._tessellate(coords) : coords
+    return exteriorRings.map((ring) => {
       const result = new YUKA.Polygon()
-      const vec3s = this._toYukaVectors3(polygonCoords, elevation)
+      const vec3s = this._toYukaVectors3(this._toYukaRing(ring), elevation)
 
-      // YUKA requires Polygon vertices in the opposite order
-      vec3s.reverse()
       result.fromContour(vec3s)
 
       return result

--- a/packages/engine/src/map/constants.ts
+++ b/packages/engine/src/map/constants.ts
@@ -1,0 +1,2 @@
+
+export const METERS_PER_DEGREE_LL = 111139

--- a/packages/engine/src/map/constants.ts
+++ b/packages/engine/src/map/constants.ts
@@ -1,2 +1,1 @@
-
 export const METERS_PER_DEGREE_LL = 111139

--- a/packages/engine/src/map/index.ts
+++ b/packages/engine/src/map/index.ts
@@ -9,7 +9,8 @@ import { createBuildings, createGround, createRoads, llToScene, setGroundScaleAn
 import { NavMeshBuilder } from './NavMeshBuilder'
 import { TileFeaturesByLayer } from './types'
 import pc from 'polygon-clipping'
-import { computeBoundingBox, convertGeometryToSceneCoordinates, scaleAndTranslate } from './GeoJSONFns'
+import { computeBoundingBox, scaleAndTranslate } from './GeoJSONFns'
+import { METERS_PER_DEGREE_LL } from './constants'
 
 let centerCoord = {}
 let centerTile = {}
@@ -33,7 +34,7 @@ export const create = async function (renderer: THREE.WebGLRenderer, args: MapPr
 
   group.add(groundMesh)
 
-  const navMesh = generateNavMesh(vectorTiles, center)
+  const navMesh = generateNavMesh(vectorTiles, center, args.scale.x * METERS_PER_DEGREE_LL)
 
   group.position.multiplyScalar(args.scale.x)
   group.scale.multiplyScalar(args.scale.x)
@@ -44,12 +45,12 @@ export const create = async function (renderer: THREE.WebGLRenderer, args: MapPr
   return { mapMesh: group, buildingMesh, groundMesh, roadsMesh, navMesh }
 }
 
-const generateNavMesh = function (tiles: TileFeaturesByLayer[], center: Position): NavMesh {
+const generateNavMesh = function (tiles: TileFeaturesByLayer[], center: Position, scale: number): NavMesh {
   const builder = new NavMeshBuilder()
   const gBuildings = tiles
     .reduce((acc, tiles) => acc.concat(tiles.building), [])
     .map((feature) => {
-      return convertGeometryToSceneCoordinates(feature.geometry as Polygon | MultiPolygon, center)
+      return scaleAndTranslate(feature.geometry as Polygon | MultiPolygon, center, scale)
     })
 
   const gGround = computeBoundingBox(gBuildings)


### PR DESCRIPTION
Looks perfectly aligned now, without transforming the helper or the buildings. Using this location that has only a few buildings and roads, which I find makes debugging easier: https://www.openstreetmap.org/search?whereami=1&query=29.84317%2C129.87367#map=17/29.84317/129.87367&layers=C

![image](https://user-images.githubusercontent.com/578371/129095945-325cd3aa-ed7e-490b-ab89-97b02695fe99.png)
