### PR TITLE
fix access of translation variable

### DIFF
--- a/packages/editor/src/components/properties/GroundPlaneNodeEditor.tsx
+++ b/packages/editor/src/components/properties/GroundPlaneNodeEditor.tsx
@@ -64,7 +64,7 @@ export const GroundPlaneNodeEditor = (props: GroundPlaneNodeEditorProps) => {
       <InputGroup name="Receive Shadow" label={t('editor:properties.groundPlane.lbl-receiveShadow')}>
         <BooleanInput value={node.receiveShadow} onChange={onChangeReceiveShadow} />
       </InputGroup>
-      <InputGroup name="Generate Navmesh" label={props.t('editor:properties.groundPlane.lbl-generateNavmesh')}>
+      <InputGroup name="Generate Navmesh" label={t('editor:properties.groundPlane.lbl-generateNavmesh')}>
         <BooleanInput value={node.generateNavmesh} onChange={onChangeGenerateNavmesh} />
       </InputGroup>
       <InputGroup name="Walkable" label={t('editor:properties.groundPlane.lbl-walkable')}>


### PR DESCRIPTION
## Summary

Fixed the code crashing due to accesing translation variable from props instead of local variable

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers

## Reviewers

@HexaField  @speigg  @NateTheGreatt 