### PR TITLE
Deleting project removes from storage provider and invalidates cache

### DIFF
--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -33,29 +33,32 @@ const storageProvider = useStorageProvider()
 export const getStorageProviderPath = (projectName: string) =>
   `https://${storageProvider.cacheDomain}/projects/${projectName}/`
 
+export const deleteProjectFilesInStorageProvider = async (projectName: string) => {
+  try {
+    const existingFiles = await getFileKeysRecursive(`projects/${projectName}`)
+    if (existingFiles.length) {
+      await Promise.all([
+        storageProvider.deleteResources(existingFiles),
+        storageProvider.createInvalidation([`projects/${projectName}*`])
+      ])
+    }
+  } catch (e) {}
+}
+
 /**
  * Updates the local storage provider with the project's current files
  * @param projectName
  */
-export const uploadLocalProjectToProvider = async (projectName, remove = true, exclusionList: RegExp[] = []) => {
+export const uploadLocalProjectToProvider = async (projectName, remove = true) => {
   // remove exiting storage provider files
   if (remove) {
-    try {
-      const existingFiles = await getFileKeysRecursive(`projects/${projectName}`)
-      if (existingFiles.length) {
-        await Promise.all([
-          storageProvider.deleteResources(existingFiles.filter((file) => exclusionList.find((exc) => exc.test(file)))),
-          storageProvider.createInvalidation([`projects/${projectName}*`])
-        ])
-      }
-    } catch (e) {}
+    await deleteProjectFilesInStorageProvider(projectName)
   }
   // upload new files to storage provider
   const projectPath = path.resolve(appRootPath.path, 'packages/projects/projects/', projectName)
   const files = getFilesRecursive(projectPath)
   const results = await Promise.all(
     files.map((file: string) => {
-      if (exclusionList.find((exc) => exc.test(file))) return Promise.resolve()
       return new Promise(async (resolve) => {
         try {
           const fileResult = fs.readFileSync(file)
@@ -262,6 +265,8 @@ export class Project extends Service {
   async remove(id: Id, params?: Params) {
     console.log('remove', id)
     try {
+      const { name } = await super.get(id, params)
+      await deleteProjectFilesInStorageProvider(name)
       await super.remove(id, params)
     } catch (e) {
       console.log(`[Projects]: failed to remove project ${id}`, e)


### PR DESCRIPTION
## Summary

When a project is deleted via the admin panel, it currently is not being removed from the storage provider or being invalidated on cloudfront.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [ ] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## Reviewers
