### PR TITLE
Updated client to allow configuration of title and assets.

### DIFF
--- a/packages/client/config/default.json
+++ b/packages/client/config/default.json
@@ -1,6 +1,11 @@
 {
   "publicRuntimeConfig": {
-    "title": "The Overlay",
+    "title": "XREngine",
+    "favicon32px": "/favicon-32x32.png",
+    "favicon16px": "/favicon-16x16.png",
+    "icon192px": "https://xrengine-static-resources.s3.us-west-1.amazonaws.com/test/guinea-pig.jpg",
+    "icon512px": "https://xrengine-static-resources.s3.us-west-1.amazonaws.com/test/guinea-pig.jpg",
+    "webmanifestLink": "/site.webmanifest",
     "siteTitle": "The Overlay",
     "siteDescription": "Connected Worlds for Everyone",
     "dev": false,

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -9,14 +9,14 @@
   <!-- PWA primary color -->
   <meta name="theme-color" content={theme.palette.primary.main} />
   <meta name="description" content="Connected Worlds for Everyone" />
-  <title>XREngine</title>
+  <title><%- title %></title>
 
   <link rel="stylesheet"
     href="https://fonts.googleapis.com/css?family=Lato:300,400,700|PT+Sans:400,400italic,700,700italic|Quicksand:400,300|Raleway:400|Roboto:300,400,700|Source+Sans+Pro:300,400,700" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="<%- appleTouchIcon %>" />
+  <link rel="icon" type="image/png" sizes="32x32" href="<%- favicon32px %>" />
+  <link rel="icon" type="image/png" sizes="16x16" href="<%- favicon16px %>" />
+  <link rel="manifest" href="<%- webmanifestLink %>" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Khula:wght@700&display=swap" rel="stylesheet">

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -90,6 +90,7 @@
     "styled-components": "5.3.3",
     "three": "0.133.1",
     "uuid": "8.3.2",
+    "vite-plugin-html": "^2.1.1",
     "webxr-native": "0.3.0"
   },
   "devDependencies": {

--- a/packages/client/public/site.webmanifest
+++ b/packages/client/public/site.webmanifest
@@ -1,1 +1,19 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "",
+  "short_name": "",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/packages/client/scripts/generate-env-config.js
+++ b/packages/client/scripts/generate-env-config.js
@@ -1,5 +1,6 @@
-const fs = require('fs').promises;
-const FindFiles = require('file-regex');
+const fs = require('fs').promises
+const FindFiles = require('file-regex')
+const mimeType = require('mime-types');
 
 (async () => {
     try {
@@ -7,6 +8,35 @@ const FindFiles = require('file-regex');
         const output = 'export default()=>{window.env = ' + (nodeConfig || JSON.stringify({publicRuntimeConfig: {}})) + '}';
         const fileMatch = await FindFiles('../dist/assets', /env-config/);
         await fs.writeFile('../dist/assets/' + fileMatch[0].file, output);
+        const manifestMatch = await FindFiles('../public', /site\.webmanifest/)
+        const manifestContents = await fs.readFile('../public/' + manifestMatch[0].file)
+        const jsonManifest = JSON.parse(manifestContents.toString())
+        if (nodeConfig && nodeConfig.publicRuntimeConfig && jsonManifest.icons) {
+            if (nodeConfig.publicRuntimeConfig.icon192px) {
+                const icon192 = jsonManifest.icons.find(icon => icon.sizes === '192x192')
+                if (icon192) {
+                    icon192.src = nodeConfig.publicRuntimeConfig.icon192px
+                    icon192.type = mimeType.lookup(nodeConfig.publicRuntimeConfig.icon192px)
+                } else jsonManifest.icons.push({
+                    src: nodeConfig.publicRuntimeConfig.icon192px,
+                    sizes: '192x192',
+                    type: mimeType.lookup(nodeConfig.publicRuntimeConfig.icon192px)
+                })
+            }
+            if (nodeConfig.publicRuntimeConfig.icon512px) {
+                const icon512 = jsonManifest.icons.find(icon => icon.sizes === '512x512')
+                if (icon512) {
+                    icon512.src = nodeConfig.publicRuntimeConfig.icon512px
+                    icon512.type = mimeType.lookup(nodeConfig.publicRuntimeConfig.icon512px)
+                } else jsonManifest.icons.push({
+                    src: nodeConfig.publicRuntimeConfig.icon512px,
+                    sizes: '512x512',
+                    type: mimeType.lookup(nodeConfig.publicRuntimeConfig.icon512px)
+                })
+            }
+        }
+        console.log('new jsonManifest', jsonManifest)
+        await fs.writeFile('../dist/' + manifestMatch[0].file, JSON.stringify(jsonManifest))
     } catch(err) {
         console.log('error in generate-env-config.js');
         console.log(err);

--- a/packages/client/vite.config.js
+++ b/packages/client/vite.config.js
@@ -6,6 +6,7 @@ import config from "config"
 import inject from '@rollup/plugin-inject'
 import OptimizationPersist from './scripts/viteoptimizeplugin'
 import PkgConfig from 'vite-plugin-package-config'
+import { injectHtml } from 'vite-plugin-html'
 
 const copyProjectDependencies = () => {
   const projects = fs
@@ -91,7 +92,18 @@ export default defineConfig((command) => {
     },
     plugins: [
       PkgConfig(),
-      OptimizationPersist()
+      OptimizationPersist(),
+        injectHtml({
+          data: {
+            title: runtime.title || 'XRENGINE',
+            appleTouchIcon: runtime.appleTouchIcon || '/apple-touch-icon.png',
+            favicon32px: runtime.favicon32px || '/favicon-32x32.png',
+            favicon16px: runtime.favicon16px || '/favicon-16x16.png',
+            icon192px: runtime.icon192px || '/android-chrome-192x192.png',
+            icon512px: runtime.icon512px || '/android-chrome-512x512.png',
+            webmanifestLink: runtime.webmanifestLink || '/site.webmanifest'
+          }
+        })
     ],
     server: {
       host: true,


### PR DESCRIPTION
Client index.html had been hard-coded to have the title 'XREngine' and to use
the XREngine favicons included in the /client/public folder. Installed vite-plugin-html
to allow for injecting variables into index.html, and used this to make title and favicons
configurable.

Updated generate-env-config.js to update site.webmanifest's icons with configured icons.