### PR TITLE
Map-39: Add test page

### DIFF
--- a/packages/client/src/pages/examples/map-test.tsx
+++ b/packages/client/src/pages/examples/map-test.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect } from 'react'
-import { Scene, WebGLRenderer, Color, DirectionalLight, PerspectiveCamera, HemisphereLight, Object3D } from 'three'
+import { Scene, WebGLRenderer, Color, DirectionalLight, PerspectiveCamera, HemisphereLight } from 'three'
 import { OrbitControls } from '@xrengine/engine/src/input/functions/OrbitControls'
-import { create } from '@xrengine/engine/src/map'
 import MapNode from '../../../../engine/src/editor/nodes/MapNode'
-import EventEmitter from 'eventemitter3'
 import MapNodeEditor from '../../../../client-core/src/world/components/editor/properties/MapNodeEditor'
 import { createState, useState } from '@hookstate/core'
 
@@ -11,14 +9,11 @@ const globalState = createState(0)
 
 const scene = new Scene()
 
-class EditorMock extends EventEmitter {
+class EditorMock {
   renderer: {
     renderer: WebGLRenderer
   }
   object = new MapNode(this)
-  constructor() {
-    super()
-  }
   setPropertySelected(propertyName: string, value: any) {
     this.object[propertyName] = value
     this.object.onChange(propertyName)

--- a/packages/client/src/pages/examples/map-test.tsx
+++ b/packages/client/src/pages/examples/map-test.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useRef } from 'react'
+import { Scene, WebGLRenderer, Color, DirectionalLight, PerspectiveCamera, HemisphereLight, Vector3 } from 'three'
+import { OrbitControls } from '@xrengine/engine/src/input/functions/OrbitControls'
+import { create } from '@xrengine/engine/src/map'
+
+let scene = new Scene()
+
+async function init(): Promise<any> {
+  scene.background = new Color('black')
+
+  let renderer = new WebGLRenderer({ canvas: document.getElementById(engineRendererCanvasId) as HTMLCanvasElement })
+  renderer.setSize(window.innerWidth, window.innerHeight)
+  renderer.setPixelRatio(window.devicePixelRatio)
+
+  scene.add(new HemisphereLight())
+  scene.add(new DirectionalLight())
+
+  let camera = new PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 10000)
+  camera.position.set(1, 2, 5)
+
+  let controls = new OrbitControls(camera, renderer.domElement)
+  controls.minDistance = 1
+  controls.maxDistance = 2000
+  controls.target.set(0, 0, 0)
+  controls.object.position.set(0, 2000, 0)
+
+  const map = await create(renderer, {
+    scale: new Vector3(1, 1, 1)
+  })
+
+  scene.add(map.mapMesh)
+
+  const animate = () => {
+    requestAnimationFrame(animate)
+
+    controls.update()
+    renderer.render(scene, camera)
+  }
+  requestAnimationFrame(animate)
+}
+
+const engineRendererCanvasId = 'engine-renderer-canvas'
+
+const canvasStyle = {
+  zIndex: 0,
+  width: '100%',
+  height: '100%',
+  position: 'absolute',
+  WebkitUserSelect: 'none',
+  userSelect: 'none'
+} as React.CSSProperties
+
+const Page = () => {
+  useEffect(() => {
+    init()
+  }, [])
+  return (
+    <>
+      <div>
+        <canvas id={engineRendererCanvasId} style={canvasStyle} />
+      </div>
+    </>
+  )
+}
+
+export default Page

--- a/packages/client/src/route/public.tsx
+++ b/packages/client/src/route/public.tsx
@@ -61,6 +61,7 @@ class RouterComp extends React.Component<{}, { hasError: boolean }> {
             component={React.lazy(() => import('../pages/examples/NavMeshBuilder'))}
           />
           <Route path="/asset-test" component={React.lazy(() => import('../pages/examples/asset-test'))} />
+          <Route path="/map-test" component={React.lazy(() => import('../pages/examples/map-test'))} />
 
           {/* Auth Routes */}
           <Route path="/auth/oauth/facebook" component={React.lazy(() => import('../pages/auth/oauth/facebook'))} />


### PR DESCRIPTION
![Peek 2021-08-03 07-52](https://user-images.githubusercontent.com/578371/129974031-3f4e0070-1f00-41c6-98f3-ccb6be1dc259.gif)

Adds a page at /map-test that lets you test the map node without needing to bother with the full editor or loading up a location in the engine.