### PR TITLE
Added optional gameserver shutdown delay.

### DIFF
--- a/packages/server-core/src/appconfig.ts
+++ b/packages/server-core/src/appconfig.ts
@@ -111,7 +111,8 @@ const gameserver = {
   releaseName: process.env.RELEASE_NAME,
   port: process.env.GAMESERVER_PORT,
   mode: process.env.SERVER_MODE,
-  locationName: process.env.PRELOAD_LOCATION_NAME
+  locationName: process.env.PRELOAD_LOCATION_NAME,
+  shutdownDelayMs: parseInt(process.env.GAMESERVER_SHUTDOWN_DELAY_MS) || 0
 }
 
 /**


### PR DESCRIPTION
## Summary

When the last user leaves a gameserver, it sets a timeout with a configured
delay before cleaning up and shutting itself down. If a user connects to it
before the timeout finishes, the timeout is cleared.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers

## References

#4152 

## Reviewers

@HexaField @speigg @NateTheGreatt