### PR TITLE
skip promise rejection if already connected

### DIFF
--- a/packages/client/src/transports/SocketWebRTCClientTransport.ts
+++ b/packages/client/src/transports/SocketWebRTCClientTransport.ts
@@ -203,7 +203,7 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
         ConnectToWorldResponse = await Promise.race([
           await request(MessageTypes.ConnectToWorld.toString()),
           new Promise((resolve, reject) => {
-            setTimeout(() => reject(new Error('Connect timed out')), 10000)
+            setTimeout(() => !ConnectToWorldResponse && reject(new Error('Connect timed out')), 10000)
           })
         ])
       } catch (err) {


### PR DESCRIPTION
it is not important fix, just that promise rejection is blocking chrome devtools if "Pause on exceptions" is turned on. And really if connection was successful there is no reason to trigger reject.