### PR TITLE
Fixed missing 'process' on built client, Docker building editor.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY package.json .
 COPY packages/client/package.json ./packages/client/
 COPY packages/client-core/package.json ./packages/client-core/
 COPY packages/common/package.json ./packages/common/
+COPY packages/editor/package.json ./packages/editor/
 COPY packages/engine/package.json ./packages/engine/
 COPY packages/gameserver/package.json ./packages/gameserver/
 COPY packages/server/package.json ./packages/server/

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -41,6 +41,7 @@
     "@material-ui/icons": "4.11.2",
     "@material-ui/styles": "4.11.4",
     "@mui-treasury/components": "1.10.1",
+    "@rollup/plugin-inject": "^4.0.2",
     "@styled-icons/boxicons-regular": "10.37.0",
     "@styled-icons/boxicons-solid": "10.37.0",
     "@styled-icons/fa-regular": "10.34.0",

--- a/packages/client/vite.config.js
+++ b/packages/client/vite.config.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { defineConfig, loadEnv } from 'vite';
 import config from "config";
+import inject from '@rollup/plugin-inject'
 
 const replaceEnvs = (obj, env) => {
   let result = {};
@@ -27,7 +28,7 @@ const replaceEnvs = (obj, env) => {
   return result;
 }
 
-export default defineConfig(() => {
+export default defineConfig((command) => {
   const env = loadEnv('', process.cwd() + '../../');
   const runtime = replaceEnvs(config.get('publicRuntimeConfig'), env);
 
@@ -37,7 +38,7 @@ export default defineConfig(() => {
     publicRuntimeConfig: JSON.stringify(runtime)
   };
 
-  return {
+  const returned = {
     plugins: [
     ],
     server: {
@@ -56,10 +57,6 @@ export default defineConfig(() => {
         'three-physx': 'three-physx/src/index.ts'
       }
     },
-    define: {
-      'process.env': process.env,
-      'process.browser': process.browser,
-    },
     build: {
       sourcemap: 'inline',
       minify: 'esbuild',
@@ -75,4 +72,15 @@ export default defineConfig(() => {
       },
     },
   };
+  if (command.command === 'build') {
+   returned.build.rollupOptions.plugins = [
+       inject({
+         process: 'process'
+       })
+   ]
+  } else returned.define = {
+    'process.env': process.env,
+    'process.browser': process.browser,
+  }
+  return returned
 });


### PR DESCRIPTION
Something caused the build of the client to not have 'process' defined.
Using @rollup/plugin-inject to inject a process definition on build.

Dockerfile had not been updated to build editor.