### PR TITLE
Keep viewport dock hidden

### DIFF
--- a/packages/editor/src/components/EditorContainer.tsx
+++ b/packages/editor/src/components/EditorContainer.tsx
@@ -562,6 +562,7 @@ const EditorContainer = () => {
           size: 8,
           children: [
             {
+              id: '+5',
               tabs: [{ id: 'viewPanel', title: 'Viewport', content: <div /> }],
               size: 1
             }


### PR DESCRIPTION
## Summary

fix viewport dock id to keep it hidden

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers

## References

[References to pertaining issue(s)](https://github.com/XRFoundation/XREngine/issues/4110)

## Reviewers

@HexaField 