### PR TITLE
Fix Chat Open UI for bottom right button

### DIFF
--- a/packages/client/src/components/InstanceChat/InstanceChat.module.scss
+++ b/packages/client/src/components/InstanceChat/InstanceChat.module.scss
@@ -49,7 +49,7 @@
   width: 40vw;
   justify-content: flex-end;
   z-index: 20;
-  margin: 5px 20px 20px 10px;
+  margin: 5px 15px 20px 10px;
   transition: all 225ms cubic-bezier(0, 0, 0.2, 1) 0ms;
   // overflow: hidden;
 
@@ -106,7 +106,7 @@
 
       :global(.MuiInput-root) {
         margin-top: 8px;
-        margin-bottom: 7px;
+        margin-bottom: 8px;
       }
 
       :global(.MuiFormLabel-root.Mui-focused):not(.MuiFormLabel-filled),
@@ -144,13 +144,13 @@
 
     @media (max-width: 768px) {
       width: 96vw;
-      margin: 20px;
+      margin: 15px 15px 20px;
       height: 100%;
     }
 
     @media (max-width: 450px) {
       width: 92vw;
-      margin: 16px;
+      margin: 10px 10px 16px;
       height: 100%;
     }
   }

--- a/packages/client/src/components/InstanceChat/index.tsx
+++ b/packages/client/src/components/InstanceChat/index.tsx
@@ -215,6 +215,7 @@ const InstanceChat = (props: Props): any => {
                 id="newMessage"
                 label={newMessageLabel}
                 name="newMessage"
+                variant="standard"
                 autoFocus
                 value={composingMessage}
                 inputProps={{


### PR DESCRIPTION
## Summary

i made UI for the chat open UI when the bottom right icon is clicked for laptop, tablet and mobile view.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers

## Fixed Screenshot

<img width="1342" alt="Screenshot 2021-11-08 at 9 58 00 AM" src="https://user-images.githubusercontent.com/30355034/140687441-913c51e9-1baa-411a-8393-1e87407b8208.png">

## References

https://github.com/XRFoundation/XREngine/issues/3997

## Reviewers

@HexaField @shawwwwwwww 