### PR TITLE
Improved Github actions and standardized scripts.

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -6,7 +6,21 @@ on:
       - master
       - 'version-increment-*'
 jobs:
+  secrets-gate:
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.check-secrets.outputs.ok }}
+    steps:
+      - name: check for secrets needed to run workflows
+        id: check-secrets
+        run: |
+          if [ ${{ secrets.BRANCH_BUILD_ENABLED }} == 'true' ]; then
+            echo "::set-output name=ok::enabled"
+          fi
   compile-codebase:
+    needs:
+      - secrets-gate
+    if: ${{ needs.secrets-gate.outputs.ok == 'enabled' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -28,7 +28,7 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Build Docker Image
-        run: bash scripts/build_docker_builder.sh dev $DOCKER_LABEL
+        run: bash scripts/build_docker_builder.sh dev $DOCKER_LABEL $PRIVATE_ECR $AWS_REGION
         env:
           DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
           REPO_NAME: ${{ secrets.DEV_REPO_NAME }}
@@ -37,7 +37,7 @@ jobs:
       - name: npm-install 'cli' and 'aws-sdk'
         run: npm install cli aws-sdk
       - name: Publish to Elastic Container Registry
-        run: bash scripts/publish_ecr_builder.sh dev $GITHUB_SHA $DOCKER_LABEL $AWS_REGION
+        run: bash scripts/publish_ecr_builder.sh dev $GITHUB_SHA $DOCKER_LABEL $PRIVATE_ECR $AWS_REGION
         env:
           DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
           REPO_NAME: ${{ secrets.DEV_REPO_NAME }}
@@ -50,7 +50,7 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
       - name: Job succeeded
-        if: always()
+        if: ${{ secrets.SEND_FINISHED_WEBHOOK }} === "true"
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6 # Not needed with a .ruby-version file

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,6 +7,17 @@ on:
     branches: [dev]
 
 jobs:
+  secrets-gate:
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.check-secrets.outputs.ok }}
+    steps:
+      - name: check for secrets needed to run workflows
+        id: check-secrets
+        run: |
+          if [ ${{ secrets.DOCUMENTATION_BUILD_ENABLED }} == 'true' ]; then
+            echo "::set-output name=ok::enabled"
+          fi
   # checks:
   #   if: github.event_name != 'push'
   #   runs-on: ubuntu-latest
@@ -24,7 +35,9 @@ jobs:
   #         npm install --production=false --legacy-peer-deps
   #         npm run build
   gh-release:
-    if: github.event_name != 'pull_request'
+    needs:
+      - secrets-gate
+    if: ${{ needs.secrets-gate.outputs.ok == 'enabled' }} && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -28,7 +28,7 @@ jobs:
           sudo rm -rf "/usr/local/share/boost"
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Build Docker Image
-        run: bash scripts/build_docker_builder.sh prod $DOCKER_LABEL
+        run: bash scripts/build_docker_builder.sh prod $DOCKER_LABEL $PRIVATE_ECR $AWS_REGION
         env:
           DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
           REPO_NAME: ${{ secrets.PROD_REPO_NAME }}
@@ -37,7 +37,7 @@ jobs:
       - name: npm-install 'cli' and 'aws-sdk'
         run: npm install cli aws-sdk
       - name: Publish to Elastic Container Registry
-        run: bash scripts/publish_ecr_builder.sh prod $GITHUB_SHA $DOCKER_LABEL $AWS_REGION
+        run: bash scripts/publish_ecr_builder.sh prod $GITHUB_SHA $DOCKER_LABEL $PRIVATE_ECR $AWS_REGION
         env:
           DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
           REPO_NAME: ${{ secrets.PROD_REPO_NAME }}
@@ -50,7 +50,7 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
       - name: Job succeeded
-        if: always()
+        if: ${{ secrets.SEND_FINISHED_WEBHOOK }} === "true"
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6 # Not needed with a .ruby-version file

--- a/.github/workflows/publish-gh-container.yml
+++ b/.github/workflows/publish-gh-container.yml
@@ -3,7 +3,21 @@ on:
   release:
     types: [created]
 jobs:
+  secrets-gate:
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.check-secrets.outputs.ok }}
+    steps:
+      - name: check for secrets needed to run workflows
+        id: check-secrets
+        run: |
+          if [ ${{ secrets.PUBLISH_GH_CONTAINER_ENABLED }} == 'true' ]; then
+            echo "::set-output name=ok::enabled"
+          fi
   dev-deploy:
+    needs:
+      - secrets-gate
+    if: ${{ needs.secrets-gate.outputs.ok == 'enabled' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,7 +33,7 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           CLUSTER_NAME: ${{ secrets.CLUSTER_NAME }}
       - name: Build Docker Image
-        run: bash scripts/build_docker.sh dev $DOCKER_LABEL $AWS_REGION
+        run: bash scripts/build_docker.sh dev $DOCKER_LABEL $PRIVATE_ECR $AWS_REGION
         env:
           DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
           REPO_NAME: ${{ secrets.DEV_REPO_NAME }}

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -5,7 +5,21 @@ on:
     types: [created]
 
 jobs:
+  secrets-gate:
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.check-secrets.outputs.ok }}
+    steps:
+      - name: check for secrets needed to run workflows
+        id: check-secrets
+        run: |
+          if [ ${{ secrets.PUBLISH_NPM_PACKAGES_ENABLED }} == 'true' ]; then
+            echo "::set-output name=ok::enabled"
+          fi
   publish-npm:
+    needs:
+      - secrets-gate
+    if: ${{ needs.secrets-gate.outputs.ok == 'enabled' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/update-deps-branch.yml
+++ b/.github/workflows/update-deps-branch.yml
@@ -4,7 +4,21 @@ on:
     branches:
       [dev]
 jobs:
+  secrets-gate:
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.check-secrets.outputs.ok }}
+    steps:
+      - name: check for secrets needed to run workflows
+        id: check-secrets
+        run: |
+          if [ ${{ secrets.UPDATE_DEPS_BRANCH_ENABLED }} == 'true' ]; then
+            echo "::set-output name=ok::enabled"
+          fi
   update-deps-branch:
+    needs:
+      - secrets-gate
+    if: ${{ needs.secrets-gate.outputs.ok == 'enabled' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/scripts/publish_ecr.sh
+++ b/scripts/publish_ecr.sh
@@ -5,16 +5,16 @@ set -x
 STAGE=$1
 TAG=$2
 LABEL=$3
-REGION=$4
-PRIVATE_ECR=$5
+PRIVATE_ECR=$4
+REGION=$5
 
 if [ $PRIVATE_ECR == "true" ]
 then
   aws ecr get-login-password --region $REGION | docker login -u AWS --password-stdin $ECR_URL
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME --region us-east-1 --public false
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME --region $REGION --public false
 else
   aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $ECR_URL
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME --region $REGION --public true
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME --region us-east-1 --public true
 fi
 
 docker tag $LABEL $ECR_URL/$REPO_NAME:$TAG

--- a/scripts/publish_ecr_builder.sh
+++ b/scripts/publish_ecr_builder.sh
@@ -5,16 +5,16 @@ set -x
 STAGE=$1
 TAG=$2
 LABEL=$3
-REGION=$4
-PRIVATE_ECR=$5
+PRIVATE_ECR=$4
+REGION=$5
 
 if [ $PRIVATE_ECR == "true" ]
 then
   aws ecr get-login-password --region $REGION | docker login -u AWS --password-stdin $ECR_URL
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-builder --region us-east-1 --public false
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-builder --region $REGION --public false
 else
   aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $ECR_URL
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-builder --region $REGION --public true
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-builder --region us-east-1 --public true
 fi
 
 docker tag $LABEL $ECR_URL/$REPO_NAME-builder:$TAG

--- a/scripts/run-builder.sh
+++ b/scripts/run-builder.sh
@@ -14,9 +14,9 @@ touch ./builder-started.txt
 bash ./scripts/setup_helm.sh
 bash ./scripts/setup_aws.sh $AWS_ACCESS_KEY $AWS_SECRET $AWS_REGION $CLUSTER_NAME
 npm run install-projects
-bash ./scripts/build_docker.sh $RELEASE_NAME $DOCKER_LABEL
+bash ./scripts/build_docker.sh $RELEASE_NAME $DOCKER_LABEL $PRIVATE_ECR $AWS_REGION
 npm install -g cli aws-sdk
-bash ./scripts/publish_ecr.sh $RELEASE_NAME ${TAG}__${START_TIME} $DOCKER_LABEL $AWS_REGION
+bash ./scripts/publish_ecr.sh $RELEASE_NAME ${TAG}__${START_TIME} $DOCKER_LABEL $PRIVATE_ECR $AWS_REGION
 bash ./scripts/deploy.sh $RELEASE_NAME ${TAG}__${START_TIME}
 DEPLOY_TIME=`date +"%d-%m-%yT%H-%M-%S"`
 bash ./scripts/publish_dockerhub.sh ${TAG}__${START_TIME} $DOCKER_LABEL


### PR DESCRIPTION
Made some changes so that forks can work without having to have
a commit at the head to change which/how GH actions run:

* Made all Github actions other than dev/prod-deploy disabled unless an
associated variable is set as a secret.

* Standardized order of PRIVATE_ECR and AWS_REGION between publish_ecr[_builder].sh
and build_docker[_builder].sh. Previous swapped order was confusing.

* Made deploy scripts and run-builder.sh always call build_docker[_builder].sh and
publish_ecr[_builder].sh with variables $PRIVATE_ECR and $AWS_REGION. If the fork is
using a private ECR repo, they should set this variable as a secret for the action to 'true',
and have the same variable set to 'true' in the builder Helm config. If the fork is using a
public ECR repo, then this doesn't need to be set at all in either place.

* Fixed incorrect usage of $AWS_REGION in publis_ecr[_builder].sh.