### PR TITLE
dev->deps merge action fix

### DIFF
--- a/.github/workflows/update-deps-branch.yml
+++ b/.github/workflows/update-deps-branch.yml
@@ -21,15 +21,11 @@ jobs:
     if: ${{ needs.secrets-gate.outputs.ok == 'enabled' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
+      - uses: actions/checkout@master
       - name: Merge dev into deps branch
-        uses: devmasx/merge-branch@1.4.0
+        uses: devmasx/merge-branch@master
         with:
-          label_name: 'merged dev into deps'
-          from_branch: 'dev'
-          target_branch: 'deps'
+          type: now
+          from_branch: dev
+          target_branch: deps
           github_token: ${{ github.token }}


### PR DESCRIPTION
## Summary

adding fixes for the github action which keeps `deps` up to date with `dev` branch

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers

## References

n/a

## Reviewers

n/a