### PR TITLE
Styling Improvements of Editor Components

### DIFF
--- a/packages/editor/src/components/assets/AssetGrid.tsx
+++ b/packages/editor/src/components/assets/AssetGrid.tsx
@@ -8,7 +8,7 @@ import { ContextMenuTrigger, ContextMenu, MenuItem } from '../layout/ContextMenu
 import { useDrag } from 'react-dnd'
 import { getEmptyImage } from 'react-dnd-html5-backend'
 import AssetTooltip from './AssetTooltip'
-import Tooltip, { TooltipContainer } from '../layout/Tooltip'
+import Tooltip from '@mui/material/Tooltip'
 import { useTranslation } from 'react-i18next'
 import { CommandManager } from '../../managers/CommandManager'
 import EditorCommands from '../../constants/EditorCommands'
@@ -34,16 +34,6 @@ const getNodes = (params?) => {
     return acc
   }, [])
 }
-/**
- * AssetGridTooltipContainer used to provide styles for tooltip shown if we hover the object.
- *
- * @author Robert Long
- * @type {styled component}
- */
-const AssetGridTooltipContainer = (styled as any)(TooltipContainer)`
-  max-width: initial;
-  text-align: left;
-`
 
 /**
  * collectMenuProps returns menu items.
@@ -102,30 +92,19 @@ function AssetGridItem({ contextMenuId, tooltipComponent, disableTooltip, item, 
     multiple: false
   }))
 
-  /**
-   * [renderTooltip  used to render tooltip for AssetGrid]
-   * @type {function component}
-   */
-  const renderTooltip = useCallback(() => {
-    const TooltipComponent = tooltipComponent
-    return (
-      <AssetGridTooltipContainer>
-        <TooltipComponent item={item} />
-      </AssetGridTooltipContainer>
-    )
-  }, [item, tooltipComponent])
-
   //showing the object in viewport once it drag and droped
   useEffect(() => {
     preview(getEmptyImage(), { captureDraggingState: true })
   }, [preview])
 
