### PR TITLE
Dock UI and File Browsing Styling

### DIFF
--- a/packages/editor/src/components/EditorContainer.tsx
+++ b/packages/editor/src/components/EditorContainer.tsx
@@ -585,7 +585,11 @@ const EditorContainer = () => {
                 },
                 {
                   id: 'assetsPanel',
-                  title: 'Elements',
+                  title: (
+                    <PanelDragContainer>
+                      <PanelTitle>Elements</PanelTitle>
+                    </PanelDragContainer>
+                  ),
                   content: <AssetsPanel />
                 }
               ]

--- a/packages/editor/src/components/assets/FileBrowserGrid.tsx
+++ b/packages/editor/src/components/assets/FileBrowserGrid.tsx
@@ -47,10 +47,12 @@ export function FileListItem({
     if (isRenaming) inputref.current.focus()
   }, [isRenaming])
   return (
-    <div onDoubleClick={onDoubleClick} onClick={onClick}>
-      <IconComponent size={'20px'} />
+    <FileListItemContainer onDoubleClick={onDoubleClick} onClick={onClick}>
+      <div style={{ marginRight: '3px' }}>
+        <IconComponent size={'20px'} />
+      </div>
       {label}
-    </div>
+    </FileListItemContainer>
   )
 }
 
@@ -61,6 +63,20 @@ export function FileListItem({
 export const FileList = (styled as any).div`
  width: 100%;
  padding: 10px;
+`
+
+/**
+ *
+ *  @author Robert Long
+ */
+export const FileListItemContainer = (styled as any).div`
+ width: 100%;
+ display: flex;
+ flex-direction: row;
+ align-items: center;
+ margin-left: 3px;
+ margin-bottom: 3px;
+ color: white;
 `
 
 MediaGrid.defaultProps = {

--- a/packages/editor/src/components/layout/Panel.tsx
+++ b/packages/editor/src/components/layout/Panel.tsx
@@ -3,6 +3,23 @@ import styled from 'styled-components'
 
 /**
  *
+ *  @author Robert Long
+ */
+export const PanelIcon = (styled as any).div`
+ color: #b6b6b6;
+ margin-right: 8px;
+`
+
+/**
+ *
+ *  @author Robert Long
+ */
+export const PanelTitle = (styled as any).div`
+ color: #b6b6b6;
+`
+
+/**
+ *
  *  @author Hanzla  Mateen
  */
 export const PanelDragContainer = (styled as any).div`
@@ -10,6 +27,17 @@ export const PanelDragContainer = (styled as any).div`
   flex: 1;
   flex-direction: row;
   align-items: center;
+
+  &.dock-tab-active {
+
+    ${PanelTitle} {
+      color: white !important;
+    }
+
+    ${PanelIcon} {
+      color: white !important;
+    }
+  }
 `
 
 /**
@@ -37,20 +65,6 @@ export const PanelToolbar = (styled as any).div`
   align-items: center;
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
 `
-
-/**
- *
- *  @author Robert Long
- */
-export const PanelIcon = (styled as any).div`
-  margin-right: 8px;
-`
-
-/**
- *
- *  @author Robert Long
- */
-export const PanelTitle = (styled as any).div``
 
 /**
  *


### PR DESCRIPTION
## Summary

update the dock tab styling and list files styling

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers

<img width="1303" alt="Screenshot 2021-11-09 at 4 39 56 PM" src="https://user-images.githubusercontent.com/30355034/140917763-a51a3fc2-8baf-4452-b089-d6f68687fe10.png">

## Reviewers

@HexaField 