### PR TITLE
Camera Layer Fixes

### DIFF
--- a/packages/engine/src/avatar/functions/createAvatar.ts
+++ b/packages/engine/src/avatar/functions/createAvatar.ts
@@ -35,6 +35,7 @@ import { LocalInputTagComponent } from '../../input/components/LocalInputTagComp
 import { FollowCameraComponent, FollowCameraDefaultValues } from '../../camera/components/FollowCameraComponent'
 import { PersistTagComponent } from '../../scene/components/PersistTagComponent'
 import { createQuaternionProxy, createVector3Proxy } from '../../common/proxies/three'
+import { CameraLayers } from '../../camera/constants/CameraLayers'
 
 const avatarRadius = 0.25
 const avatarHeight = 1.8
@@ -113,6 +114,10 @@ export const createAvatar = (spawnAction: typeof NetworkWorldAction.spawnAvatar.
   })
 
   addComponent(entity, Object3DComponent, { value: tiltContainer })
+  tiltContainer.traverse((o) => {
+    o.layers.disable(CameraLayers.Scene)
+    o.layers.enable(CameraLayers.Avatar)
+  })
 
   const filterData = new PhysX.PxQueryFilterData()
   filterData.setWords(CollisionGroups.Default | CollisionGroups.Ground | CollisionGroups.Trigger, 0)

--- a/packages/engine/src/camera/constants/CameraLayers.ts
+++ b/packages/engine/src/camera/constants/CameraLayers.ts
@@ -1,6 +1,8 @@
 export const CameraLayers = {
-  None: 0,
-  Avatar: 1,
+  Render: 0, // DEFAULT: TRUE - everything to render should have layer 0 enabled
+  Scene: 1, // DEFAULT: TRUE
   Portal: 2,
-  Scene: 3
+  Avatar: 3,
+  Gizmos: 4,
+  UI: 5
 }

--- a/packages/engine/src/camera/systems/CameraSystem.ts
+++ b/packages/engine/src/camera/systems/CameraSystem.ts
@@ -247,7 +247,7 @@ export default async function CameraSystem(world: World): Promise<System> {
           const arrow = new ArrowHelper()
           coneDebugHelpers.push(arrow)
           arrow.traverse((obj: Object3D) => {
-            obj.layers.set(CameraLayers.Avatar)
+            obj.layers.set(CameraLayers.Gizmos)
           })
           Engine.scene.add(arrow)
         }

--- a/packages/engine/src/initializeEngine.ts
+++ b/packages/engine/src/initializeEngine.ts
@@ -58,7 +58,7 @@ const configureClient = async (options: Required<InitializeOptions>) => {
 
   if (options.scene.disabled !== true) {
     Engine.camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 10000)
-    Engine.camera.layers.enableAll()
+    Engine.camera.layers.set(0)
     Engine.scene.add(Engine.camera)
     Engine.camera.add(Engine.audioListener)
     addClientInputListeners(canvas)

--- a/packages/engine/src/interaction/systems/InteractiveSystem.ts
+++ b/packages/engine/src/interaction/systems/InteractiveSystem.ts
@@ -30,6 +30,7 @@ import { AudioTagComponent } from '../../audio/components/AudioTagComponent'
 import { PersistTagComponent } from '../../scene/components/PersistTagComponent'
 import { System } from '../../ecs/classes/System'
 import { World } from '../../ecs/classes/World'
+import { CameraLayers } from '../../camera/constants/CameraLayers'
 
 const upVec = new Vector3(0, 1, 0)
 
@@ -50,6 +51,10 @@ export default async function InteractiveSystem(world: World): Promise<System> {
 
   const interactTextEntity = createEntity()
   const textGroup = new Group().add(text)
+  textGroup.traverse((o) => {
+    o.layers.disable(CameraLayers.Scene)
+    o.layers.enable(CameraLayers.Gizmos)
+  })
   addComponent(interactTextEntity, Object3DComponent, { value: textGroup })
   addComponent(interactTextEntity, PersistTagComponent, {})
   const transformComponent = addComponent(interactTextEntity, TransformComponent, {

--- a/packages/engine/src/physics/components/RaycastComponent.ts
+++ b/packages/engine/src/physics/components/RaycastComponent.ts
@@ -1,4 +1,4 @@
-import { Vector3 } from '@etherealjs/core'
+import { Vector3 } from 'three'
 import { createMappedComponent } from '../../ecs/functions/ComponentFunctions'
 import { RaycastHit, SceneQueryType } from '../types/PhysicsTypes'
 

--- a/packages/engine/src/scene/functions/createTriggerVolume.ts
+++ b/packages/engine/src/scene/functions/createTriggerVolume.ts
@@ -1,4 +1,5 @@
 import { BoxBufferGeometry, BoxHelper, Material, Mesh, Object3D, Quaternion, Vector3 } from 'three'
+import { CameraLayers } from '../../camera/constants/CameraLayers'
 import { addComponent, getComponent } from '../../ecs/functions/ComponentFunctions'
 import { ColliderComponent } from '../../physics/components/ColliderComponent'
 import { CollisionGroups } from '../../physics/enums/CollisionGroups'
@@ -41,7 +42,7 @@ export const createTriggerVolume = async function (entity, args): Promise<Mesh> 
     // A visual representation for the trigger
     boxMesh.scale.multiplyScalar(2) // engine uses half-extents for box size, to be compatible with gltf and threejs
     const box = new BoxHelper(boxMesh, 0xffff00)
-    box.layers.set(1)
+    box.layers.set(CameraLayers.Gizmos)
     addObject3DComponent(entity, box, {})
   }
 

--- a/packages/engine/src/scene/systems/SceneObjectSystem.ts
+++ b/packages/engine/src/scene/systems/SceneObjectSystem.ts
@@ -59,8 +59,6 @@ export default async function SceneObjectSystem(world: World): Promise<System> {
 
       // Apply material stuff
       object3DComponent.value.traverse((obj: Mesh) => {
-        // Set default layer
-        obj.layers.set(CameraLayers.Scene)
         const material = obj.material as Material
         if (typeof material !== 'undefined') material.dithering = true
 

--- a/packages/engine/src/xrui/functions/createXRUI.tsx
+++ b/packages/engine/src/xrui/functions/createXRUI.tsx
@@ -7,6 +7,7 @@ import { Object3DComponent } from '../../scene/components/Object3DComponent'
 import { Entity } from '../../ecs/classes/Entity'
 import { XRUIStateContext } from '../XRUIStateContext'
 import { Engine } from '../../ecs/classes/Engine'
+import { CameraLayers } from '../../camera/constants/CameraLayers'
 
 let depsLoaded: Promise<[typeof import('ethereal'), typeof import('react-dom')]>
 
@@ -45,6 +46,10 @@ export function createXRUI<S extends State<any>>(
     // TODO: revise this pattern after refactor
     if (Engine.defaultWorld.entities.indexOf(entity) === -1) return
     addComponent(entity, Object3DComponent, { value: uiRoot })
+    uiRoot.traverse((o) => {
+      o.layers.disable(CameraLayers.Scene)
+      o.layers.enable(CameraLayers.UI)
+    })
     addComponent(entity, XRUIComponent, { layer: uiRoot })
   })
   return { entity, state }


### PR DESCRIPTION
## Summary

- Default camera layer is now 'scene' instead of 'avatar'
- Added new layers for UI & Gizmos

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## Reviewers

@speigg