### PR TITLE
Updated cors-proxying to be done entirely via nginx in production.

### DIFF
--- a/packages/ops/xrengine/Chart.yaml
+++ b/packages/ops/xrengine/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.4.0
+version: 3.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/packages/ops/xrengine/templates/api-server-ingress.yaml
+++ b/packages/ops/xrengine/templates/api-server-ingress.yaml
@@ -1,7 +1,6 @@
 {{- if and .Values.api.enabled (ne (.Values.api.ingress.disabled | default "") "true") -}}
 {{- $fullName := include "xrengine.api.fullname" . -}}
 {{- $svcPort := .Values.api.service.port -}}
-{{- $corsSvcPort := .Values.api.service.corsServerPort -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -35,11 +34,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  {{ if (eq . "/cors-proxy(/|$)(.*)") }}
-                  number: {{ $corsSvcPort }}
-                  {{ else }}
                   number: {{ $svcPort }}
-                  {{ end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/packages/ops/xrengine/templates/api-server-service.yaml
+++ b/packages/ops/xrengine/templates/api-server-service.yaml
@@ -12,12 +12,6 @@ spec:
       targetPort: {{ .Values.api.service.port }}
       protocol: TCP
       name: http
-    {{ if .Values.api.service.corsServerPort }}
-    - port: {{  .Values.api.service.corsServerPort }}
-      targetPort: {{ .Values.api.service.corsServerPort }}
-      protocol: TCP
-      name: cors-proxy
-    {{ end }}
   selector:
     {{- include "xrengine.api.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/packages/server-core/src/world/scene/scene-parser.ts
+++ b/packages/server-core/src/world/scene/scene-parser.ts
@@ -7,7 +7,7 @@ import { getCachedAsset } from '../../media/storageprovider/getCachedAsset'
 export const sceneRelativePathIdentifier = '__$project$__'
 export const corsPath = isDev
   ? `https://${config.server.hostname}:${config.server.corsServerPort}`
-  : `​https://${config.server.hostname}/cors-proxy`
+  : `https://${config.server.hostname}/cors-proxy`
 
 export const parseSceneDataCacheURLs = (sceneData: SceneJson, cacheDomain: string) => {
   for (const [key, val] of Object.entries(sceneData)) {
@@ -18,7 +18,7 @@ export const parseSceneDataCacheURLs = (sceneData: SceneJson, cacheDomain: strin
       if (val.includes(sceneRelativePathIdentifier)) {
         sceneData[key] = getCachedAsset(val.replace(sceneRelativePathIdentifier, '/projects'), cacheDomain)
       } else if (val.startsWith('https://')) {
-        sceneData[key] = `${corsPath}/${val}`
+        sceneData[key] = isDev ? `${corsPath}/${val}` : `${corsPath}/${val.replace('https://', '')}`
       }
     }
   }
@@ -35,6 +35,7 @@ export const cleanSceneDataCacheURLs = (sceneData: SceneJson, cacheDomain: strin
         sceneData[key] = val.replace('https://' + cacheDomain + '/projects', sceneRelativePathIdentifier)
       } else if (val.startsWith(corsPath)) {
         sceneData[key] = (val as string).slice(corsPath?.length + 1)
+        if (!isDev && sceneData[key].search(/https:\/\//) < 0) sceneData[key] = 'https://' + sceneData[key]
       }
     }
   }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -70,5 +70,5 @@ process.on('unhandledRejection', (error, promise) => {
     logger.info('Feathers application started on %s://%s:%d', useSSL ? 'https' : 'http', config.server.hostname, port)
   )
 
-  StartCorsServer(useSSL, certOptions)
+  if (process.env.APP_ENV === 'development') StartCorsServer(useSSL, certOptions)
 })()


### PR DESCRIPTION
## Summary

The following ingress annotation will proxy requests passed to /cors-proxy/
_without a protocol_ and return them with the header Access-Control-Allow_Origin:
<caller's domain>:

      nginx.ingress.kubernetes.io/server-snippet: |
        location ~* /cors-proxy/(.*) {
          proxy_http_version 1.1;
          proxy_hide_header Access-Control-Allow-Origin;
          add_header Access-Control-Allow-Origin $http_origin;
          proxy_intercept_errors on;
          error_page 301 302 307 = @handle_redirects;
          proxy_pass https://$1?$args;
        }

        location @handle_redirects {
          proxy_pass_request_headers on;
          proxy_hide_header Access-Control-Allow-Origin;
          add_header Access-Control-Allow-Origin "$http_origin";
          proxy_pass $upstream_http_location;
        }

It will need to be added to api.ingress.annotations in the Helm config file.

Reverted Helm chart changes, since they are no longer necessary.

Updated scene-parser.ts to conditionally remove the 'https://' from proxied routes when
in production. Nginx requires a scheme in proxy_pass and has problems with double slashes
in capture groups that are being proxied, so we're assuming https for all proxy requests
and passing everything except the protocol after /cors-proxy/

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
