### PR TITLE
Fixed several bugs in Harmony.

### DIFF
--- a/packages/client-core/src/admin/components/Party/PartyTable.tsx
+++ b/packages/client-core/src/admin/components/Party/PartyTable.tsx
@@ -78,8 +78,8 @@ const PartyTable = (props: PartyPropsTable) => {
   const rows = adminPartyData.map((el) =>
     createData(
       el.id,
-      el.instance.ipAddress || <span className={classes.spanNone}>None</span>,
-      el.location.name || <span className={classes.spanNone}>None</span>
+      el.instance?.ipAddress || <span className={classes.spanNone}>None</span>,
+      el.location?.name || <span className={classes.spanNone}>None</span>
     )
   )
 

--- a/packages/client-core/src/admin/reducers/admin/bots/BotsService.ts
+++ b/packages/client-core/src/admin/reducers/admin/bots/BotsService.ts
@@ -1,11 +1,12 @@
 import { Dispatch } from 'redux'
 import { client } from '../../../../feathers'
 import { BotsAction } from './BotsActions'
-import { useBotState } from './BotsState'
+import { accessBotState } from './BotsState'
+import { accessAuthState } from '../../../../user/reducers/auth/AuthState'
 
 export const BotService = {
   createBotAsAdmin: (data: any) => {
-    ;async (dispatch: Dispatch): Promise<any> => {
+    return async (dispatch: Dispatch): Promise<any> => {
       try {
         const bot = await client.service('bot').create(data)
         dispatch(BotsAction.botCreated(bot))
@@ -15,12 +16,12 @@ export const BotService = {
     }
   },
   fetchBotAsAdmin: (incDec?: 'increment' | 'decrement') => {
-    ;async (dispatch: Dispatch, getState: any): Promise<any> => {
+    return async (dispatch: Dispatch, getState: any): Promise<any> => {
       try {
-        const user = getState().get('auth').user
-        const skip = useBotState().bots.skip.value
-        const limit = useBotState().bots.limit.value
-        if (user.userRole === 'admin') {
+        const user = accessAuthState().user
+        const skip = accessBotState().bots.skip.value
+        const limit = accessBotState().bots.limit.value
+        if (user.userRole.value === 'admin') {
           const bots = await client.service('bot').find({
             query: {
               $sort: {
@@ -39,7 +40,7 @@ export const BotService = {
     }
   },
   createBotCammand: (data: any) => {
-    ;async (dispatch: Dispatch): Promise<any> => {
+    return async (dispatch: Dispatch): Promise<any> => {
       try {
         const botCammand = await client.service('bot-command').create(data)
         dispatch(BotsAction.botCammandCreated(botCammand))
@@ -49,7 +50,7 @@ export const BotService = {
     }
   },
   removeBots: (id: string) => {
-    ;async (dispatch: Dispatch): Promise<any> => {
+    return async (dispatch: Dispatch): Promise<any> => {
       try {
         const bot = await client.service('bot').remove(id)
         dispatch(BotsAction.botRemoved(bot))
@@ -59,7 +60,7 @@ export const BotService = {
     }
   },
   removeBotsCommand: (id: string) => {
-    ;async (dispatch: Dispatch): Promise<any> => {
+    return async (dispatch: Dispatch): Promise<any> => {
       try {
         const result = await client.service('bot-command').remove(id)
         dispatch(BotsAction.botCommandRemoved(result))
@@ -69,7 +70,7 @@ export const BotService = {
     }
   },
   updateBotAsAdmin: (id: string, bot: any) => {
-    ;async (dispatch: Dispatch): Promise<any> => {
+    return async (dispatch: Dispatch): Promise<any> => {
       try {
         const result = await client.service('bot').patch(id, bot)
         dispatch(BotsAction.botPatched(result))

--- a/packages/client-core/src/admin/reducers/admin/bots/BotsState.ts
+++ b/packages/client-core/src/admin/reducers/admin/bots/BotsState.ts
@@ -45,6 +45,7 @@ export const botsReceptor = (action: BotsActionType): void => {
   state.batch((s) => {
     switch (action.type) {
       case 'BOT_ADMIN_DISPLAY':
+        result = action.bots
         s.merge({ error: '' })
         return s.merge({
           bots: { bots: result.data, retrieving: false, fetched: true, updateNeeded: false, lastFetched: new Date() }

--- a/packages/client-core/src/admin/reducers/admin/group/GroupService.ts
+++ b/packages/client-core/src/admin/reducers/admin/group/GroupService.ts
@@ -2,7 +2,7 @@ import { Dispatch } from 'redux'
 import { client } from '../../../../feathers'
 import { GroupAction } from './GroupActions'
 import { AlertService } from '../../../../common/reducers/alert/AlertService'
-import { useGroupState } from './GroupState'
+import { accessGroupState } from './GroupState'
 /**
  *
  * @param files FIle type
@@ -13,8 +13,8 @@ import { useGroupState } from './GroupState'
 export const GroupService = {
   getGroupService: (incDec?: 'increment' | 'decrement') => {
     return async (dispatch: Dispatch): Promise<any> => {
-      const skip = useGroupState().group.skip.value
-      const limit = useGroupState().group.limit.value
+      const skip = accessGroupState().group.skip.value
+      const limit = accessGroupState().group.limit.value
       try {
         dispatch(GroupAction.fetchingGroup())
         const list = await client.service('group').find({

--- a/packages/client-core/src/admin/reducers/admin/instance/service.ts
+++ b/packages/client-core/src/admin/reducers/admin/instance/service.ts
@@ -4,14 +4,15 @@ import { client } from '../../../../feathers'
 import { AlertService } from '../../../../common/reducers/alert/AlertService'
 import Store from '../../../../store'
 import { Config } from '@xrengine/common/src/config'
+import { accessAuthState } from '../../../../user/reducers/auth/AuthState'
 
 export function fetchAdminInstances(incDec?: 'increment' | 'decrement') {
   return async (dispatch: Dispatch, getState: any): Promise<any> => {
     const skip = getState().get('adminInstance').get('instances').get('skip')
     const limit = getState().get('adminInstance').get('instances').get('limit')
-    const user = getState().get('auth').user
+    const user = accessAuthState().user
     try {
-      if (user.userRole === 'admin') {
+      if (user.userRole.value === 'admin') {
         const instances = await client.service('instance').find({
           query: {
             $sort: {

--- a/packages/client-core/src/admin/reducers/admin/party/service.ts
+++ b/packages/client-core/src/admin/reducers/admin/party/service.ts
@@ -2,6 +2,7 @@ import { partyAdminCreated, partyRetrievedAction } from './actions'
 import { Dispatch } from 'redux'
 import { client } from '../../../../feathers'
 import { AlertService } from '../../../../common/reducers/alert/AlertService'
+import { accessAuthState } from '../../../../user/reducers/auth/AuthState'
 
 export const createAdminParty = (data) => {
   return async (dispatch: Dispatch): Promise<any> => {
@@ -17,11 +18,11 @@ export const createAdminParty = (data) => {
 
 export const fetchAdminParty = (incDec?: 'increment' | 'decrement') => {
   return async (dispatch: Dispatch, getState: any): Promise<any> => {
-    const user = getState().get('auth').user
+    const user = accessAuthState().user
     const skip = getState().get('adminParty').get('parties').get('skip')
     const limit = getState().get('adminParty').get('parties').get('limit')
     try {
-      if (user.userRole === 'admin') {
+      if (user.userRole.value === 'admin') {
         const parties = await client.service('party').find({
           query: {
             $sort: {

--- a/packages/client-core/src/admin/reducers/admin/service.ts
+++ b/packages/client-core/src/admin/reducers/admin/service.ts
@@ -6,11 +6,11 @@ import { Config } from '@xrengine/common/src/config'
 import { client } from '../../../feathers'
 import { AlertService } from '../../../common/reducers/alert/AlertService'
 import { PublicVideo, videosFetchedSuccess, videosFetchedError } from '../../../media/components/video/actions'
-import { useAuthState } from '@xrengine/client-core/src/user/reducers/auth/AuthState'
+import { accessAuthState } from '@xrengine/client-core/src/user/reducers/auth/AuthState'
 
 export function createVideo(data: VideoCreationForm) {
   return async (dispatch: Dispatch, getState: any) => {
-    const token = useAuthState().authUser.accessToken.value
+    const token = accessAuthState().authUser.accessToken.value
     try {
       const res = await axios.post(`${Config.publicRuntimeConfig.apiServer}/video`, data, {
         headers: {

--- a/packages/client-core/src/admin/reducers/admin/user/service.ts
+++ b/packages/client-core/src/admin/reducers/admin/user/service.ts
@@ -14,14 +14,15 @@ import {
 import { client } from '../../../../feathers'
 import { loadedUsers } from './actions'
 import { AlertService } from '../../../../common/reducers/alert/AlertService'
+import { accessAuthState } from '../../../../user/reducers/auth/AuthState'
 
 export function fetchUsersAsAdmin(incDec?: 'increment' | 'decrement') {
   return async (dispatch: Dispatch, getState: any): Promise<any> => {
-    const user = getState().get('auth').user
+    const user = accessAuthState().user
     const skip = getState().get('adminUser').get('users').get('skip')
     const limit = getState().get('adminUser').get('users').get('limit')
     try {
-      if (user.userRole === 'admin') {
+      if (user.userRole.value === 'admin') {
         const users = await client.service('user').find({
           query: {
             $sort: {

--- a/packages/client-core/src/social/reducers/chat/reducers.ts
+++ b/packages/client-core/src/social/reducers/chat/reducers.ts
@@ -28,7 +28,6 @@ import {
 } from '../actions'
 
 import { Message } from '@xrengine/common/src/interfaces/Message'
-import { Channel } from '@xrengine/common/src/interfaces/Channel'
 
 import _ from 'lodash'
 import moment from 'moment'

--- a/packages/client-core/src/social/reducers/chat/service.ts
+++ b/packages/client-core/src/social/reducers/chat/service.ts
@@ -15,7 +15,6 @@ import {
 } from './actions'
 import waitForClientAuthenticated from '../../../util/wait-for-client-authenticated'
 
-import { User } from '@xrengine/common/src/interfaces/User'
 import Store from '../../../store'
 import { AlertService } from '../../../common/reducers/alert/AlertService'
 
@@ -152,6 +151,22 @@ export function updateChatTarget(targetObjectType: string, targetObject: any) {
     dispatch(
       setChatTarget(targetObjectType, targetObject, targetChannelResult.total > 0 ? targetChannelResult.data[0].id : '')
     )
+  }
+}
+
+export function clearChatTargetIfCurrent(targetObjectType: string, targetObject: any) {
+  return async (dispatch: Dispatch): Promise<any> => {
+    const chatState = store.getState().get('chat')
+    const chatStateTargetObjectType = chatState.get('targetObjectType')
+    const chatStateTargetObjectId = chatState.get('targetObject').id
+    if (
+      targetObjectType === chatStateTargetObjectType &&
+      (targetObject.id === chatStateTargetObjectId ||
+        targetObject.relatedUserId === chatStateTargetObjectId ||
+        targetObject.userId === chatStateTargetObjectId)
+    ) {
+      dispatch(setChatTarget('', {}, ''))
+    }
   }
 }
 

--- a/packages/client-core/src/social/reducers/location/service.ts
+++ b/packages/client-core/src/social/reducers/location/service.ts
@@ -8,10 +8,12 @@ import {
   socialLocationBanCreated,
   socialLocationNotFound
 } from './actions'
+import waitForClientAuthenticated from '../../../util/wait-for-client-authenticated'
 
 export function getLocations(skip?: number, limit?: number) {
   return async (dispatch: Dispatch, getState: any): Promise<any> => {
     try {
+      await waitForClientAuthenticated()
       const locationResults = await client.service('location').find({
         query: {
           $limit: limit != null ? limit : getState().get('locations').get('limit'),

--- a/packages/client-core/src/social/reducers/party/service.ts
+++ b/packages/client-core/src/social/reducers/party/service.ts
@@ -18,7 +18,8 @@ import { Config } from '@xrengine/common/src/config'
 import { AlertService } from '../../../common/reducers/alert/AlertService'
 import Store from '../../../store'
 import { UserAction } from '../../../user/store/UserAction'
-import { useAuthState } from '../../../user/reducers/auth/AuthState'
+import { accessAuthState } from '../../../user/reducers/auth/AuthState'
+import { clearChatTargetIfCurrent } from '../chat/service'
 
 const store = Store.store
 
@@ -40,7 +41,7 @@ let socketId: any
 export const getParties = async (): Promise<void> => {
   const parties = await client.service('party').find()
   console.log('PARTIES', parties)
-  const userId = useAuthState().user.id.value
+  const userId = accessAuthState().user.id.value
   console.log('USERID: ', userId)
   if ((client as any).io && socketId === undefined) {
     ;(client as any).io.emit('request-user-id', ({ id }: { id: number }) => {
@@ -137,7 +138,7 @@ export function transferPartyOwner(partyUserId: string) {
 
 if (!Config.publicRuntimeConfig.offlineMode) {
   client.service('party-user').on('created', async (params) => {
-    const selfUser = useAuthState().user
+    const selfUser = accessAuthState().user
     if ((store.getState() as any).get('party').get('party') == null) {
       store.dispatch(createdParty(params))
     }
@@ -162,7 +163,7 @@ if (!Config.publicRuntimeConfig.offlineMode) {
 
   client.service('party-user').on('patched', (params) => {
     const updatedPartyUser = params.partyUser
-    const selfUser = useAuthState().user
+    const selfUser = accessAuthState().user
     store.dispatch(patchedPartyUser(updatedPartyUser))
     if (
       updatedPartyUser.user.channelInstanceId != null &&
@@ -175,17 +176,11 @@ if (!Config.publicRuntimeConfig.offlineMode) {
 
   client.service('party-user').on('removed', (params) => {
     const deletedPartyUser = params.partyUser
-    const selfUser = useAuthState().user
+    const selfUser = accessAuthState().user
     store.dispatch(removedPartyUser(deletedPartyUser))
-    if (
-      deletedPartyUser.user.channelInstanceId != null &&
-      deletedPartyUser.user.channelInstanceId === selfUser.channelInstanceId.value
-    )
-      store.dispatch(UserAction.addedChannelLayerUser(deletedPartyUser.user))
-    if (deletedPartyUser.user.channelInstanceId !== selfUser.channelInstanceId.value)
-      store.dispatch(UserAction.removedChannelLayerUser(deletedPartyUser.user))
+    store.dispatch(UserAction.removedChannelLayerUser(deletedPartyUser.user))
     if (params.partyUser.userId === selfUser.id) {
-      console.log('Attempting to end video call')
+      store.dispatch(clearChatTargetIfCurrent('party', { id: params.partyUser.partyId }))
       // TODO: Reenable me!
       // endVideoChat({ leftParty: true });
     }
@@ -197,6 +192,7 @@ if (!Config.publicRuntimeConfig.offlineMode) {
 
   client.service('party').on('patched', (params) => {
     store.dispatch(patchedParty(params.party))
+    store.dispatch(clearChatTargetIfCurrent('party', params.party))
   })
 
   client.service('party').on('removed', (params) => {

--- a/packages/client/src/components/Drawer/Left/index.tsx
+++ b/packages/client/src/components/Drawer/Left/index.tsx
@@ -206,7 +206,7 @@ const LeftDrawer = (props: Props): any => {
       if (friendState.get('updateNeeded') === true && friendState.get('getFriendsInProgress') !== true) {
         getFriends(0)
       }
-      if (friendState.get('closeDetails') === selectedUser.id) {
+      if (selectedUser.id?.length > 0 && friendState.get('closeDetails') === selectedUser.id) {
         closeDetails()
         friendState.set('closeDetails', '')
       }
@@ -216,7 +216,7 @@ const LeftDrawer = (props: Props): any => {
       if (groupState.get('updateNeeded') === true && groupState.get('getGroupsInProgress') !== true) {
         getGroups(0)
       }
-      if (groupState.get('closeDetails') === selectedGroup.id) {
+      if (selectedGroup?.id.length > 0 && groupState.get('closeDetails') === selectedGroup.id) {
         closeDetails()
         groupState.set('closeDetails', '')
       }

--- a/packages/client/src/components/Harmony/Layout.tsx
+++ b/packages/client/src/components/Harmony/Layout.tsx
@@ -119,30 +119,33 @@ const Layout = (props: Props): any => {
           <Alerts />
           {childrenWithProps}
         </Fragment>
-        {authUser?.accessToken?.value != null && authUser.accessToken.value.length > 0 && user?.id?.value != null && (
-          <Fragment>
-            <LeftDrawer
-              harmony={true}
-              detailsType={detailsType}
-              setDetailsType={setDetailsType}
-              groupFormOpen={groupFormOpen}
-              setGroupFormOpen={setGroupFormOpen}
-              groupFormMode={groupFormMode}
-              setGroupFormMode={setGroupFormMode}
-              groupForm={groupForm}
-              setGroupForm={setGroupForm}
-              selectedUser={selectedUser}
-              setSelectedUser={setSelectedUser}
-              selectedGroup={selectedGroup}
-              setSelectedGroup={setSelectedGroup}
-              openBottomDrawer={bottomDrawerOpen}
-              leftDrawerOpen={leftDrawerOpen}
-              setLeftDrawerOpen={setLeftDrawerOpen}
-              setRightDrawerOpen={setRightDrawerOpen}
-              setBottomDrawerOpen={setBottomDrawerOpen}
-            />
-          </Fragment>
-        )}
+        {authUser?.accessToken?.value != null &&
+          authUser.accessToken.value.length > 0 &&
+          user?.id?.value != null &&
+          user.id.value.length > 0 && (
+            <Fragment>
+              <LeftDrawer
+                harmony={true}
+                detailsType={detailsType}
+                setDetailsType={setDetailsType}
+                groupFormOpen={groupFormOpen}
+                setGroupFormOpen={setGroupFormOpen}
+                groupFormMode={groupFormMode}
+                setGroupFormMode={setGroupFormMode}
+                groupForm={groupForm}
+                setGroupForm={setGroupForm}
+                selectedUser={selectedUser}
+                setSelectedUser={setSelectedUser}
+                selectedGroup={selectedGroup}
+                setSelectedGroup={setSelectedGroup}
+                openBottomDrawer={bottomDrawerOpen}
+                leftDrawerOpen={leftDrawerOpen}
+                setLeftDrawerOpen={setLeftDrawerOpen}
+                setRightDrawerOpen={setRightDrawerOpen}
+                setBottomDrawerOpen={setBottomDrawerOpen}
+              />
+            </Fragment>
+          )}
         {authUser?.accessToken.value != null && authUser.accessToken.value.length > 0 && user?.id.value != null && (
           <Fragment>
             <RightDrawer rightDrawerOpen={rightDrawerOpen} setRightDrawerOpen={setRightDrawerOpen} />

--- a/packages/gallery/src/reducers/post/service.ts
+++ b/packages/gallery/src/reducers/post/service.ts
@@ -6,7 +6,7 @@ import { Dispatch } from 'redux'
 import { AlertService } from '@xrengine/client-core/src/common/reducers/alert/AlertService'
 import { client } from '@xrengine/client-core/src/feathers'
 import { upload } from '@xrengine/engine/src/scene/functions/upload'
-import { useAuthState } from '@xrengine/client-core/src/user/reducers/auth/AuthState'
+import { accessAuthState } from '@xrengine/client-core/src/user/reducers/auth/AuthState'
 import {
   fetchingFeeds,
   feedsRetrieved,
@@ -82,7 +82,7 @@ export function getFeeds(type: string, id?: string, limit?: number) {
         })
         dispatch(feedsMyFeaturedRetrieved(feedsResults.data))
       } else if (type && type === 'admin') {
-        const user = useAuthState().user
+        const user = accessAuthState().user
         if (user?.userRole?.value === 'admin') {
           dispatch(fetchingAdminFeeds())
           const feedsResults = await client.service('feed').find({

--- a/packages/server-core/src/social/channel/channel.service.ts
+++ b/packages/server-core/src/social/channel/channel.service.ts
@@ -66,7 +66,7 @@ export default (app: Application): any => {
         // if (user2AvatarResult.total > 0) {
         //   data.user2.dataValues.avatarUrl = user2AvatarResult.data[0].url;
         // }
-        targetIds = [data.userId1, data.userId2]
+        targetIds = []
       } else if (data.channelType === 'group') {
         if (data.group == null) {
           data.group = await (app.service('group') as any).Model.findOne({

--- a/packages/social/src/reducers/feed/service.ts
+++ b/packages/social/src/reducers/feed/service.ts
@@ -6,7 +6,7 @@ import { AlertService } from '@xrengine/client-core/src/common/reducers/alert/Al
 import { client } from '@xrengine/client-core/src/feathers'
 import { upload } from '@xrengine/engine/src/scene/functions/upload'
 
-import { useAuthState } from '@xrengine/client-core/src/user/reducers/auth/AuthState'
+import { accessAuthState } from '@xrengine/client-core/src/user/reducers/auth/AuthState'
 
 import {
   fetchingFeeds,
@@ -83,7 +83,7 @@ export function getFeeds(type: string, id?: string, limit?: number) {
         })
         dispatch(feedsMyFeaturedRetrieved(feedsResults.data))
       } else if (type && type === 'admin') {
-        const user = useAuthState().user
+        const user = accessAuthState().user
         if (user.userRole.value === 'admin') {
           dispatch(fetchingAdminFeeds())
           const feedsResults = await client.service('feed').find({


### PR DESCRIPTION
Replaced all instances of useAuthState in .ts files with accessAuthState.
Replaced some earlier reversions of useAuthState -> getState() with
accessAuthState.

Fixed some issues with chats not being cleared when their associated entity is no
longer accessible to the user, e.g. a user is removed from a group or a friend
relationship is terminated. Added a new function `clearChatTargetIfCurrent` to
chat service.ts.

Some API calls were being made before doLoginAuto had run. Added waitForClientAuthenticated()
to them so that they don't occur until the client has credentials.

Made user channels not target anyone for created updates, since that only occurs when one
user sends a friend request to another. No one should see this channel until the request
has been accepted.

Updated sendInvite() in invite service to check if there's already a matching invite, and
to not send another if there is one.

Removed some .on('removed') copypasta that was adding channel layer users when someone left
a group/party/friendship.