### PR TITLE
Lock threejs to a specific commit from github until webxr bugs are fixed

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -64,7 +64,6 @@
     "react-router-dom": "5.3.0",
     "sass": "1.43.4",
     "socket.io-client": "4.4.0",
-    "three": "0.135.0",
     "webxr-native": "0.3.0",
     "yuka": "0.7.6"
   },

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -58,7 +58,7 @@
     "react": "17.0.2",
     "simplex-noise": "^3.0.0",
     "socket.io": "4.4.0",
-    "three": "0.135.0",
+    "three": "git://github.com/mrdoob/three.js.git#38eb8439c6f58188480c08d24f0e56321ff3f758",
     "three-mesh-bvh": "^0.5.0",
     "troika-three-text": "^0.44.0",
     "ts-matches": "^5.1.0-1",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -58,7 +58,7 @@
     "react": "17.0.2",
     "simplex-noise": "^3.0.0",
     "socket.io": "4.4.0",
-    "three": "git://github.com/mrdoob/three.js.git#38eb8439c6f58188480c08d24f0e56321ff3f758",
+    "three": "git://github.com/XRFoundation/three.js.git#5fcd5dd253ba9f6196cbe04968e5925cb5ef4c9a",
     "three-mesh-bvh": "^0.5.0",
     "troika-three-text": "^0.44.0",
     "ts-matches": "^5.1.0-1",

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -71,6 +71,7 @@
     "mime-types": "^2.1.34",
     "moment": "2.29.1",
     "multer": "^1.4.2",
+    "mysql2": "2.3.3",
     "nanoid": "3.1.30",
     "node-fetch": "^2.6.0",
     "nodemailer-smtp-transport": "^2.4.2",


### PR DESCRIPTION
## Summary

Locks threejs to a specific commit on github until webxr fixes are in

## References

https://github.com/mrdoob/three.js/pull/22918
https://github.com/mrdoob/three.js/pull/22919

