### PR TITLE
Removed disabled/delete options from static-resource.seed.ts

### DIFF
--- a/packages/server-core/src/media/static-resource/static-resource.seed.ts
+++ b/packages/server-core/src/media/static-resource/static-resource.seed.ts
@@ -17,8 +17,6 @@ const getAvatarURL = (avatarName) => {
 }
 
 export const staticResourceSeed = {
-  disabled: !config || !config.db.forceRefresh,
-  delete: config && config.db.forceRefresh,
   randomize: false,
   path: 'static-resource',
   templates: [


### PR DESCRIPTION
When local configuration of disabled/delete was removed from .seed files in favor of top-level
one, static-resource.seed.ts erroneously had its left in, which resulted in the seeding when no
user table was detected not running for this since config.db.forceRefresh wasn't true.