### PR TITLE
MAP-39: quick fix for rendering roads above avatar

### DIFF
--- a/packages/engine/src/map/MeshBuilder.ts
+++ b/packages/engine/src/map/MeshBuilder.ts
@@ -22,7 +22,7 @@ import { Text } from 'troika-three-text'
 import { mergeBufferGeometries } from '../common/classes/BufferGeometryUtils'
 import { unifyFeatures } from './GeoJSONFns'
 import { NUMBER_OF_TILES_PER_DIMENSION, RASTER_TILE_SIZE_HDPI } from './MapBoxClient'
-import { DEFAULT_FEATURE_STYLES, getFeatureStyles } from './styles'
+import { DEFAULT_FEATURE_STYLES, getFeatureStyles, MAX_Z_INDEX } from './styles'
 import { toIndexed } from './toIndexed'
 import { ILayerName, TileFeaturesByLayer } from './types'
 import { getRelativeSizesOfGeometries } from '../common/functions/GeometryFunctions'
@@ -265,7 +265,7 @@ export function buildMeshes(
 
     const material = getOrCreateMaterial(MeshLambertMaterial, materialParams)
     const mesh = new Mesh(g, material)
-    mesh.renderOrder = styles.extrude === 'flat' ? styles.zIndex : Infinity
+    mesh.renderOrder = styles.extrude === 'flat' ? -1 * (MAX_Z_INDEX - styles.zIndex) : Infinity
     return mesh
   })
 }
@@ -327,7 +327,7 @@ export function createGround(rasterTiles: ImageBitmap[], latitude: number): Mesh
 
   // prevent z-fighting with vector roads
   material.depthTest = false
-  mesh.renderOrder = -1
+  mesh.renderOrder = -1 * MAX_Z_INDEX
 
   // rotate to face up
   mesh.geometry.rotateX(-Math.PI / 2)

--- a/packages/engine/src/map/styles.ts
+++ b/packages/engine/src/map/styles.ts
@@ -78,6 +78,8 @@ viewpoint:2
 waste_basket:2
 */
 
+export const MAX_Z_INDEX = 10000
+
 export interface IStyles {
   color?: {
     /** use same color on all surfaces */


### PR DESCRIPTION
caveat: the ground and roads of the map will render below other objects, like the ground plane, so the ground plane should be made invisible.