### PR TITLE
Fixed some bugs in S3 project updating.

### DIFF
--- a/packages/server-core/src/hooks/add-associations.ts
+++ b/packages/server-core/src/hooks/add-associations.ts
@@ -15,6 +15,7 @@ function processInclude(includeCollection: any, context: HookContext): any {
 
 export default (options = {}): any => {
   return (context: any): any => {
+    if (!context.params) context.params = {}
     try {
       const sequelize = context.params.sequelize || {}
       const include = sequelize.include || []

--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -148,7 +148,7 @@ export class S3Provider implements StorageProviderInterface {
             CallerReference: Date.now().toString(),
             Paths: {
               Quantity: invalidationItems.length,
-              Items: invalidationItems.map((item) => `/${item}`)
+              Items: invalidationItems.map((item) => (item[0] !== '/' ? `/${item}` : item))
             }
           }
         },

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -6,8 +6,7 @@ import { getFileKeysRecursive } from '../../media/storageprovider/storageProvide
 export const retriggerBuilderService = async (app: Application) => {
   try {
     // invalidate cache for all installed projects
-    const files = await getFileKeysRecursive(`projects`)
-    await useStorageProvider().createInvalidation(files)
+    await useStorageProvider().createInvalidation(['projects*'])
   } catch (e) {
     console.log('[Project Rebuild]: Failed to invalidate cache with error', e)
   }

--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -43,7 +43,7 @@ export const uploadLocalProjectToProvider = async (projectName) => {
     if (existingFiles.length) {
       await Promise.all([
         storageProvider.deleteResources(existingFiles),
-        storageProvider.createInvalidation(existingFiles)
+        storageProvider.createInvalidation([`projects/${projectName}*`])
       ])
     }
   } catch (e) {}
@@ -221,7 +221,7 @@ export class Project extends Service {
       repositoryPath: data.url
     }
 
-    await super.create(dbEntryData, params)
+    await super.create(dbEntryData, params || {})
   }
 
   /**


### PR DESCRIPTION
## Summary

Made invalidation requests be for entirety of projects folder
(project-helper.ts:retriggerBuilderService) or a specific project folder
(project.class.ts:uploadLocalProjectToProvider). This saves a ton of invalidation
paths, which will cut down on costs.

Fixed a couple cases where params were null, which was causing params.sequelize to throw
errors due to reading a value from null.

Made createInvalidationCall not append a '/' to the start of each item if it already
has a leading slash.

A summary of changes being made in this PR

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## Reviewers

@HexaField @speigg @NateTheGreatt