### PR TITLE
Removed useAuthState from services.

### DIFF
--- a/packages/client-core/src/admin/components/Bots/CreateBot.tsx
+++ b/packages/client-core/src/admin/components/Bots/CreateBot.tsx
@@ -105,7 +105,7 @@ const CreateBot = (props: Props) => {
   })
 
   React.useEffect(() => {
-    const instanceFilter = data.filter((el) => el.location.id === state.location)
+    const instanceFilter = data.filter((el) => el.location?.id === state.location)
     if (instanceFilter.length > 0) {
       setState({ ...state, instance: '' })
       setCurrentIntance(instanceFilter)

--- a/packages/client-core/src/admin/components/Bots/updateBot.tsx
+++ b/packages/client-core/src/admin/components/Bots/updateBot.tsx
@@ -125,7 +125,7 @@ const UpdateBot = (props: Props) => {
 
   React.useEffect(() => {
     if (bot) {
-      const instanceFilter = data.filter((el) => el.location.id === state.location)
+      const instanceFilter = data.filter((el) => el.location?.id === state.location)
       if (instanceFilter.length > 0) {
         setState({ ...state, instance: state.instance || '' })
         setCurrentIntance(instanceFilter)

--- a/packages/client-core/src/admin/components/Instance/InstanceTable.tsx
+++ b/packages/client-core/src/admin/components/Instance/InstanceTable.tsx
@@ -85,7 +85,7 @@ const InstanceTable = (props: Props) => {
       id,
       ipAddress,
       currentUsers,
-      locationId: locationId.name || '',
+      locationId: locationId?.name || '',
       channelId,
       action: (
         <>

--- a/packages/client-core/src/admin/reducers/admin/bots/service.ts
+++ b/packages/client-core/src/admin/reducers/admin/bots/service.ts
@@ -1,6 +1,5 @@
 import { Dispatch } from 'redux'
 import { client } from '../../../../feathers'
-import { useAuthState } from '../../../../user/reducers/auth/AuthState'
 import { botCreated, fetchedBot, botCammandCreated, botRemoved, botCommandRemoved, botPatched } from './actions'
 
 export const createBotAsAdmin =
@@ -18,10 +17,10 @@ export const fetchBotAsAdmin =
   (incDec?: 'increment' | 'decrement') =>
   async (dispatch: Dispatch, getState: any): Promise<any> => {
     try {
-      const user = useAuthState().user
+      const user = getState().get('auth').user
       const skip = getState().get('adminBots').get('bots').get('skip')
       const limit = getState().get('adminBots').get('bots').get('limit')
-      if (user.userRole.value === 'admin') {
+      if (user.userRole === 'admin') {
         const bots = await client.service('bot').find({
           query: {
             $sort: {

--- a/packages/client-core/src/admin/reducers/admin/instance/service.ts
+++ b/packages/client-core/src/admin/reducers/admin/instance/service.ts
@@ -4,15 +4,14 @@ import { client } from '../../../../feathers'
 import { dispatchAlertError } from '../../../../common/reducers/alert/service'
 import Store from '../../../../store'
 import { Config } from '@xrengine/common/src/config'
-import { useAuthState } from '../../../../user/reducers/auth/AuthState'
 
 export function fetchAdminInstances(incDec?: 'increment' | 'decrement') {
   return async (dispatch: Dispatch, getState: any): Promise<any> => {
     const skip = getState().get('adminInstance').get('instances').get('skip')
     const limit = getState().get('adminInstance').get('instances').get('limit')
-    const user = useAuthState().user
+    const user = getState().get('auth').user
     try {
-      if (user.userRole.value === 'admin') {
+      if (user.userRole === 'admin') {
         const instances = await client.service('instance').find({
           query: {
             $sort: {

--- a/packages/client-core/src/admin/reducers/admin/party/service.ts
+++ b/packages/client-core/src/admin/reducers/admin/party/service.ts
@@ -2,7 +2,6 @@ import { partyAdminCreated, partyRetrievedAction } from './actions'
 import { Dispatch } from 'redux'
 import { client } from '../../../../feathers'
 import { dispatchAlertError } from '../../../../common/reducers/alert/service'
-import { useAuthState } from '../../../../user/reducers/auth/AuthState'
 
 export const createAdminParty = (data) => {
   return async (dispatch: Dispatch): Promise<any> => {
@@ -18,11 +17,11 @@ export const createAdminParty = (data) => {
 
 export const fetchAdminParty = (incDec?: 'increment' | 'decrement') => {
   return async (dispatch: Dispatch, getState: any): Promise<any> => {
-    const user = useAuthState().user
-    const skip = getState().get('adminParties').get('parties').get('skip')
-    const limit = getState().get('adminParties').get('parties').get('limit')
+    const user = getState().get('auth').user
+    const skip = getState().get('adminParty').get('parties').get('skip')
+    const limit = getState().get('adminParty').get('parties').get('limit')
     try {
-      if (user.userRole.value === 'admin') {
+      if (user.userRole === 'admin') {
         const parties = await client.service('party').find({
           query: {
             $sort: {

--- a/packages/client-core/src/admin/reducers/admin/user/service.ts
+++ b/packages/client-core/src/admin/reducers/admin/user/service.ts
@@ -14,15 +14,14 @@ import {
 import { client } from '../../../../feathers'
 import { loadedUsers } from './actions'
 import { dispatchAlertError } from '../../../../common/reducers/alert/service'
-import { useAuthState } from '../../../../user/reducers/auth/AuthState'
 
 export function fetchUsersAsAdmin(incDec?: 'increment' | 'decrement') {
   return async (dispatch: Dispatch, getState: any): Promise<any> => {
-    const user = useAuthState().user
+    const user = getState().get('auth').user
     const skip = getState().get('adminUser').get('users').get('skip')
     const limit = getState().get('adminUser').get('users').get('limit')
     try {
-      if (user.userRole.value === 'admin') {
+      if (user.userRole === 'admin') {
         const users = await client.service('user').find({
           query: {
             $sort: {


### PR DESCRIPTION
Apparently hooks can only be used in function components. Errors were being thrown
when useAuthState() was being called in service functions. Reverted them to calls
to getState().get('auth').

Fixed a few conditional reference errors in some admin pages.