### PR TITLE
If no cachedomain is configured, throw an error in getCachedAsset

### DIFF
--- a/packages/server-core/src/media/storageprovider/getCachedAsset.ts
+++ b/packages/server-core/src/media/storageprovider/getCachedAsset.ts
@@ -1,4 +1,4 @@
 export const getCachedAsset = (path: string, cacheDomain: string) => {
-  if (!cacheDomain) throw new Error('No cache domain found - please check our storage provider configuration')
+  if (!cacheDomain) throw new Error('No cache domain found - please check the storage provider configuration')
   return new URL(path ?? '', 'https://' + cacheDomain).href
 }

--- a/packages/server-core/src/media/storageprovider/getCachedAsset.ts
+++ b/packages/server-core/src/media/storageprovider/getCachedAsset.ts
@@ -1,3 +1,4 @@
 export const getCachedAsset = (path: string, cacheDomain: string) => {
-  return path && cacheDomain ? new URL(path, 'https://' + cacheDomain).href : ''
+  if (!cacheDomain) throw new Error('No cache domain found - please check our storage provider configuration')
+  return new URL(path, 'https://' + cacheDomain).href
 }

--- a/packages/server-core/src/media/storageprovider/getCachedAsset.ts
+++ b/packages/server-core/src/media/storageprovider/getCachedAsset.ts
@@ -1,4 +1,4 @@
 export const getCachedAsset = (path: string, cacheDomain: string) => {
   if (!cacheDomain) throw new Error('No cache domain found - please check our storage provider configuration')
-  return new URL(path, 'https://' + cacheDomain).href
+  return new URL(path ?? '', 'https://' + cacheDomain).href
 }


### PR DESCRIPTION
## Summary

If no cache domain is configured, getCachedAsset will throw an error

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## Reviewers

@HexaField @speigg @NateTheGreatt