### PR TITLE
Create upload and projects folders if not found on server startup

### DIFF
--- a/packages/server-core/src/media/storageprovider/local.storage.ts
+++ b/packages/server-core/src/media/storageprovider/local.storage.ts
@@ -18,6 +18,13 @@ const keyPathRegex = /([a-zA-Z0-9/_-]+)\/[a-zA-Z0-9]+.[a-zA-Z0-9]+/
 export class LocalStorage implements StorageProviderInterface {
   path = './upload'
   cacheDomain = config.server.localStorageProvider
+
+  constructor() {
+    // make upload folder if it doesnt already exist
+    if (!fs.existsSync(path.join(appRootPath.path, 'packages/server/upload')))
+      fs.mkdirSync(path.join(appRootPath.path, 'packages/server/upload'))
+  }
+
   getObject = async (key: string): Promise<StorageObjectInterface> => {
     const filePath = path.join(appRootPath.path, 'packages', 'server', this.path, key)
     const result = await fs.promises.readFile(filePath)

--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -92,9 +92,6 @@ export class Project extends Service {
     super(options)
     this.app = app
 
-    // copy default project if it doesn't exist
-    if (!fs.existsSync(path.resolve(projectsRootFolder, 'default-project'))) copyDefaultProject()
-
     if (isDev && !config.db.forceRefresh) {
       this._fetchDevLocalProjects()
     }

--- a/packages/server-core/src/projects/project/project.service.ts
+++ b/packages/server-core/src/projects/project/project.service.ts
@@ -1,11 +1,15 @@
 import hooks from './project.hooks'
 import { Application } from '../../../declarations'
-import { Project } from './project.class'
+import { copyDefaultProject, Project } from './project.class'
 import createModel from './project.model'
 import projectDocs from './project.docs'
 import { retriggerBuilderService } from './project-helper'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 import * as authentication from '@feathersjs/authentication'
+import fs from 'fs'
+import path from 'path'
+import appRootPath from 'app-root-path'
+
 const { authenticate } = authentication.hooks
 
 declare module '../../../declarations' {
@@ -23,6 +27,10 @@ export default (app: Application): void => {
     paginate: app.get('paginate'),
     multi: true
   }
+
+  // copy default project if it doesn't exist
+  if (!fs.existsSync(path.resolve(path.join(appRootPath.path, 'packages/projects/projects/'), 'default-project')))
+    copyDefaultProject()
 
   const projectClass = new Project(options, app)
   projectClass.docs = projectDocs


### PR DESCRIPTION
## Summary

Creates /packages/server/upload and /packages/projects/projects fodlers on startup if they aren't found

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
