### PR TITLE
Fixed some more bugs with video chat.

### DIFF
--- a/packages/client-core/src/common/services/ChannelConnectionService.ts
+++ b/packages/client-core/src/common/services/ChannelConnectionService.ts
@@ -62,7 +62,7 @@ store.receptors.push((action: ChannelConnectionActionType): any => {
         return s.merge({ connected: true, instanceServerConnecting: false, updateNeeded: false, readyToConnect: false })
       case 'CHANNEL_SERVER_DISCONNECTED':
         if (connectionSocket != null) (connectionSocket as any).close()
-        return
+        return s.merge({ connected: false, instanceProvisioned: false })
       case 'SOCKET_CREATED':
         if (connectionSocket != null) (connectionSocket as any).close()
         connectionSocket = action.socket

--- a/packages/client-core/src/social/services/ChatService.ts
+++ b/packages/client-core/src/social/services/ChatService.ts
@@ -156,7 +156,7 @@ store.receptors.push((action: ChatActionType) => {
         const channel = s.channels.channels.find((c) => c.id.value === channelId)
 
         if (channel) {
-          channel.set(action.channel)
+          channel.merge(action.channel)
         } else {
           s.channels.channels[s.channels.channels.length].set(action.channel)
         }
@@ -169,7 +169,7 @@ store.receptors.push((action: ChatActionType) => {
         const channel = s.channels.channels.find((c) => c.id.value === channelId)
 
         if (channel) {
-          channel.set(action.channel)
+          channel.merge(action.channel)
         } else {
           s.channels.channels[s.channels.channels.length].set(action.channel)
         }

--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -227,7 +227,7 @@ export async function configureMediaTransports(
     }
   }
 
-  //This probably isn't needed anymore with chanenls handling all audio and video, but left it in and commented
+  //This probably isn't needed anymore with channels handling all audio and video, but left it in and commented
   //just in case.
   // if (
   //   networkTransport.channelSendTransport == null ||

--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -1032,7 +1032,7 @@ if (!Config.publicRuntimeConfig.offlineMode) {
     }
 
     if (selfUser.id.value === user.id) {
-      store.dispatch(UserAction.clearLayerUsers())
+      if (selfUser.instanceId.value !== user.instanceId) store.dispatch(UserAction.clearLayerUsers())
       if (selfUser.channelInstanceId.value !== user.channelInstanceId)
         store.dispatch(UserAction.clearChannelLayerUsers())
       store.dispatch(AuthAction.userUpdated(user))

--- a/packages/client-core/src/user/services/UserService.ts
+++ b/packages/client-core/src/user/services/UserService.ts
@@ -36,11 +36,10 @@ store.receptors.push((action: UserActionType): void => {
           return layerUser != null && layerUser.id.value === newUser.id
         })
         if (idx === -1) {
-          s.layerUsers.merge([newUser])
+          return s.layerUsers.merge([newUser])
         } else {
-          s.layerUsers[idx].set(newUser)
+          return s.layerUsers[idx].set(newUser)
         }
-        return s.layerUsersUpdateNeeded.set(true)
       }
       case 'REMOVED_LAYER_USER': {
         const layerUsers = s.layerUsers
@@ -65,11 +64,10 @@ store.receptors.push((action: UserActionType): void => {
           return layerUser != null && layerUser.value.id === newUser.id
         })
         if (idx === -1) {
-          s.channelLayerUsers.merge([newUser])
+          return s.channelLayerUsers.merge([newUser])
         } else {
-          s.channelLayerUsers[idx].set(newUser)
+          return s.channelLayerUsers[idx].set(newUser)
         }
-        return s.channelLayerUsersUpdateNeeded.set(true)
       }
       case 'REMOVED_CHANNEL_LAYER_USER':
         const newUser = action.user

--- a/packages/client/src/components/Drawer/Bottom/index.tsx
+++ b/packages/client/src/components/Drawer/Bottom/index.tsx
@@ -292,8 +292,8 @@ const BottomDrawer = (props: Props): any => {
           <div className={styles['list-container']}>
             <List ref={messageRef as any} onScroll={(e) => onMessageScroll(e)} className={styles['message-container']}>
               {activeChannel != null &&
-                activeChannel.Messages.value &&
-                [...activeChannel.Messages.value]
+                activeChannel.messages.value &&
+                [...activeChannel.messages.value]
                   .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
                   .map((message) => {
                     return (

--- a/packages/client/src/components/Drawer/Left/index.tsx
+++ b/packages/client/src/components/Drawer/Left/index.tsx
@@ -147,13 +147,6 @@ const LeftDrawer = (props: Props): any => {
       }
     }, [partyState.updateNeeded.value])
 
-    useEffect(() => {
-      if (user.instanceId.value != null && userState.layerUsersUpdateNeeded.value === true)
-        UserService.getLayerUsers(true)
-      if (user.channelInstanceId.value != null && userState.channelLayerUsersUpdateNeeded.value === true)
-        UserService.getLayerUsers(false)
-    }, [user, userState.layerUsersUpdateNeeded.value, userState.channelLayerUsersUpdateNeeded.value])
-
     const showFriendDeleteConfirm = (e, friendId) => {
       e.preventDefault()
       setFriendDeletePending(friendId)

--- a/packages/client/src/components/Harmony/index.tsx
+++ b/packages/client/src/components/Harmony/index.tsx
@@ -214,7 +214,7 @@ const Harmony = (props: Props): any => {
   const transportState = useTransportStreamState()
   const producerStartingRef = useRef(producerStarting)
   const activeAVChannelIdRef = useRef(activeAVChannelId)
-  const instanceChannelRef = useRef(null)
+  const instanceChannelRef = useRef('')
   const channelRef = useRef(channels)
   const harmonyHiddenRef = useRef(harmonyHidden)
   const callStartedFromButtonRef = useRef(callStartedFromButton)
@@ -230,8 +230,8 @@ const Harmony = (props: Props): any => {
       : currentLocation?.locationSettings?.value
       ? currentLocation?.locationSettings?.videoEnabled?.value
       : false
-  const isCamVideoEnabled = mediastream.isCamVideoEnabled
-  const isCamAudioEnabled = mediastream.isCamAudioEnabled
+  const isCamVideoEnabled = mediastream.isCamVideoEnabled.value
+  const isCamAudioEnabled = mediastream.isCamAudioEnabled.value
 
   useEffect(() => {
     navigator.mediaDevices
@@ -262,7 +262,7 @@ const Harmony = (props: Props): any => {
     )
 
     EngineEvents.instance.addEventListener(SocketWebRTCClientTransport.EVENTS.CHANNEL_DISCONNECTED, () => {
-      if (activeAVChannelIdRef.current.length > 0) setChannelDisconnected(true)
+      if (activeAVChannelIdRef.current?.length > 0) setChannelDisconnected(true)
     })
     EngineEvents.instance.addEventListener(SocketWebRTCClientTransport.EVENTS.CHANNEL_RECONNECTED, async () => {
       setChannelAwaitingProvision({
@@ -296,26 +296,34 @@ const Harmony = (props: Props): any => {
   }, [])
 
   useEffect(() => {
-    if (selfUser?.instanceId != null && MediaStreams.instance.channelType === 'instance') {
+    if (
+      selfUser?.instanceId != null &&
+      MediaStreams.instance.channelType === 'instance' &&
+      transportState.channelType.value !== 'instance'
+    ) {
       MediaStreams.instance.channelId = instanceChannel.id
       TransportService.updateChannelTypeState()
     }
-    if (selfUser?.instanceId.value != null && userState.layerUsersUpdateNeeded.value === true)
-      UserService.getLayerUsers(true)
-    if (selfUser?.channelInstanceId.value != null && userState.channelLayerUsersUpdateNeeded.value === true)
+    if (selfUser?.channelInstanceId.value != null && userState.channelLayerUsersUpdateNeeded.value)
       UserService.getLayerUsers(false)
-  }, [selfUser, userState.layerUsersUpdateNeeded.value, userState.channelLayerUsersUpdateNeeded.value])
+  }, [selfUser, userState.channelLayerUsersUpdateNeeded.value])
+
+  useEffect(() => {
+    TransportService.updateChannelTypeState()
+  }, [MediaStreams.instance.channelType, MediaStreams.instance.channelId])
 
   useEffect(() => {
     setActiveAVChannelId(transportState.channelId.value)
 
     if (targetChannelId == null || targetChannelId === '') {
       // TODO: fix this - it causes crashes for some reason
-      // const matchingChannel = channelEntries.find((entry) => entry?.id === activeAVChannelIdRef.current)
-      // if (matchingChannel)
-      //   setActiveChat(matchingChannel.channelType, {
-      //     id: matchingChannel.instanceId
-      //   })
+      // -> Please open a Github issue documenting how to make these crashes occur and tag @barankyle
+      // -> Without this, a lot of things don't function properly
+      const matchingChannel = channelEntries.find((entry) => entry?.id === activeAVChannelIdRef.current)
+      if (matchingChannel)
+        setActiveChat(matchingChannel.channelType, {
+          id: matchingChannel.instanceId
+        })
     }
   }, [transportState])
 
@@ -376,16 +384,13 @@ const Harmony = (props: Props): any => {
   }, [channels])
 
   useEffect(() => {
-    instanceChannelRef.current = instanceChannel ? instanceChannel.id : null
+    instanceChannelRef.current = instanceChannel ? instanceChannel.id : ''
   }, [instanceChannel])
 
   useEffect(() => {
-    setVideoPaused(!isCamVideoEnabled)
-  }, [isCamVideoEnabled.value])
-
-  useEffect(() => {
     setAudioPaused(!isCamAudioEnabled)
-  }, [isCamAudioEnabled.value])
+    setVideoPaused(!isCamVideoEnabled)
+  }, [isCamAudioEnabled, isCamVideoEnabled])
 
   useEffect(() => {
     if (noGameserverProvision === true) {
@@ -609,7 +614,7 @@ const Harmony = (props: Props): any => {
 
   const handleMicClick = async (e: any) => {
     e.stopPropagation()
-    const channel = channels[activeAVChannelIdRef.current]
+    const channel = channels.find((channel) => channel.id === activeAVChannelIdRef.current)
     const channelType = channel.instanceId == null ? 'channel' : 'instance'
     await checkMediaStream('audio', channelType, activeAVChannelIdRef.current)
     if (MediaStreams.instance?.camAudioProducer == null) {
@@ -631,7 +636,7 @@ const Harmony = (props: Props): any => {
 
   const handleCamClick = async (e: any) => {
     e.stopPropagation()
-    const channel = channels[activeAVChannelIdRef.current]
+    const channel = channels.find((channel) => channel.id === activeAVChannelIdRef.current)
     const channelType = channel.instanceId == null ? 'channel' : 'instance'
     await checkMediaStream('video', channelType, activeAVChannelIdRef.current)
     if (MediaStreams.instance?.camVideoProducer == null) {
@@ -766,7 +771,7 @@ const Harmony = (props: Props): any => {
   }
 
   function getChannelName(): string {
-    const channel = channels[targetChannelId]
+    const channel = channels.find((channel) => channel.id === targetChannelId)
     if (channel && channel.channelType !== 'instance') {
       if (channel.channelType === 'group') return channel[channel.channelType].name
       if (channel.channelType === 'party') return 'Current party'
@@ -776,7 +781,7 @@ const Harmony = (props: Props): any => {
   }
 
   function getAVChannelName(): string {
-    const channel = channels[activeAVChannelId]
+    const channel = channels.find((channel) => channel.id === activeAVChannelIdRef.current)
     if (channel && channel.channelType !== 'instance') {
       if (channel.channelType === 'group') return channel[channel.channelType].name
       if (channel.channelType === 'party') return 'Current party'
@@ -1166,7 +1171,7 @@ const Harmony = (props: Props): any => {
           )}
           {targetChannelId?.length > 0 && (
             <header className={styles.mediaControls}>
-              {activeAVChannelId === '' && (
+              {(!activeAVChannelId || activeAVChannelId === '') && (
                 <div
                   className={classNames({
                     [styles.iconContainer]: true,
@@ -1177,7 +1182,7 @@ const Harmony = (props: Props): any => {
                   <Call />
                 </div>
               )}
-              {activeAVChannelId !== '' && (
+              {activeAVChannelId && activeAVChannelId !== '' && (
                 <div className={styles.activeCallControls}>
                   <div
                     className={classNames({
@@ -1240,7 +1245,7 @@ const Harmony = (props: Props): any => {
             )}
           </div>
         </div>
-        {activeAVChannelId !== '' && harmonyHidden !== true && (
+        {activeAVChannelId && activeAVChannelId !== '' && harmonyHidden !== true && (
           <div className={styles['video-container']}>
             <div className={styles['active-chat-plate']}>{getAVChannelName()}</div>
             <Grid className={styles['party-user-container']} container direction="row">
@@ -1286,8 +1291,8 @@ const Harmony = (props: Props): any => {
           )}
           <List ref={messageRef as any} onScroll={(e) => onMessageScroll(e)} className={styles['message-container']}>
             {activeChannel != null &&
-              activeChannel.Messages &&
-              [...activeChannel.Messages]
+              activeChannel.messages &&
+              [...activeChannel.messages]
                 .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
                 .map((message) => {
                   return (

--- a/packages/client/src/components/MediaIconsBox/index.tsx
+++ b/packages/client/src/components/MediaIconsBox/index.tsx
@@ -25,7 +25,10 @@ import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { EngineEvents } from '@xrengine/engine/src/ecs/classes/EngineEvents'
 import { useChatState } from '@xrengine/client-core/src/social/services/ChatService'
 import { useLocationState } from '@xrengine/client-core/src/social/services/LocationService'
-import { useChannelConnectionState } from '@xrengine/client-core/src/common/services/ChannelConnectionService'
+import {
+  ChannelConnectionService,
+  useChannelConnectionState
+} from '@xrengine/client-core/src/common/services/ChannelConnectionService'
 import { useMediaStreamState } from '@xrengine/client-core/src/media/services/MediaStreamService'
 import { MediaStreamService } from '@xrengine/client-core/src/media/services/MediaStreamService'
 
@@ -95,7 +98,10 @@ const MediaIconsBox = (props) => {
       (Network.instance.transport as any).channelType !== 'instance'
     ) {
       await endVideoChat({})
-      if ((Network.instance.transport as any).channelSocket?.connected === true) await leave(false)
+      if ((Network.instance.transport as any).channelSocket?.connected === true) {
+        await leave(false)
+        await ChannelConnectionService.provisionChannelServer(instanceChannel.id)
+      }
     }
   }
   const handleMicClick = async () => {

--- a/packages/client/src/components/PartyVideoWindows/index.tsx
+++ b/packages/client/src/components/PartyVideoWindows/index.tsx
@@ -24,18 +24,27 @@ const PartyVideoWindows = (props: Props): JSX.Element => {
   const channelLayerUsers = userState.channelLayerUsers
 
   useEffect(() => {
-    if (selfUser?.instanceId.value != null && userState.layerUsersUpdateNeeded === true) UserService.getLayerUsers(true)
-    if (selfUser?.channelInstanceId.value != null && userState.channelLayerUsersUpdateNeeded === true)
-      UserService.getLayerUsers(false)
-  }, [selfUser, userState.layerUsersUpdateNeeded, userState.channelLayerUsersUpdateNeeded])
-
-  useEffect(() => {
     if ((Network.instance?.transport as any)?.channelType === 'channel') {
       setDisplayedUsers(channelLayerUsers.filter((user) => user.id !== selfUser.id.value))
     } else {
       setDisplayedUsers(layerUsers.filter((user) => nearbyLayerUsers.includes(user.id)))
     }
   }, [layerUsers, channelLayerUsers])
+
+  // useEffect(() => {
+  //   console.log('nearbyLayerUsers changed in PartyVideoWindows', nearbyLayerUsers, Array.isArray(nearbyLayerUsers))
+  //   if ((Network.instance?.transport as any)?.channelType === 'instance') {
+  //     // console.log('Updating displayed layer users', nearbyLayerUsers, layerUsers)
+  //     // const nearbyClone =JSON.parse(JSON.stringify(nearbyLayerUsers))
+  //     // console.log('nearbyClone', nearbyClone)
+  //     const layerUserCopy = JSON.parse(JSON.stringify(layerUsers))
+  //     console.log('layerUsers', layerUsers, 'layerUserCopy', layerUserCopy)
+  //     const filtered = layerUserCopy
+  //     console.log('filtered', filtered)
+  //     // setDisplayedUsers(filtered)
+  //     setDisplayedUsers(filtered)
+  //   }
+  // }, [nearbyLayerUsers])
 
   const [expanded, setExpanded] = useState(true)
 

--- a/packages/client/src/components/World/NetworkInstanceProvisioning.tsx
+++ b/packages/client/src/components/World/NetworkInstanceProvisioning.tsx
@@ -43,11 +43,8 @@ export const NetworkInstanceProvisioning = (props: Props) => {
   const locationState = useLocationState()
   const instanceConnectionState = useInstanceConnectionState()
   useEffect(() => {
-    if (selfUser?.instanceId.value != null && userState.layerUsersUpdateNeeded.value === true)
-      UserService.getLayerUsers(true)
-    if (selfUser?.channelInstanceId.value != null && userState.channelLayerUsersUpdateNeeded.value === true)
-      UserService.getLayerUsers(false)
-  }, [selfUser, userState.layerUsersUpdateNeeded.value, userState.channelLayerUsersUpdateNeeded.value])
+    if (selfUser?.instanceId.value != null && userState.layerUsersUpdateNeeded.value) UserService.getLayerUsers(true)
+  }, [selfUser, userState.layerUsersUpdateNeeded.value])
 
   useEffect(() => {
     AuthService.doLoginAuto(true)

--- a/packages/common/src/interfaces/User.ts
+++ b/packages/common/src/interfaces/User.ts
@@ -17,7 +17,7 @@ export interface UserScope {
 
 export interface User {
   id?: UserId
-  name?: string
+  name: string
   userRole?: string
   avatarId?: string
   identityProviders?: IdentityProvider[]

--- a/packages/engine/src/networking/functions/getNearbyUsers.ts
+++ b/packages/engine/src/networking/functions/getNearbyUsers.ts
@@ -12,7 +12,7 @@ export function getNearbyUsers(userId: UserId, maxMediaUsers = 8): Array<NearbyU
   const otherUsers = [] as UserId[]
   for (const [otherUserId] of Engine.defaultWorld.clients) {
     if (userId === otherUserId) continue
-    otherUsers.push(userId)
+    otherUsers.push(otherUserId)
   }
   if (userAvatar != null) {
     const userPosition = getComponent(userAvatar, TransformComponent).position


### PR DESCRIPTION
## Summary

Separated some layer/channel user refetching so it's only called in one place, and
only from a component that's required for that type of user fetching to occur (there were
a lot of duplicate calls since it was being instantiated by four components).

Changed all references to channel.Messages to channel.messages.

Added some better useEffects to handle state changes for transports.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## Reviewers
