### PR TITLE
Fixed documentation build issues

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,8 +20,6 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=8192
         run: |
           npm install --production=false --legacy-peer-deps
-          cd packages/docs
-          npm install --production=false --legacy-peer-deps
           npm run build
   gh-release:
     if: github.event_name != 'pull_request'
@@ -44,6 +42,6 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "gh-actions"
           npm install --production=false --legacy-peer-deps
+          npm run build
           cd packages/docs
-          npm install --production=false --legacy-peer-deps
           npm run deploy

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -73,7 +73,6 @@
     "@typescript-eslint/parser": "4.31.2",
     "cross-env": "7.0.3",
     "eslint": "7.32.0",
-    "typedoc": "0.22.4",
     "typescript": "4.4.3"
   }
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -52,9 +52,9 @@
     "@types/react-helmet": "6.1.2",
     "@types/react-router-dom": "5.1.9",
     "cross-env": "7.0.3",
-    "docusaurus-plugin-typedoc": "0.16.2",
-    "typedoc": "0.22.4",
-    "typedoc-plugin-markdown": "3.11.0",
+    "docusaurus-plugin-typedoc": "0.16.1",
+    "typedoc": "0.21.9",
+    "typedoc-plugin-markdown": "3.10.4",
     "typescript": "4.4.3"
   }
 }

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -103,7 +103,6 @@
     "rollup-plugin-node-polyfills": "0.2.1",
     "rollup-plugin-sass": "1.2.8",
     "ts-jest": "27.0.5",
-    "typedoc": "0.22.4",
     "typescript": "4.4.3"
   },
   "gitHead": "2313453697ca7c6b8d36b3b166b5a6445fe1c851"

--- a/packages/gameserver/package.json
+++ b/packages/gameserver/package.json
@@ -123,7 +123,6 @@
     "semantic-release-monorepo": "7.0.5",
     "ts-node": "10.2.1",
     "ts-node-dev": "1.1.8",
-    "typedoc": "0.22.4",
     "typescript": "4.4.3"
   },
   "gitHead": "66449f6ffba4d32c424b16b4f0667fe0ad36562c"

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -120,7 +120,6 @@
     "rollup-plugin-livereload": "2.0.5",
     "rollup-plugin-terser": "7.0.2",
     "rollup-plugin-typescript2": "0.30.0",
-    "typedoc": "0.22.4",
     "typescript": "4.4.3"
   },
   "gitHead": "2313453697ca7c6b8d36b3b166b5a6445fe1c851"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -132,7 +132,6 @@
     "cross-env": "7.0.3",
     "eslint": "7.32.0",
     "ts-node": "10.2.1",
-    "typedoc": "0.22.4",
     "typescript": "4.4.3"
   },
   "gitHead": "66449f6ffba4d32c424b16b4f0667fe0ad36562c"


### PR DESCRIPTION
Rolled back typedoc and typedoc-plugin-markdown. Latest versions were breaking docusaurus.

Also removed typedoc as a dependency from all other packages since it didn't appear
to be used.