### PR TITLE
Network Ownership on Client Sends Outgoing Pose

### DIFF
--- a/packages/engine/src/networking/systems/IncomingNetworkSystem.ts
+++ b/packages/engine/src/networking/systems/IncomingNetworkSystem.ts
@@ -18,6 +18,7 @@ import { XRHandsInputComponent } from '../../xr/components/XRHandsInputComponent
 import { Group } from 'three'
 import { AvatarComponent } from '../../avatar/components/AvatarComponent'
 import { avatarHalfHeight } from '../../avatar/functions/createAvatar'
+import { NetworkObjectOwnedTag } from '../components/NetworkObjectOwnedTag'
 
 export const applyDelayedActions = (world: World) => {
   const { delayedActions } = world
@@ -112,10 +113,9 @@ export const applyUnreliableQueue = (networkInstance: Network) => (world: World)
           console.warn(`Rejecting update for non-existing network object: ${pose.networkId}`)
           continue
         }
-        const networkComponent = getComponent(networkObjectEntity, NetworkObjectComponent)
 
         // don't apply state if this client has ownership
-        const weHaveOwnership = networkComponent.userId === Engine.userId
+        const weHaveOwnership = hasComponent(networkObjectEntity, NetworkObjectOwnedTag)
         if (weHaveOwnership) {
           // console.warn(`Received network update for entity that this client owns: ${pose.networkId}`)
           continue

--- a/packages/engine/src/networking/systems/OutgoingNetworkSystem.ts
+++ b/packages/engine/src/networking/systems/OutgoingNetworkSystem.ts
@@ -18,7 +18,6 @@ import { XRHandsInputComponent } from '../../xr/components/XRHandsInputComponent
 import { NetworkTransport } from '../interfaces/NetworkTransport'
 import { Mesh } from 'three'
 import { Entity } from '../../ecs/classes/Entity'
-import { GolfBallComponent } from '@xrengine/projects/projects/puttclub/components/GolfBallComponent'
 import { NetworkObjectOwnedTag } from '../components/NetworkObjectOwnedTag'
 
 /***********
@@ -139,9 +138,6 @@ export const rerouteActions = pipe(
 
 export const queueEntityTransform = (world: World, entity: Entity) => {
   const { outgoingNetworkState, previousNetworkState } = world
-  // if(hasComponent(entity, GolfBallComponent)) {
-  //   console.log(getComponent(entity, VelocityComponent).velocity)
-  // }
 
   const networkObject = getComponent(entity, NetworkObjectComponent)
   const transformComponent = getComponent(entity, TransformComponent)

--- a/packages/engine/tests/networking/systems/OutgoingNetworkSystem.test.ts
+++ b/packages/engine/tests/networking/systems/OutgoingNetworkSystem.test.ts
@@ -247,15 +247,11 @@ describe('OutgoingNetworkSystem Unit Tests', () => {
         handsPose: []
       }
 
-      // client is not host (world.isHosting === false)
-      Engine.userId = '0' as UserId
-
-      for (let i = 0; i < 2; i++) {
+      for (let i = 0; i < 8; i++) {
         const entity = createEntity()
 
-        // make first entity the client's entity
-        if (i === 0) {
-          world.localClientEntity = entity
+        // make every other entity owned by this instance
+        if (i % 2) {
           const ownedNetworkTag = addComponent(entity, NetworkObjectOwnedTag, {})
         }
 
@@ -267,7 +263,7 @@ describe('OutgoingNetworkSystem Unit Tests', () => {
         const networkObject = addComponent(entity, NetworkObjectComponent, {
           // remote owner
           userId: i as unknown as UserId,
-          networkId: 0 as NetworkId,
+          networkId: i as NetworkId,
           prefab: '',
           parameters: {},
         })
@@ -278,9 +274,13 @@ describe('OutgoingNetworkSystem Unit Tests', () => {
       queueUnchangedPosesClient(world)
 
       /* assert */
-      // verify only 1 client pose was queued
+      // verify only every odd entity pose was queued
       const { outgoingNetworkState } = world
-      strictEqual(outgoingNetworkState.pose.length, 1)
+      strictEqual(outgoingNetworkState.pose.length, 4)
+      strictEqual(outgoingNetworkState.pose[0].networkId, 1)
+      strictEqual(outgoingNetworkState.pose[1].networkId, 3)
+      strictEqual(outgoingNetworkState.pose[2].networkId, 5)
+      strictEqual(outgoingNetworkState.pose[3].networkId, 7)
     })
   })
 

--- a/packages/engine/tests/networking/systems/OutgoingNetworkSystem.test.ts
+++ b/packages/engine/tests/networking/systems/OutgoingNetworkSystem.test.ts
@@ -19,6 +19,7 @@ import { VelocityComponent } from '../../../src/physics/components/VelocityCompo
 import { NetworkObjectComponent } from '../../../src/networking/components/NetworkObjectComponent'
 import { NetworkId } from '@xrengine/common/src/interfaces/NetworkId'
 import { TestNetwork } from '../TestNetwork'
+import { NetworkObjectOwnedTag } from '../../../src/networking/components/NetworkObjectOwnedTag'
 
 describe('OutgoingNetworkSystem Unit Tests', () => {
 
@@ -255,6 +256,7 @@ describe('OutgoingNetworkSystem Unit Tests', () => {
         // make first entity the client's entity
         if (i === 0) {
           world.localClientEntity = entity
+          const ownedNetworkTag = addComponent(entity, NetworkObjectOwnedTag, {})
         }
 
         const transform = addComponent(entity, TransformComponent, {


### PR DESCRIPTION
## Summary

owned objects now send their pose from the client

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [ ] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## Reviewers

@speigg @NateTheGreatt