### PR TITLE
Consolidate error logging

### DIFF
--- a/packages/client-core/src/admin/services/ActiveRouteService.ts
+++ b/packages/client-core/src/admin/services/ActiveRouteService.ts
@@ -46,8 +46,7 @@ export const ActiveRouteService = {
         ActiveRouteService.fetchActiveRoutes()
       }
     } catch (err) {
-      console.error(err)
-      AlertService.dispatchAlertError(err.message)
+      AlertService.dispatchAlertError(err)
     }
   },
   fetchActiveRoutes: async (incDec?: 'increment' | 'decrement') => {
@@ -59,8 +58,7 @@ export const ActiveRouteService = {
         dispatch(ActiveRouteActions.activeRoutesRetrievedAction(routes))
       }
     } catch (err) {
-      console.error(err)
-      AlertService.dispatchAlertError(err.message)
+      AlertService.dispatchAlertError(err)
     }
   }
 }

--- a/packages/client-core/src/admin/services/AdminService.ts
+++ b/packages/client-core/src/admin/services/AdminService.ts
@@ -49,7 +49,7 @@ export const AdminService = {
       AlertService.dispatchAlertSuccess('Video uploaded')
       dispatch(AdminAction.videoCreated(result))
     } catch (err) {
-      AlertService.dispatchAlertError('Video upload error: ' + err.response.data.message)
+      AlertService.dispatchAlertError(new Error('Video upload error: ' + err.response.data.message))
     }
   },
   updateVideo: async (data: VideoUpdateForm) => {

--- a/packages/client-core/src/admin/services/GroupService.ts
+++ b/packages/client-core/src/admin/services/GroupService.ts
@@ -72,8 +72,7 @@ export const GroupService = {
         })
         dispatch(GroupAction.setAdminGroup(list))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -84,8 +83,7 @@ export const GroupService = {
         const newGroup = await client.service('group').create({ ...groupItem })
         dispatch(GroupAction.addAdminGroup(newGroup))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -96,8 +94,7 @@ export const GroupService = {
         const group = await client.service('group').patch(groupId, groupItem)
         dispatch(GroupAction.updateGroup(group))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -108,8 +105,7 @@ export const GroupService = {
         await client.service('group').remove(groupId)
         dispatch(GroupAction.removeGroupAction(groupId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/admin/services/InstanceService.ts
+++ b/packages/client-core/src/admin/services/InstanceService.ts
@@ -74,8 +74,7 @@ export const InstanceService = {
           dispatch(InstanceAction.instancesRetrievedAction(instances))
         }
       } catch (err) {
-        console.error(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },

--- a/packages/client-core/src/admin/services/LocationService.ts
+++ b/packages/client-core/src/admin/services/LocationService.ts
@@ -82,8 +82,7 @@ export const LocationService = {
         const result = await client.service('location').patch(id, location)
         dispatch(LocationAction.locationPatched(result))
       } catch (err) {
-        console.error(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -101,8 +100,7 @@ export const LocationService = {
         const result = await client.service('location').create(location)
         dispatch(LocationAction.locationCreated(result))
       } catch (err) {
-        console.error(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },

--- a/packages/client-core/src/admin/services/PartyService.ts
+++ b/packages/client-core/src/admin/services/PartyService.ts
@@ -46,8 +46,7 @@ export const PartyService = {
         const result = await client.service('party').create(data)
         dispatch(PartyAction.partyAdminCreated(result))
       } catch (err) {
-        console.error(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -72,8 +71,7 @@ export const PartyService = {
           dispatch(PartyAction.partyRetrievedAction(parties))
         }
       } catch (err) {
-        console.error(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/admin/services/RouteService.ts
+++ b/packages/client-core/src/admin/services/RouteService.ts
@@ -47,8 +47,7 @@ export const RouteService = {
         dispatch(RouteActions.installedRoutesRetrievedAction(routes))
       }
     } catch (err) {
-      console.error(err)
-      AlertService.dispatchAlertError(err.message)
+      AlertService.dispatchAlertError(err)
     }
   }
 }

--- a/packages/client-core/src/admin/services/ScopeService.ts
+++ b/packages/client-core/src/admin/services/ScopeService.ts
@@ -64,8 +64,7 @@ export const ScopeService = {
         })
         dispatch(ScopeAction.addAdminScope(newItem))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -85,8 +84,7 @@ export const ScopeService = {
         })
         dispatch(ScopeAction.setAdminScope(list))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -99,8 +97,7 @@ export const ScopeService = {
         })
         dispatch(ScopeAction.updateAdminScope(updatedScope))
       } catch (err) {
-        console.error(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -111,8 +108,7 @@ export const ScopeService = {
         await client.service('scope').remove(scopeId)
         dispatch(ScopeAction.removeScopeItem(scopeId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/admin/services/ScopeTypeService.ts
+++ b/packages/client-core/src/admin/services/ScopeTypeService.ts
@@ -59,8 +59,7 @@ export const ScopeTypeService = {
         })
         dispatch(ScopeTypeAction.getScopeTypes(result))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/admin/services/Setting/AdminRedisSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/AdminRedisSettingService.ts
@@ -35,7 +35,7 @@ export const AdminRedisSettingService = {
         const redisSetting = await client.service('redis-setting').find()
         dispatch(AdminRedisSettingAction.redisSettingRetrieved(redisSetting))
       } catch (err) {
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/admin/services/Setting/AuthSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/AuthSettingService.ts
@@ -46,7 +46,7 @@ export const AuthSettingService = {
         const authSetting = await client.service('authentication-setting').find()
         dispatch(AuthSettingAction.authSettingRetrieved(authSetting))
       } catch (err) {
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -57,8 +57,7 @@ export const AuthSettingService = {
         const result = await client.service('authentication-setting').patch(id, data)
         dispatch(AuthSettingAction.authSettingPatched(result))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/admin/services/Setting/AwsSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/AwsSettingService.ts
@@ -36,7 +36,7 @@ export const AwsSettingService = {
         const awsSetting = await client.service('aws-setting').find()
         dispatch(AwsSettingAction.awsSettingRetrieved(awsSetting))
       } catch (err) {
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/admin/services/Setting/ChargebeeSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/ChargebeeSettingService.ts
@@ -32,7 +32,7 @@ export const ChargebeeSettingService = {
         const chargeBee = await client.service('chargebee-setting').find()
         dispatch(ChargebeeSettingAction.fetchedChargebee(chargeBee))
       } catch (err) {
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/admin/services/UserRoleService.ts
+++ b/packages/client-core/src/admin/services/UserRoleService.ts
@@ -46,8 +46,7 @@ export const UserROleService = {
         const userRole = await client.service('user-role').find()
         dispatch(UserRoleAction.userRoleRetrieved(userRole))
       } catch (err) {
-        console.error(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -65,8 +64,7 @@ export const UserROleService = {
         const userRole = await client.service('user').patch(id, { userRole: role })
         dispatch(UserRoleAction.userRoleUpdated(userRole))
       } catch (err) {
-        console.error(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/admin/services/UserService.ts
+++ b/packages/client-core/src/admin/services/UserService.ts
@@ -102,8 +102,7 @@ export const UserService = {
           dispatch(UserAction.loadedUsers(users))
         }
       } catch (err) {
-        console.error(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -157,8 +156,7 @@ export const UserService = {
         })
         dispatch(UserAction.searchedUser(result))
       } catch (err) {
-        console.error(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },

--- a/packages/client-core/src/common/services/AlertService.ts
+++ b/packages/client-core/src/common/services/AlertService.ts
@@ -70,10 +70,11 @@ export const AlertService = {
     AlertService.restartTimer()
     return dispatch(AlertAction.showAlert('warning', message))
   },
-  dispatchAlertError: (message: string) => {
+  dispatchAlertError: (err: Error) => {
     const dispatch = useDispatch()
     AlertService.restartTimer()
-    return dispatch(AlertAction.showAlert('error', message))
+    console.error(err)
+    return dispatch(AlertAction.showAlert('error', err.message))
   },
   dispatchAlertCancel: () => {
     const dispatch = useDispatch()

--- a/packages/client-core/src/social/services/ArMediaService.ts
+++ b/packages/client-core/src/social/services/ArMediaService.ts
@@ -81,8 +81,7 @@ export const ArMediaService = {
         })
         dispatch(ArMediaAction.setAdminArMedia(list))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -94,8 +93,7 @@ export const ArMediaService = {
         const list = await client.service('ar-media').find({ query: { action: type || null } })
         dispatch(ArMediaAction.setArMedia(list.data))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -107,8 +105,7 @@ export const ArMediaService = {
         const item = await client.service('ar-media').get(itemId)
         dispatch(ArMediaAction.retrievedArMediaItem(item))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -135,8 +132,7 @@ export const ArMediaService = {
         })
         dispatch(ArMediaAction.addAdminArMedia(newItem))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -163,8 +159,7 @@ export const ArMediaService = {
         await client.service('ar-media').remove(mediaItemId)
         dispatch(ArMediaAction.removeArMediaItem(mediaItemId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/social/services/ChatService.ts
+++ b/packages/client-core/src/social/services/ChatService.ts
@@ -233,8 +233,7 @@ export const ChatService = {
         })
         dispatch(ChatAction.loadedChannels(channelResult))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -249,7 +248,7 @@ export const ChatService = {
         })
         dispatch(ChatAction.loadedChannel(channelResult.data[0], 'instance'))
       } catch (err) {
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -271,8 +270,7 @@ export const ChatService = {
         }
         await client.service('message').create(data)
       } catch (err) {
-        console.error(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -312,8 +310,7 @@ export const ChatService = {
         })
         dispatch(ChatAction.loadedMessages(channelId, messageResult))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -323,8 +320,7 @@ export const ChatService = {
       try {
         await client.service('message').remove(messageId)
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -336,8 +332,7 @@ export const ChatService = {
           text: text
         })
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },

--- a/packages/client-core/src/social/services/CreatorService.ts
+++ b/packages/client-core/src/social/services/CreatorService.ts
@@ -115,8 +115,7 @@ export const CreatorService = {
         const creatorResponse = await client.service('creator').create(creatorInfo)
         dispatch(CreatorAction.creatorLoggedRetrieved(creatorResponse))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -128,8 +127,7 @@ export const CreatorService = {
         const creator = await client.service('creator').find({ query: { action: 'current' } })
         dispatch(CreatorAction.creatorLoggedRetrieved(creator))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -141,8 +139,7 @@ export const CreatorService = {
         const results = await client.service('creator').find({ query: {} })
         dispatch(CreatorAction.creatorsRetrieved(results))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -154,8 +151,7 @@ export const CreatorService = {
         const creator = await client.service('creator').get(creatorId)
         dispatch(CreatorAction.creatorRetrieved(creator))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -178,8 +174,7 @@ export const CreatorService = {
           }
         }
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
         if (callBack) {
           callBack(err.message)
         }
@@ -195,8 +190,7 @@ export const CreatorService = {
         const notificationList = await client.service('notifications').find({ query: { action: 'byCurrentCreator' } })
         dispatch(CreatorAction.creatorNotificationList(notificationList))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -207,8 +201,7 @@ export const CreatorService = {
         const follow = await client.service('follow-creator').create({ creatorId })
         follow && dispatch(CreatorAction.updateCreatorAsFollowed())
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -219,8 +212,7 @@ export const CreatorService = {
         const follow = await client.service('follow-creator').remove(creatorId)
         follow && dispatch(CreatorAction.updateCreatorNotFollowed())
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -231,8 +223,7 @@ export const CreatorService = {
         const follow = await client.service('block-creator').create({ creatorId })
         follow && dispatch(CreatorAction.updateCreatorAsBlocked(creatorId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -246,8 +237,7 @@ export const CreatorService = {
           CreatorService.getCreators()
         }
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -258,8 +248,7 @@ export const CreatorService = {
         const list = await client.service('block-creator').find({ query: { action: 'blocked', creatorId } })
         dispatch(CreatorAction.creatorBlockedUsers(list.data))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -270,8 +259,7 @@ export const CreatorService = {
         const list = await client.service('follow-creator').find({ query: { action: 'followers', creatorId } })
         dispatch(CreatorAction.creatorFollowers(list.data))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -282,8 +270,7 @@ export const CreatorService = {
         const list = await client.service('follow-creator').find({ query: { action: 'following', creatorId } })
         dispatch(CreatorAction.creatorFollowing(list.data))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/social/services/FeedCommentService.ts
+++ b/packages/client-core/src/social/services/FeedCommentService.ts
@@ -64,8 +64,7 @@ export const FeedCommentService = {
         const comments = await client.service('comments').find({ query: { feedId } })
         dispatch(FeedCommentAction.feedsCommentsRetrieved(comments.data))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -76,8 +75,7 @@ export const FeedCommentService = {
         const newComment = await client.service('comments').create({ feedId, text })
         dispatch(FeedCommentAction.addFeedComment(newComment))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -88,8 +86,7 @@ export const FeedCommentService = {
         await client.service('comments-fires').create({ commentId })
         dispatch(FeedCommentAction.addFeedCommentFire(commentId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -100,8 +97,7 @@ export const FeedCommentService = {
         await client.service('comments-fires').remove(commentId)
         dispatch(FeedCommentAction.removeFeedCommentFire(commentId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -112,8 +108,7 @@ export const FeedCommentService = {
         const comments = await client.service('comments-fires').find({ query: { action: 'comment-fires', commentId } })
         dispatch(FeedCommentAction.commentFires(comments.data))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/social/services/FeedFiresService.ts
+++ b/packages/client-core/src/social/services/FeedFiresService.ts
@@ -40,8 +40,7 @@ export const FeedFiresService = {
         const feedsResults = await client.service('feed-fires').find({ query: { feedId: feedId } })
         dispatch(FeedFiresAction.feedFiresRetrieved(feedsResults.data))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -52,8 +51,7 @@ export const FeedFiresService = {
         await client.service('feed-fires').create({ feedId })
         dispatch(FeedAction.addFeedFire(feedId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -64,8 +62,7 @@ export const FeedFiresService = {
         await client.service('feed-fires').remove(feedId)
         dispatch(FeedAction.removeFeedFire(feedId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/social/services/FeedService.ts
+++ b/packages/client-core/src/social/services/FeedService.ts
@@ -264,8 +264,7 @@ export const FeedService = {
           dispatch(FeedAction.feedsRetrieved(feedsResults.data))
         }
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -277,8 +276,7 @@ export const FeedService = {
         const feed = await client.service('feed').get(feedId)
         dispatch(FeedAction.feedRetrieved(feed))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -289,8 +287,7 @@ export const FeedService = {
         await client.service('feed').patch(feedId, { viewsCount: feedId })
         dispatch(FeedAction.addFeedView(feedId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -311,8 +308,7 @@ export const FeedService = {
           return mediaLinks
         }
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -333,8 +329,7 @@ export const FeedService = {
         const updatedFeed = await client.service('feed').patch(feedId, feed)
         dispatch(FeedAction.updateFeedInList(updatedFeed))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -345,8 +340,7 @@ export const FeedService = {
         await client.service('feed').patch(feedId, { featured: 1 })
         dispatch(FeedAction.feedAsFeatured(feedId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -357,8 +351,7 @@ export const FeedService = {
         await client.service('feed').patch(feedId, { featured: 0 })
         dispatch(FeedAction.feedNotFeatured(feedId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -378,8 +371,7 @@ export const FeedService = {
         await client.service('feed').remove(feedId)
         dispatch(FeedAction.deleteFeed(feedId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -395,8 +387,7 @@ export const FeedService = {
       try {
         dispatch(FeedAction.lastFeedVideoUrl(filepath))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/social/services/FriendService.ts
+++ b/packages/client-core/src/social/services/FriendService.ts
@@ -123,8 +123,7 @@ export const FriendService = {
         })
         dispatch(FriendAction.loadedFriends(friendResult))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
         dispatch(FriendAction.loadedFriends({ data: [], limit: 0, skip: 0, total: 0 }))
       }
     }
@@ -152,8 +151,7 @@ export const FriendService = {
       try {
         await client.service('user-relationship').remove(relatedUserId)
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },

--- a/packages/client-core/src/social/services/GroupService.ts
+++ b/packages/client-core/src/social/services/GroupService.ts
@@ -191,8 +191,7 @@ export const GroupService = {
         })
         dispatch(GroupAction.loadedGroups(groupResults))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -205,8 +204,7 @@ export const GroupService = {
           description: values.description
         })
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -223,8 +221,7 @@ export const GroupService = {
       try {
         await client.service('group').patch(values.id, patch)
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -242,8 +239,7 @@ export const GroupService = {
         }
         await client.service('group').remove(groupId)
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -253,8 +249,7 @@ export const GroupService = {
       try {
         await client.service('group-user').remove(groupUserId)
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -274,8 +269,7 @@ export const GroupService = {
         })
         dispatch(GroupAction.loadedInvitableGroups(groupResults))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
         dispatch(GroupAction.loadedInvitableGroups({ data: [], limit: 0, skip: 0, total: 0 }))
       }
     }

--- a/packages/client-core/src/social/services/InviteService.ts
+++ b/packages/client-core/src/social/services/InviteService.ts
@@ -101,20 +101,20 @@ export const InviteService = {
     {
       if (data.identityProviderType === 'email') {
         if (emailRegex.test(data.token) !== true) {
-          AlertService.dispatchAlertError('Invalid email address')
+          AlertService.dispatchAlertError(new Error('Invalid email address'))
           return
         }
       }
       if (data.identityProviderType === 'sms') {
         if (phoneRegex.test(data.token) !== true) {
-          AlertService.dispatchAlertError('Invalid 10-digit US phone number')
+          AlertService.dispatchAlertError(new Error('Invalid 10-digit US phone number'))
           return
         }
       }
 
       if (data.inviteCode != null) {
         if (inviteCodeRegex.test(data.inviteCode) !== true) {
-          AlertService.dispatchAlertError('Invalid Invite Code')
+          AlertService.dispatchAlertError(new Error('Invalid Invite Code'))
           return
         } else {
           const userResult = await client.service('user').find({
@@ -129,7 +129,7 @@ export const InviteService = {
           }
 
           if (userResult.total === 0) {
-            AlertService.dispatchAlertError('No user has that invite code')
+            AlertService.dispatchAlertError(new Error('No user has that invite code'))
             return
           } else {
             data.invitee = userResult.data[0].id
@@ -139,13 +139,13 @@ export const InviteService = {
 
       if (data.invitee != null) {
         if (userIdRegex.test(data.invitee) !== true) {
-          AlertService.dispatchAlertError('Invalid user ID')
+          AlertService.dispatchAlertError(new Error('Invalid user ID'))
           return
         }
       }
 
       if ((data.token == null || data.token.length === 0) && (data.invitee == null || data.invitee.length === 0)) {
-        AlertService.dispatchAlertError(`Not a valid recipient`)
+        AlertService.dispatchAlertError(new Error(`Not a valid recipient`))
         return
       }
 
@@ -167,8 +167,7 @@ export const InviteService = {
         AlertService.dispatchAlertSuccess('Invite Sent')
         dispatch(InviteAction.sentInvite(inviteResult))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -190,8 +189,7 @@ export const InviteService = {
         })
         dispatch(InviteAction.retrievedReceivedInvites(inviteResult))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -213,7 +211,7 @@ export const InviteService = {
         })
         dispatch(InviteAction.retrievedSentInvites(inviteResult))
       } catch (err) {
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -224,8 +222,7 @@ export const InviteService = {
         await client.service('invite').remove(invite.id)
         dispatch(InviteAction.removedSentInvite())
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -240,8 +237,7 @@ export const InviteService = {
         })
         dispatch(InviteAction.acceptedInvite())
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -252,7 +248,7 @@ export const InviteService = {
         await client.service('invite').remove(invite.id)
         dispatch(InviteAction.declinedInvite())
       } catch (err) {
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },

--- a/packages/client-core/src/social/services/InviteTypeService.ts
+++ b/packages/client-core/src/social/services/InviteTypeService.ts
@@ -45,8 +45,7 @@ export const InviteTypeService = {
         const inviteTypeResult = await client.service('invite-type').find()
         dispatch(InviteTypeAction.retrievedInvitesTypes(inviteTypeResult))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/social/services/LocationService.ts
+++ b/packages/client-core/src/social/services/LocationService.ts
@@ -106,8 +106,7 @@ export const LocationService = {
         })
         dispatch(LocationAction.socialLocationsRetrieved(locationResults))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -119,8 +118,7 @@ export const LocationService = {
         const location = await client.service('location').get(locationId)
         dispatch(LocationAction.socialLocationRetrieved(location))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -172,8 +170,7 @@ export const LocationService = {
         })
         dispatch(LocationAction.socialLocationBanCreated())
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/social/services/PartyService.ts
+++ b/packages/client-core/src/social/services/PartyService.ts
@@ -107,7 +107,7 @@ export const PartyService = {
         const partyResult = await client.service('party').get(null)
         dispatch(PartyAction.loadedParty(partyResult))
       } catch (err) {
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -161,8 +161,7 @@ export const PartyService = {
       try {
         await client.service('party').create({})
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -181,8 +180,7 @@ export const PartyService = {
         }
         await client.service('party').remove(partyId)
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -192,8 +190,7 @@ export const PartyService = {
       try {
         await client.service('party-user').remove(partyUserId)
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -205,8 +202,7 @@ export const PartyService = {
           isOwner: 1
         })
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/social/services/PopupsStateService.ts
+++ b/packages/client-core/src/social/services/PopupsStateService.ts
@@ -63,8 +63,7 @@ export const PopupsStateService = {
       try {
         dispatch(PopupsStateAction.changeCreatorPage(state, id))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -74,8 +73,7 @@ export const PopupsStateService = {
       try {
         dispatch(PopupsStateAction.changeCreatorForm(state))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -85,8 +83,7 @@ export const PopupsStateService = {
       try {
         dispatch(PopupsStateAction.changeFeedPage(state, id))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -96,8 +93,7 @@ export const PopupsStateService = {
       try {
         dispatch(PopupsStateAction.changeNewFeedPage(state, id, fPath, nameId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -107,8 +103,7 @@ export const PopupsStateService = {
       try {
         dispatch(PopupsStateAction.changeShareForm(state, id, imgSrc))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -118,8 +113,7 @@ export const PopupsStateService = {
       try {
         dispatch(PopupsStateAction.changeArMedia(state))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -129,8 +123,7 @@ export const PopupsStateService = {
       try {
         dispatch(PopupsStateAction.changeWebXR(state, itemId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/social/services/RegistrationService.ts
+++ b/packages/client-core/src/social/services/RegistrationService.ts
@@ -46,8 +46,7 @@ export const RegistrationService = {
 
         // dispatch(creatorLoggedRetrieved(creator))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/social/services/TheFeedsFiresService.ts
+++ b/packages/client-core/src/social/services/TheFeedsFiresService.ts
@@ -48,8 +48,7 @@ export const TheFeedsFiresService = {
         //       dispatch(thefeedsFiresRetrieved(thefeedsResults.data, thefeedsId));
         setThefeedsFires(thefeedsResults)
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -64,8 +63,7 @@ export const TheFeedsFiresService = {
         //@ts-ignore
         dispatch(addTheFeedsFire(feedsFireStore))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -76,8 +74,7 @@ export const TheFeedsFiresService = {
         await client.service('thefeeds-fires').remove(thefeedsId)
         dispatch(TheFeedsAction.removeTheFeedsFire(thefeedsId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/social/services/TheFeedsService.ts
+++ b/packages/client-core/src/social/services/TheFeedsService.ts
@@ -52,8 +52,7 @@ export const TheFeedsService = {
         const thefeeds = await client.service('thefeeds').find()
         dispatch(TheFeedsAction.thefeedsRetrieved(thefeeds.data))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -70,8 +69,7 @@ export const TheFeedsService = {
         })
         dispatch(TheFeedsAction.addTheFeeds(thefeeds))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -87,8 +85,7 @@ export const TheFeedsService = {
         const updatedItem = await client.service('thefeeds').patch(thefeeds.id, thefeeds)
         dispatch(TheFeedsAction.updateTheFeedsInList(updatedItem))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -99,8 +96,7 @@ export const TheFeedsService = {
         await client.service('thefeeds').remove(thefeedsId)
         dispatch(TheFeedsAction.deleteTheFeeds(thefeedsId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/social/services/WebxrNativeService.ts
+++ b/packages/client-core/src/social/services/WebxrNativeService.ts
@@ -34,8 +34,7 @@ export const WebxrNativeService = {
       try {
         dispatch(WebxrNativeAction.setWebXrNative())
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -46,8 +45,7 @@ export const WebxrNativeService = {
       try {
         dispatch(WebxrNativeAction.tougleWebXrNative())
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -245,8 +245,7 @@ export const AuthService = {
         dispatch(AuthAction.loadedUserData(user))
       })
       .catch((err: any) => {
-        console.log(err)
-        AlertService.dispatchAlertError('Failed to load user data')
+        AlertService.dispatchAlertError(new Error('Failed to load user data'))
       })
   },
   loginUserByPassword: async (form: EmailLoginForm) => {
@@ -254,7 +253,7 @@ export const AuthService = {
     {
       // check email validation.
       if (!validateEmail(form.email)) {
-        AlertService.dispatchAlertError('Please input valid email address')
+        AlertService.dispatchAlertError(new Error('Please input valid email address'))
 
         return
       }
@@ -281,10 +280,8 @@ export const AuthService = {
           AuthService.loadUserData(authUser.identityProvider.userId).then(() => (window.location.href = '/'))
         })
         .catch((err: any) => {
-          console.log(err)
-
           dispatch(AuthAction.loginUserError('Failed to login'))
-          AlertService.dispatchAlertError(err.message)
+          AlertService.dispatchAlertError(err)
         })
         .finally(() => dispatch(AuthAction.actionProcessing(false)))
     }
@@ -307,9 +304,8 @@ export const AuthService = {
         loadXRAvatarForUpdatedUser(walletUser)
         dispatch(AuthAction.loadedUserData(walletUser))
       } catch (err) {
-        console.log(err)
         dispatch(AuthAction.loginUserError('Failed to login'))
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       } finally {
         dispatch(AuthAction.actionProcessing(false))
       }
@@ -352,9 +348,8 @@ export const AuthService = {
         dispatch(AuthAction.actionProcessing(false))
         window.location.href = redirectSuccess
       } catch (err) {
-        console.log(err)
         dispatch(AuthAction.loginUserError('Failed to login'))
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
         window.location.href = `${redirectError}?error=${err.message}`
         dispatch(AuthAction.actionProcessing(false))
       }
@@ -395,7 +390,7 @@ export const AuthService = {
         .catch((err: any) => {
           console.log('error', err)
           dispatch(AuthAction.registerUserByEmailError(err.message))
-          AlertService.dispatchAlertError(err.message)
+          AlertService.dispatchAlertError(err)
         })
         .finally(() => {
           console.log('4 finally', dispatch)
@@ -419,9 +414,8 @@ export const AuthService = {
           AuthService.loginUserByJwt(res.accessToken, '/', '/')
         })
         .catch((err: any) => {
-          console.log(err)
           dispatch(AuthAction.didVerifyEmail(false))
-          AlertService.dispatchAlertError(err.message)
+          AlertService.dispatchAlertError(err)
         })
         .finally(() => dispatch(AuthAction.actionProcessing(false)))
     }
@@ -481,7 +475,6 @@ export const AuthService = {
           window.location.href = '/'
         })
         .catch((err: any) => {
-          console.log(err)
           dispatch(AuthAction.didResetPassword(false))
           window.location.href = '/'
         })
@@ -510,7 +503,7 @@ export const AuthService = {
         const stripped = emailPhone.replace(/-/g, '')
         if (validatePhoneNumber(stripped)) {
           if (!enableSmsMagicLink) {
-            AlertService.dispatchAlertError('Please input valid email address')
+            AlertService.dispatchAlertError(new Error('Please input valid email address'))
 
             return
           }
@@ -519,13 +512,13 @@ export const AuthService = {
           emailPhone = '+1' + stripped
         } else if (validateEmail(emailPhone)) {
           if (!enableEmailMagicLink) {
-            AlertService.dispatchAlertError('Please input valid phone number')
+            AlertService.dispatchAlertError(new Error('Please input valid phone number'))
 
             return
           }
           type = 'email'
         } else {
-          AlertService.dispatchAlertError('Please input valid email or phone number')
+          AlertService.dispatchAlertError(new Error('Please input valid email or phone number'))
 
           return
         }
@@ -543,9 +536,8 @@ export const AuthService = {
           AlertService.dispatchAlertSuccess('Login Magic Link was sent. Please check your Email or SMS.')
         })
         .catch((err: any) => {
-          console.log(err)
           dispatch(AuthAction.didCreateMagicLink(false))
-          AlertService.dispatchAlertError(err.message)
+          AlertService.dispatchAlertError(err)
         })
         .finally(() => dispatch(AuthAction.actionProcessing(false)))
     }
@@ -568,8 +560,7 @@ export const AuthService = {
           return AuthService.loadUserData(identityProvider.userId)
         })
         .catch((err: any) => {
-          console.log(err)
-          AlertService.dispatchAlertError(err.message)
+          AlertService.dispatchAlertError(err)
         })
         .finally(() => dispatch(AuthAction.actionProcessing(false)))
     }
@@ -590,8 +581,7 @@ export const AuthService = {
           if (identityProvider.userId != null) return AuthService.loadUserData(identityProvider.userId)
         })
         .catch((err: any) => {
-          console.log(err)
-          AlertService.dispatchAlertError(err.message)
+          AlertService.dispatchAlertError(err)
         })
         .finally(() => dispatch(AuthAction.actionProcessing(false)))
     }
@@ -618,8 +608,7 @@ export const AuthService = {
           if (identityProvider.userId != null) return AuthService.loadUserData(identityProvider.userId)
         })
         .catch((err: any) => {
-          console.log(err)
-          AlertService.dispatchAlertError(err.message)
+          AlertService.dispatchAlertError(err)
         })
         .finally(() => dispatch(AuthAction.actionProcessing(false)))
     }
@@ -642,8 +631,7 @@ export const AuthService = {
           return AuthService.loadUserData(userId)
         })
         .catch((err: any) => {
-          console.log(err)
-          AlertService.dispatchAlertError(err.message)
+          AlertService.dispatchAlertError(err)
         })
         .finally(() => dispatch(AuthAction.actionProcessing(false)))
     }

--- a/packages/social/src/state/FeedBookmarkService.ts
+++ b/packages/social/src/state/FeedBookmarkService.ts
@@ -14,8 +14,7 @@ export const FeedBookmarkService = {
         await client.service('feed-bookmark').create({ feedId })
         dispatch(FeedAction.addFeedBookmark(feedId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -26,8 +25,7 @@ export const FeedBookmarkService = {
         await client.service('feed-bookmark').remove(feedId)
         dispatch(FeedAction.removeFeedBookmark(feedId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/social/src/state/FeedLikesService.ts
+++ b/packages/social/src/state/FeedLikesService.ts
@@ -13,7 +13,7 @@ export const FeedLikesService = {
         const feedsResults = await client.service('feed-likes').find({ query: { feedId: feedId } })
         dispatch(FeedLikesAction.feedLikesRetrieved(feedsResults.data))
       } catch (err) {
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -24,7 +24,7 @@ export const FeedLikesService = {
         await client.service('feed-likes').create({ feedId })
         dispatch(FeedAction.addFeedLike(feedId))
       } catch (err) {
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -35,7 +35,7 @@ export const FeedLikesService = {
         await client.service('feed-likes').remove(feedId)
         dispatch(FeedAction.removeFeedLike(feedId))
       } catch (err) {
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/social/src/state/FeedReportsService.ts
+++ b/packages/social/src/state/FeedReportsService.ts
@@ -29,8 +29,7 @@ export const FeedReportsService = {
         await client.service('feed-report').create({ feedId })
         // dispatch(addFeedReport(feedId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }

--- a/packages/social/src/state/TheFeedsBookmarkService.ts
+++ b/packages/social/src/state/TheFeedsBookmarkService.ts
@@ -18,8 +18,7 @@ export const TheFeedsBookmarkService = {
         let thefeeds = await client.service('thefeeds-bookmark').create({ thefeedsId })
         dispatch(TheFeedsBookmarkAction.addTheFeedsBookmark(thefeeds))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   },
@@ -30,8 +29,7 @@ export const TheFeedsBookmarkService = {
         await client.service('thefeeds-bookmark').remove(thefeedsId)
         dispatch(TheFeedsBookmarkAction.removeTheFeedsBookmark(thefeedsId))
       } catch (err) {
-        console.log(err)
-        AlertService.dispatchAlertError(err.message)
+        AlertService.dispatchAlertError(err)
       }
     }
   }


### PR DESCRIPTION
## Summary

Some errors were being caught in try/catch blocks, displayed in a toast, and never printed to the console; now we pass entire error objects to `AlertService.dispatchAlertError(err)` where the errors can be logged consistently. 

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## Reviewers

@HexaField @speigg @NateTheGreatt
