### PR TITLE
Fixed issue with gameserver active user count not updating.

### DIFF
--- a/packages/gameserver/src/channels.ts
+++ b/packages/gameserver/src/channels.ts
@@ -326,16 +326,17 @@ export default (app: Application): void => {
 
             if (instanceId != null && instance != null) {
               const activeUsers = Engine.defaultWorld.clients
+              const activeUsersCount = activeUsers.length || activeUsers.size
               try {
                 await app.service('instance').patch(instanceId, {
-                  currentUsers: activeUsers.length
+                  currentUsers: activeUsersCount
                 })
               } catch (err) {
                 console.log('Failed to patch instance user count, likely because it was destroyed')
               }
 
               const user = await app.service('user').get(userId)
-              const instanceIdKey = app.isChannelInstance === true ? 'channelInstanceId' : 'instanceId'
+              const instanceIdKey = app.isChannelInstance ? 'channelInstanceId' : 'instanceId'
               if (
                 (Engine.defaultWorld.clients.has(userId) && config.kubernetes.enabled) ||
                 process.env.NODE_ENV === 'development'
@@ -375,7 +376,7 @@ export default (app: Application): void => {
 
               app.channel(`instanceIds/${instanceId as string}`).leave(connection)
 
-              if (activeUsers.length < 1) {
+              if (activeUsersCount < 1) {
                 console.log('Deleting instance ' + instanceId)
                 try {
                   await app.service('instance').patch(instanceId, {


### PR DESCRIPTION
Client disconnect handler was checking Engine.defaultWorld.client.length to determine number of active
users. Not sure when clients was made a Map, but one needs to do <Map>.size to get the number of entries
rather than <Map>.length, which returns undefined.