### PR TITLE
Fixed issues with audio/video not transmitting and local channel connection.

### DIFF
--- a/packages/gameserver/src/WebRTCFunctions.ts
+++ b/packages/gameserver/src/WebRTCFunctions.ts
@@ -73,7 +73,7 @@ export const sendNewProducer =
     const world = Engine.defaultWorld
     const selfClient = world.clients.get(userId)!
     if (selfClient?.socketId != null) {
-      for (const [userId, client] of world.clients) {
+      for (const [, client] of world.clients) {
         logger.info(`Sending media for ${userId}`)
         Object.entries(client.media!).map(([subName, subValue]) => {
           if (
@@ -526,8 +526,8 @@ export async function handleWebRtcSendTrack(socket, data, callback): Promise<any
       }
     }
 
-    for (const [userId, client] of world.clients) {
-      if (client.userId !== userId)
+    for (const [clientUserId, client] of world.clients) {
+      if (clientUserId !== userId)
         client.socket!.emit(
           MessageTypes.WebRTCCreateProducer.toString(),
           userId,

--- a/packages/gameserver/src/channels.ts
+++ b/packages/gameserver/src/channels.ts
@@ -174,7 +174,7 @@ export default (app: Application): void => {
 
             const isReady = status.state === 'Ready'
             const isNeedingNewServer =
-              config.kubernetes.enabled === false &&
+              !config.kubernetes.enabled &&
               (status.state === 'Shutdown' ||
                 app.instance == null ||
                 app.instance.locationId !== locationId ||
@@ -185,7 +185,7 @@ export default (app: Application): void => {
              * need to programatically shut down and restart the gameserver process.
              */
             console.log(app.instance?.locationId, locationId)
-            if (config.kubernetes.enabled === false && app.instance && app.instance.locationId !== locationId) {
+            if (!config.kubernetes.enabled && app.instance && app.instance.locationId != locationId) {
               app.restart()
               return
             }
@@ -273,7 +273,7 @@ export default (app: Application): void => {
               }
             }
             // console.log(`Patching user ${user.id} instanceId to ${app.instance.id}`);
-            const instanceIdKey = app.isChannelInstance === true ? 'channelInstanceId' : 'instanceId'
+            const instanceIdKey = app.isChannelInstance ? 'channelInstanceId' : 'instanceId'
             await app.service('user').patch(userId, {
               [instanceIdKey]: app.instance.id
             })
@@ -302,7 +302,7 @@ export default (app: Application): void => {
             await app.service('instance-attendance').create(newInstanceAttendance)
             ;(connection as any).instanceId = app.instance.id
             app.channel(`instanceIds/${app.instance.id as string}`).join(connection)
-            if (app.isChannelInstance !== true)
+            if (!app.isChannelInstance) {
               await app.service('message').create(
                 {
                   targetObjectId: app.instance.id,
@@ -316,40 +316,41 @@ export default (app: Application): void => {
                   }
                 }
               )
-            if (user.partyId != null) {
-              const partyUserResult = await app.service('party-user').find({
-                query: {
-                  partyId: user.partyId
-                }
-              })
-              const party = await app.service('party').get(user.partyId, null!)
-              const partyUsers = (partyUserResult as any).data
-              const partyOwner = partyUsers.find((partyUser) => partyUser.isOwner === 1)
-              if (partyOwner?.userId === userId && party.instanceId !== app.instance.id) {
-                await app.service('party').patch(user.partyId, {
-                  instanceId: app.instance.id
+              if (user.partyId != null) {
+                const partyUserResult = await app.service('party-user').find({
+                  query: {
+                    partyId: user.partyId
+                  }
                 })
-                const nonOwners = partyUsers.filter(
-                  (partyUser) => partyUser.isOwner !== 1 && partyUser.isOwner !== true
-                )
-                const emittedIp = !config.kubernetes.enabled
-                  ? await getLocalServerIp(app.isChannelInstance)
-                  : {
-                      ipAddress: status.address,
-                      port: status.portsList[0].port
-                    }
-                await Promise.all(
-                  nonOwners.map(async (partyUser) => {
-                    await app.service('instance-provision').emit('created', {
-                      userId: partyUser.userId,
-                      ipAddress: emittedIp.ipAddress,
-                      port: emittedIp.port,
-                      locationId: locationId,
-                      channelId: channelId,
-                      sceneId: sceneId
-                    })
+                const party = await app.service('party').get(user.partyId, null!)
+                const partyUsers = (partyUserResult as any).data
+                const partyOwner = partyUsers.find((partyUser) => partyUser.isOwner === 1)
+                if (partyOwner?.userId === userId && party.instanceId !== app.instance.id) {
+                  await app.service('party').patch(user.partyId, {
+                    instanceId: app.instance.id
                   })
-                )
+                  const nonOwners = partyUsers.filter(
+                    (partyUser) => partyUser.isOwner !== 1 && partyUser.isOwner !== true
+                  )
+                  const emittedIp = !config.kubernetes.enabled
+                    ? await getLocalServerIp(app.isChannelInstance)
+                    : {
+                        ipAddress: status.address,
+                        port: status.portsList[0].port
+                      }
+                  await Promise.all(
+                    nonOwners.map(async (partyUser) => {
+                      await app.service('instance-provision').emit('created', {
+                        userId: partyUser.userId,
+                        ipAddress: emittedIp.ipAddress,
+                        port: emittedIp.port,
+                        locationId: locationId,
+                        channelId: channelId,
+                        sceneId: sceneId
+                      })
+                    })
+                  )
+                }
               }
             }
           }


### PR DESCRIPTION
## Summary

New audio and video was not being sent to clients because of an improper overwrite of variable 'userId'
in handleWebRtcSendTrack().

Fixed a bug where local channel servers restarted on a second user joining since null was being !== to
undefined, which returns true. Changed that to !=. We're just checking if two different values for locationId
are different, if they're both undefined/null then no need to restart.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