+  const TooltipComponent = tooltipComponent
+
   //creating view for AssetGrid using ContextMenuTrigger and tooltip component
   return (
     <div ref={drag}>
       <ContextMenuTrigger id={contextMenuId} collect={collectMenuProps} holdToDisplay={-1}>
-        <Tooltip renderContent={renderTooltip} disabled={disableTooltip}>
-          {content}
+        <Tooltip title={<TooltipComponent item={item} />}>
+          <div>{content}</div>
         </Tooltip>
       </ContextMenuTrigger>
     </div>

--- a/packages/editor/src/components/assets/AssetTooltip.tsx
+++ b/packages/editor/src/components/assets/AssetTooltip.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components'
  */
 const TooltipContainer = (styled as any).div`
   display: flex;
-  width: 600px;
+  maxWidth: 100px;
   padding: 12px 0;
 `
 
@@ -23,8 +23,6 @@ const TooltipThumbnailContainer = (styled as any).div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 200px;
-  height: 200px;
 `
 
 /**
@@ -50,34 +48,38 @@ const TooltipContent = (styled as any).div`
  * @param       {any} item
  * @constructor
  */
-export function AssetTooltip({ item }) {
-  let thumbnail
+export class AssetTooltip extends React.Component {
+  render() {
+    let { item } = this.props
 
-  // check if item contains thumbnailUrl then initializing thumbnail
-  // else creating thumbnail if there is videoUrl
-  // then check if item contains iconComponent then initializing using IconComponent
-  //else initialize thumbnail using src from item object
-  if (item.thumbnailUrl) {
-    thumbnail = <img src={item.thumbnailUrl} />
-  } else if (item.videoUrl) {
-    thumbnail = <video src={item.videoUrl} autoPlay muted />
-  } else if (item.iconComponent) {
-    const IconComponent = item.iconComponent
-    thumbnail = <IconComponent size={100} />
-  } else {
-    thumbnail = <img src={item.src} />
+    let thumbnail
+
+    // check if item contains thumbnailUrl then initializing thumbnail
+    // else creating thumbnail if there is videoUrl
+    // then check if item contains iconComponent then initializing using IconComponent
+    //else initialize thumbnail using src from item object
+    if (item.thumbnailUrl) {
+      thumbnail = <img src={item.thumbnailUrl} />
+    } else if (item.videoUrl) {
+      thumbnail = <video src={item.videoUrl} autoPlay muted />
+    } else if (item.iconComponent) {
+      const IconComponent = item.iconComponent
+      thumbnail = <IconComponent size={50} />
+    } else {
+      thumbnail = <img src={item.src} />
+    }
+
+    //creating tooltip view
+    return (
+      <TooltipContainer>
+        <TooltipThumbnailContainer>{thumbnail}</TooltipThumbnailContainer>
+        <TooltipContent>
+          <b>{item.label}</b>
+          {item.description && <div>{item.description}</div>}
+        </TooltipContent>
+      </TooltipContainer>
+    )
   }
-
-  //creating tooltip view
-  return (
-    <TooltipContainer>
-      <TooltipThumbnailContainer>{thumbnail}</TooltipThumbnailContainer>
-      <TooltipContent>
-        <b>{item.label}</b>
-        {item.description && <div>{item.description}</div>}
-      </TooltipContent>
-    </TooltipContainer>
-  )
 }
 
 export default AssetTooltip

--- a/packages/editor/src/components/inputs/ColorInput.tsx
+++ b/packages/editor/src/components/inputs/ColorInput.tsx
@@ -3,7 +3,7 @@ import SketchPicker from 'react-color/lib/Sketch'
 import Input from './Input'
 import { Color } from 'three'
 import styled from 'styled-components'
-import Popover from '../layout/Popover'
+import Popover from '@mui/material/Popover'
 
 /**
  * ColorInputContainer used to provide styles for ColorInputContainer div.
@@ -91,24 +91,34 @@ export function ColorInput({ value, onChange, disabled, isValueAsInteger = false
     [onChange]
   )
 
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null)
+
+  const handlePopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handlePopoverClose = () => {
+    setAnchorEl(null)
+  }
+
+  const open = Boolean(anchorEl)
+
   //initializing hexColor by getting hexString
   const hexColor = '#' + (isValueAsInteger ? value.toString(16) : value.getHexString())
 
   //creating view for ColorInput
   return (
     <ColorInputContainer>
-      <Popover
-        disabled={disabled}
-        renderContent={() => (
+      <StyledColorInput as="div" disabled={disabled} onClick={handlePopoverOpen}>
+        <ColorPreview style={{ background: hexColor }} />
+        <ColorText>{hexColor.toUpperCase()}</ColorText>
+      </StyledColorInput>
+      <Popover open={open && !disabled} anchorEl={anchorEl} onClose={handlePopoverClose}>
+        <div>
           <ColorInputPopover>
             <SketchPicker {...rest} color={hexColor} disableAlpha={true} onChange={onChangePicker} />
           </ColorInputPopover>
-        )}
-      >
-        <StyledColorInput as="div" disabled={disabled}>
-          <ColorPreview style={{ background: hexColor }} />
-          <ColorText>{hexColor.toUpperCase()}</ColorText>
-        </StyledColorInput>
+        </div>
       </Popover>
     </ColorInputContainer>
   )

--- a/packages/editor/src/components/inputs/SelectInput.tsx
+++ b/packages/editor/src/components/inputs/SelectInput.tsx
@@ -48,7 +48,8 @@ const staticStyle = {
   }),
   menuList: (base) => ({
     ...base,
-    padding: '0'
+    padding: '0',
+    maxHeight: '120px'
   }),
   option: (base, { isFocused }) => ({
     ...base,
@@ -133,6 +134,7 @@ export function SelectInput({
       components={{ IndicatorSeparator: () => null }}
       placeholder={placeholder}
       options={options}
+      menuPlacement="auto"
       onChange={(option) => onChange(option && option.value, option)}
       isDisabled={disabled}
     />


### PR DESCRIPTION
## Summary

improve styling of editor components; select, popover and tooltip

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers

## Reviewers

@HexaField 