### PR TITLE
Revert location and avatar works again

### DIFF
--- a/packages/client/src/components/World/index.tsx
+++ b/packages/client/src/components/World/index.tsx
@@ -32,29 +32,27 @@ import { SocketWebRTCClientTransport } from '../../transports/SocketWebRTCClient
 
 const engineRendererCanvasId = 'engine-renderer-canvas'
 
-const getDefaulEngineInitializeOptions = (): InitializeOptions => {
-  return {
-    publicPath: location.origin,
-    networking: {
-      schema: {
-        transport: SocketWebRTCClientTransport
-      } as NetworkSchema
-    },
-    renderer: {
-      canvasId: engineRendererCanvasId
-    },
-    physics: {
-      simulationEnabled: false,
-      physxWorker: new Worker('/scripts/loadPhysXClassic.js')
-    },
-    systems: [
-      {
-        type: SystemUpdateType.Fixed,
-        system: GolfSystem,
-        after: GameManagerSystem
-      }
-    ]
-  }
+const defaulEngineInitializeOptions: InitializeOptions = {
+  publicPath: location.origin,
+  networking: {
+    schema: {
+      transport: SocketWebRTCClientTransport
+    } as NetworkSchema
+  },
+  renderer: {
+    canvasId: engineRendererCanvasId
+  },
+  physics: {
+    simulationEnabled: false,
+    physxWorker: new Worker('/scripts/loadPhysXClassic.js')
+  },
+  systems: [
+    {
+      type: SystemUpdateType.Fixed,
+      system: GolfSystem,
+      after: GameManagerSystem
+    }
+  ]
 }
 
 const goHome = () => (window.location.href = window.location.origin)
@@ -122,7 +120,7 @@ export const EnginePage = (props: Props) => {
   const [newSpawnPos, setNewSpawnPos] = useState<ReturnType<typeof PortalComponent.get>>(null)
   const selfUser = props.authState.get('user')
   const party = props.partyState.get('party')
-  const engineInitializeOptions = props.engineInitializeOptions ?? getDefaulEngineInitializeOptions()
+  const engineInitializeOptions = props.engineInitializeOptions ??  defaulEngineInitializeOptions
 
   let sceneId = null
 

--- a/packages/client/src/pages/location/[locationName].tsx
+++ b/packages/client/src/pages/location/[locationName].tsx
@@ -1,16 +1,44 @@
-import EmoteMenu from '@xrengine/client-core/src/common/components/EmoteMenu'
-import LoadingScreen from '@xrengine/client-core/src/common/components/Loader'
-import UserMenu from '@xrengine/client-core/src/user/components/UserMenu'
-import { InteractableModal } from '@xrengine/client-core/src/world/components/InteractableModal'
 import React, { useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import InstanceChat from '../../components/InstanceChat'
+import World, { EngineCallbacks } from '../../components/World'
 import Layout from '../../components/Layout/Layout'
-import MediaIconsBox from '../../components/MediaIconsBox'
+import { useTranslation } from 'react-i18next'
+import { InitializeOptions } from '@xrengine/engine/src/initializationOptions'
+import { NetworkSchema } from '@xrengine/engine/src/networking/interfaces/NetworkSchema'
+import { CharacterUISystem } from '@xrengine/client-core/src/systems/CharacterUISystem'
+import { UISystem } from '@xrengine/engine/src/xrui/systems/UISystem'
+import LoadingScreen from '@xrengine/client-core/src/common/components/Loader'
+import { SystemUpdateType } from '@xrengine/engine/src/ecs/functions/SystemUpdateType'
+import { InteractableModal } from '@xrengine/client-core/src/world/components/InteractableModal'
+import UserMenu from '@xrengine/client-core/src/user/components/UserMenu'
+import EmoteMenu from '@xrengine/client-core/src/common/components/EmoteMenu'
+import { SocketWebRTCClientTransport } from '../../transports/SocketWebRTCClientTransport'
 import RecordingApp from '../../components/Recorder/RecordingApp'
-import World, { EngineCallbacks } from '../../components/World/index'
+import MediaIconsBox from '../../components/MediaIconsBox'
 
 const engineRendererCanvasId = 'engine-renderer-canvas'
+
+const engineInitializeOptions: InitializeOptions = {
+  publicPath: location.origin,
+  networking: {
+    schema: {
+      transport: SocketWebRTCClientTransport
+    } as NetworkSchema
+  },
+  renderer: {
+    canvasId: engineRendererCanvasId
+  },
+  physics: {
+    simulationEnabled: false,
+    physxWorker: new Worker('/scripts/loadPhysXClassic.js')
+  },
+  systems: [
+    {
+      type: SystemUpdateType.Fixed,
+      system: CharacterUISystem,
+      after: UISystem
+    }
+  ]
+}
 
 const LocationPage = (props) => {
   const [loadingItemCount, setLoadingItemCount] = useState(99)
@@ -32,6 +60,7 @@ const LocationPage = (props) => {
         allowDebug={true}
         locationName={props.match.params.locationName}
         history={props.history}
+        engineInitializeOptions={engineInitializeOptions}
         engineCallbacks={engineCallbacks}
         showTouchpad
       >
@@ -40,7 +69,6 @@ const LocationPage = (props) => {
         <MediaIconsBox />
         <UserMenu />
         <EmoteMenu />
-        <InstanceChat />
       </World>
     </Layout>
   )


### PR DESCRIPTION
This reverts a bunch of changes made in the last couple of days to merge different bits together. This gets the avatars working again, but ideally we can look at the diff and bring the important stuff back.