### PR TITLE
Assign entity to collider userData

### DIFF
--- a/packages/engine/src/avatar/functions/createAvatar.ts
+++ b/packages/engine/src/avatar/functions/createAvatar.ts
@@ -120,6 +120,9 @@ export const createAvatar = (
             y: transform.position.y + avatarHalfHeight,
             z: transform.position.z
           }
+        },
+        userData: {
+          entity
         }
       })
     )
@@ -150,6 +153,9 @@ export const createAvatarController = (entity: Entity) => {
       },
       material: {
         dynamicFriction: 0.1
+      },
+      userData: {
+        entity
       }
     })
   )

--- a/packages/engine/src/avatar/functions/detectUserInPortal.ts
+++ b/packages/engine/src/avatar/functions/detectUserInPortal.ts
@@ -8,9 +8,9 @@ import { teleportPlayer } from './teleportPlayer'
 
 export const detectUserInPortal = (entity: Entity): void => {
   const raycastComponent = getComponent(entity, RaycastComponent)
-  if (!raycastComponent?.raycastQuery?.hits[0]?.body?.userData) return
+  if (!raycastComponent?.raycastQuery?.hits[0]?.body?.userData?.entity) return
 
-  const portalEntity = raycastComponent.raycastQuery.hits[0].body.userData
+  const portalEntity = raycastComponent.raycastQuery.hits[0].body.userData.entity
   const portalComponent = getComponent(portalEntity, PortalComponent)
 
   if (!portalComponent) return

--- a/packages/engine/src/game/systems/GameManagerSystem.ts
+++ b/packages/engine/src/game/systems/GameManagerSystem.ts
@@ -90,7 +90,7 @@ export const GameManagerSystem = async (): Promise<System> => {
       const collider = getComponent(entity, ColliderComponent)
       const gameObject = getComponent(entity, GameObject)
       for (const collisionEvent of collider.body.collisionEvents) {
-        const otherEntity = collisionEvent.bodyOther.userData as Entity
+        const otherEntity = collisionEvent.bodyOther.userData.entity as Entity
         if (typeof otherEntity === 'undefined') continue
         const otherGameObject = getComponent(otherEntity, GameObject)
         if (!otherGameObject) continue

--- a/packages/engine/src/physics/behaviors/createCollider.ts
+++ b/packages/engine/src/physics/behaviors/createCollider.ts
@@ -6,6 +6,7 @@ import { ColliderTypes } from '../types/PhysicsTypes'
 import { arrayOfPointsToArrayOfVector3 } from '../../scene/functions/arrayOfPointsToArrayOfVector3'
 import { Engine } from '../../ecs/classes/Engine'
 import { mergeBufferGeometries } from '../../common/classes/BufferGeometryUtils'
+import { Entity } from '../../ecs/classes/Entity'
 
 /**
  * @author HydraFire <github.com/HydraFire>
@@ -32,6 +33,7 @@ type ColliderData = {
 }
 
 export function createCollider(
+  entity: Entity,
   mesh: Mesh | any,
   pos = new Vector3(),
   rot = new Quaternion(),
@@ -151,6 +153,9 @@ export function createCollider(
       // scale: { x: scale.x, y: scale.y, z: scale.z }, // this actually does nothing, physx doesn't have a scale param apparently...
       linearVelocity: { x: 0, y: 0, z: 0 },
       angularVelocity: { x: 0, y: 0, z: 0 }
+    },
+    userData: {
+      entity
     }
   })
 

--- a/packages/engine/src/physics/behaviors/parseModelColliders.ts
+++ b/packages/engine/src/physics/behaviors/parseModelColliders.ts
@@ -112,7 +112,7 @@ export const createCollidersFromModel = (entity: Entity, asset: any) => {
       transform.scale
     )
     // console.log('IS NAN', mesh.scale)
-    createCollider(mesh, position, quaternion, scale)
+    createCollider(entity, mesh, position, quaternion, scale)
     mesh.removeFromParent()
   })
 }

--- a/packages/engine/src/scene/behaviors/createGround.ts
+++ b/packages/engine/src/scene/behaviors/createGround.ts
@@ -22,6 +22,7 @@ export const createGround = (entity: Entity, args: GroundProps) => {
   addObject3DComponent(entity, mesh, { receiveShadow: true, 'material.color': args.color })
 
   const body = createCollider(
+    entity,
     {
       userData: {
         type: 'ground',

--- a/packages/engine/src/scene/behaviors/createPortal.ts
+++ b/packages/engine/src/scene/behaviors/createPortal.ts
@@ -71,7 +71,7 @@ export const createPortal = async (entity: Entity, args: PortalProps) => {
 
     PhysXInstance.instance.addBody(portalBody)
 
-    portalBody.userData = entity
+    portalBody.userData = { entity }
 
     addComponent(entity, ColliderComponent, { body: portalBody })
 

--- a/packages/engine/src/scene/functions/SceneLoading.ts
+++ b/packages/engine/src/scene/functions/SceneLoading.ts
@@ -254,6 +254,7 @@ export class WorldScene {
       case 'box-collider':
         const boxColliderProps: BoxColliderProps = component.data
         createCollider(
+          entity,
           {
             userData: {
               type: 'box',


### PR DESCRIPTION
- Entities are now by default assigned to collider bodies via `colliderComponent.body.userData.entity` and `avatarControllerComponent.controller.userData.entity`