### PR TITLE
Vastly increased GS socket timeout locally.

### DIFF
--- a/packages/gameserver/src/NetworkFunctions.ts
+++ b/packages/gameserver/src/NetworkFunctions.ts
@@ -129,7 +129,7 @@ export async function validateNetworkObjects(): Promise<void> {
   const world = Engine.defaultWorld!
   for (const [userId, client] of world.clients) {
     // Validate that user has phoned home recently
-    if (Date.now() - client.lastSeenTs > 30000) {
+    if (process.env.NODE_ENV !== 'development' && Date.now() - client.lastSeenTs > 30000) {
       console.log('Removing client ', userId, ' due to inactivity')
       if (!client) return console.warn('Client is not in client list')
 

--- a/packages/gameserver/src/app.ts
+++ b/packages/gameserver/src/app.ts
@@ -86,6 +86,7 @@ export const createApp = (): Application => {
         socketio(
           {
             serveClient: false,
+            pingTimeout: process.env.NODE_ENV === 'development' ? 1200000 : 20000,
             cors: {
               origin: [
                 'https://' + config.gameserver.clientHost,


### PR DESCRIPTION
GS doesn't check for idle clients and server socket.io has pingTimeout of
20 minutes when process.env.NODE_ENV is 'development'.