### PR TITLE
Editor Renderer Fixes

### DIFF
--- a/packages/editor/src/managers/ControlManager.ts
+++ b/packages/editor/src/managers/ControlManager.ts
@@ -27,7 +27,7 @@ export class ControlManager {
   }
 
   initControls() {
-    this.inputManager = new InputManager(SceneManager.instance.canvas)
+    this.inputManager = new InputManager(Engine.renderer.domElement)
     this.flyControls = new FlyControls(Engine.camera as PerspectiveCamera, this.inputManager)
     this.editorControls = new EditorControls(Engine.camera, this.inputManager, this.flyControls)
     this.playModeControls = new PlayModeControls(this.inputManager, this.editorControls, this.flyControls)

--- a/packages/editor/src/managers/ProjectManager.ts
+++ b/packages/editor/src/managers/ProjectManager.ts
@@ -60,7 +60,7 @@ export class ProjectManager {
    * @return {Promise}             [scene to render]
    */
   async loadProject(projectFile: SceneJson) {
-    this.dispose()
+    // this.dispose()
 
     await ProjectManager.instance.init()
 

--- a/packages/editor/src/managers/SceneManager.ts
+++ b/packages/editor/src/managers/SceneManager.ts
@@ -298,15 +298,6 @@ export class SceneManager {
    */
   onResize = () => {
     ControlManager.instance.inputManager.onResize()
-    // const camera = Engine.camera as PerspectiveCamera
-    // const canvas = Engine.renderer.domElement
-    // const containerEl = canvas.parentElement.parentElement
-    // camera.aspect = containerEl.offsetWidth / containerEl.offsetHeight
-    // camera.updateProjectionMatrix()
-    // Engine.renderer.setSize(containerEl.offsetWidth, containerEl.offsetHeight, false)
-    // Engine.csm.updateFrustums();
-
-    // configureEffectComposer(this.postProcessingNode?.postProcessingOptions)
     CommandManager.instance.emit('resize')
   }
 


### PR DESCRIPTION
## Summary

- editor initialises it's renderers only once
- changing scenes in the editor no longer crashes

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [ ] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## Reviewers

@NPatel10 