### PR TITLE
Fix map scaling issues

### DIFF
--- a/packages/editor/src/nodes/MapNode.ts
+++ b/packages/editor/src/nodes/MapNode.ts
@@ -79,7 +79,6 @@ export default class MapNode extends EditorNodeMixin(Object3D) {
 
     Object.values(this.mapLayers).forEach((layer) => {
       if (layer) {
-        this.applyScale(layer)
         this.add(layer)
       }
     })
@@ -88,7 +87,6 @@ export default class MapNode extends EditorNodeMixin(Object3D) {
     this.labels = createLabels(vectorTiles, center)
 
     this.labels.forEach((label) => {
-      label.scale.copy(this.scale)
       this.add(label.object3d)
     })
   }

--- a/packages/engine/src/map/GeoLabelNode.ts
+++ b/packages/engine/src/map/GeoLabelNode.ts
@@ -34,8 +34,7 @@ export class GeoLabelNode {
   geoMiddleSlice: Position[]
   transformGeoPosition: (position: Position) => Position
 
-  object3d: Object3D & { sync(): void; fontSize: number }
-  scale: Vector3
+  object3d: Object3D & { sync(): void }
 
   constructor(feature: Feature<LineString>, transformGeoPosition: (position: Position) => Position) {
     this.geoFeature = feature
@@ -45,8 +44,6 @@ export class GeoLabelNode {
 
     // Update the rendering:
     this.object3d.sync()
-
-    this.scale = new Vector3(1, 1, 1)
 
     this.geoLength = length(this.geoFeature)
     this.geoMiddleSlice = lineSliceAlong(
@@ -73,9 +70,6 @@ export class GeoLabelNode {
       angleDiff < Math.PI / 2 || angleDiff > (Math.PI * 3) / 2 ? angle + Math.PI : angle
     )
     this.object3d.rotateX(-Math.PI / 2)
-
-    this.object3d.fontSize = Math.max(...this.scale.toArray()) * DEFAULT_FONT_SIZE
-    this.object3d.position.multiply(this.scale)
 
     this.object3d.sync()
   }

--- a/packages/engine/src/map/GeoLabelNode.ts
+++ b/packages/engine/src/map/GeoLabelNode.ts
@@ -1,5 +1,5 @@
 import { Feature, LineString, Position } from 'geojson'
-import { Vector3, Camera } from 'three'
+import { Vector3, Camera, Object3D } from 'three'
 import { Text } from 'troika-three-text'
 import { length, lineSliceAlong } from '@turf/turf'
 
@@ -34,19 +34,19 @@ export class GeoLabelNode {
   geoMiddleSlice: Position[]
   transformGeoPosition: (position: Position) => Position
 
-  object3d: Text
+  object3d: Object3D & { sync(): void; fontSize: number }
   scale: Vector3
 
   constructor(feature: Feature<LineString>, transformGeoPosition: (position: Position) => Position) {
     this.geoFeature = feature
     this.transformGeoPosition = transformGeoPosition
 
-    this.scale = new Vector3(1, 1, 1)
-
     this.object3d = createTextObject(feature.properties.name)
 
     // Update the rendering:
     this.object3d.sync()
+
+    this.scale = new Vector3(1, 1, 1)
 
     this.geoLength = length(this.geoFeature)
     this.geoMiddleSlice = lineSliceAlong(
@@ -73,6 +73,9 @@ export class GeoLabelNode {
       angleDiff < Math.PI / 2 || angleDiff > (Math.PI * 3) / 2 ? angle + Math.PI : angle
     )
     this.object3d.rotateX(-Math.PI / 2)
+
+    this.object3d.fontSize = Math.max(...this.scale.toArray()) * DEFAULT_FONT_SIZE
+    this.object3d.position.multiply(this.scale)
 
     this.object3d.sync()
   }

--- a/packages/engine/src/map/index.ts
+++ b/packages/engine/src/map/index.ts
@@ -44,7 +44,6 @@ export const create = async function (args: MapProps) {
   setGroundScaleAndPosition(groundMesh, buildingMesh)
 
   labels.forEach((label) => {
-    label.scale.copy(args.scale)
     group.add(label.object3d)
   })
 


### PR DESCRIPTION
There were some issues with how the scale value from the editor was being applied to the Object3Ds within the map due to some confusion about what code should have that responsibility. As a result, the scale was being applied to the buildings, roads, and landuse meshes twice. There was also some scale-related code in the GeoLabelNode class that isn't needed.

Before
![Screenshot from 2021-08-27 17-12-53](https://user-images.githubusercontent.com/578371/131200006-282e0740-73da-45d2-be1e-5ee16e299108.png)

After
![Screenshot from 2021-08-27 17-18-19](https://user-images.githubusercontent.com/578371/131200116-9c9a3d9e-0562-4e50-b7ff-45ab74891cc9.png)

