### PR TITLE
Fixed issues with provisioning channel instances and clearing instanceIds

### DIFF
--- a/packages/client-core/src/common/services/ChannelConnectionService.ts
+++ b/packages/client-core/src/common/services/ChannelConnectionService.ts
@@ -185,6 +185,7 @@ export const ChannelConnectionAction = {
   channelServerProvisioned: (provisionResult: InstanceServerProvisionResult, channelId?: string | null) => {
     return {
       type: 'CHANNEL_SERVER_PROVISIONED' as const,
+      id: provisionResult.id,
       ipAddress: provisionResult.ipAddress,
       port: provisionResult.port,
       channelId: channelId

--- a/packages/client-core/src/common/services/InstanceConnectionService.ts
+++ b/packages/client-core/src/common/services/InstanceConnectionService.ts
@@ -16,6 +16,7 @@ import { InstanceServerProvisionResult } from '@xrengine/common/src/interfaces/I
 //State
 const state = createState({
   instance: {
+    id: '',
     ipAddress: '',
     port: ''
   },
@@ -44,7 +45,7 @@ store.receptors.push((action: InstanceConnectionActionType): any => {
         })
       case 'INSTANCE_SERVER_PROVISIONED':
         return s.merge({
-          instance: { ipAddress: action.ipAddress, port: action.port },
+          instance: { id: action.id, ipAddress: action.ipAddress, port: action.port },
           locationId: action.locationId!,
           sceneId: action.sceneId!,
           instanceProvisioning: false,
@@ -197,6 +198,7 @@ export const InstanceConnectionAction = {
   ) => {
     return {
       type: 'INSTANCE_SERVER_PROVISIONED' as const,
+      id: provisionResult.id,
       ipAddress: provisionResult.ipAddress,
       port: provisionResult.port,
       locationId: locationId,

--- a/packages/client-core/src/social/services/ChatService.ts
+++ b/packages/client-core/src/social/services/ChatService.ts
@@ -7,6 +7,7 @@ import { AlertService } from '../../common/services/AlertService'
 import { Config } from '@xrengine/common/src/config'
 
 import { accessAuthState } from '../../user/services/AuthService'
+import { accessInstanceConnectionState } from '../../common/services/InstanceConnectionService'
 import { Message } from '@xrengine/common/src/interfaces/Message'
 import { MessageResult } from '@xrengine/common/src/interfaces/MessageResult'
 import { Channel } from '@xrengine/common/src/interfaces/Channel'
@@ -63,10 +64,10 @@ store.receptors.push((action: ChatActionType) => {
           channels: action.channels
         })
       case 'LOADED_CHANNEL': {
-        const idx =
-          (typeof action.channel.id === 'string' &&
-            s.channels.channels.findIndex((c) => c.id.value === action.channel.id)) ||
-          s.channels.channels.length
+        let findIndex
+        if (typeof action.channel.id === 'string')
+          findIndex = s.channels.channels.findIndex((c) => c.id.value === action.channel.id)
+        let idx = findIndex && findIndex > -1 ? findIndex : s.channels.channels.length
         s.channels.channels[idx].set(action.channel)
 
         if (action.channelType === 'instance') {
@@ -243,9 +244,11 @@ export const ChatService = {
       try {
         const channelResult = await client.service('channel').find({
           query: {
-            channelType: 'instance'
+            channelType: 'instance',
+            instanceId: accessInstanceConnectionState().instance.id.value
           }
         })
+        if (channelResult.total === 0) return setTimeout(() => ChatService.getInstanceChannel(), 5000)
         dispatch(ChatAction.loadedChannel(channelResult.data[0], 'instance'))
       } catch (err) {
         AlertService.dispatchAlertError(err)

--- a/packages/client/src/components/InstanceChat/index.tsx
+++ b/packages/client/src/components/InstanceChat/index.tsx
@@ -57,13 +57,18 @@ const InstanceChat = (props: Props): any => {
 
   useEffect(() => {
     if (
-      user?.instanceId?.value != null &&
+      user?.instanceId?.value === instanceConnectionState.instance.id?.value &&
       instanceConnectionState.connected.value === true &&
       channelState.fetchingInstanceChannel.value !== true
     ) {
       ChatService.getInstanceChannel()
     }
-  }, [user?.instanceId?.value, instanceConnectionState.connected?.value, channelState.fetchingInstanceChannel.value])
+  }, [
+    user?.instanceId?.value,
+    instanceConnectionState.instance.id?.value,
+    instanceConnectionState.connected?.value,
+    channelState.fetchingInstanceChannel.value
+  ])
 
   const handleComposingMessageChange = (event: any): void => {
     const message = event.target.value

--- a/packages/client/src/components/MediaIconsBox/index.tsx
+++ b/packages/client/src/components/MediaIconsBox/index.tsx
@@ -25,6 +25,7 @@ import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { EngineEvents } from '@xrengine/engine/src/ecs/classes/EngineEvents'
 import { useChatState } from '@xrengine/client-core/src/social/services/ChatService'
 import { useLocationState } from '@xrengine/client-core/src/social/services/LocationService'
+import { useInstanceConnectionState } from '@xrengine/client-core/src/common/services/InstanceConnectionService'
 import {
   ChannelConnectionService,
   useChannelConnectionState
@@ -40,10 +41,11 @@ const MediaIconsBox = (props) => {
 
   const user = useAuthState().user
   const chatState = useChatState()
+  const instanceId = useInstanceConnectionState().instance.id.value
   const channelState = chatState.channels
   const channels = channelState.channels.value
   const channelEntries = Object.values(channels).filter((channel) => !!channel) as any
-  const instanceChannel = channelEntries.find((entry) => entry.instanceId != null)
+  const instanceChannel = channelEntries.find((entry) => entry.instanceId === instanceId)
   const currentLocation = useLocationState().currentLocation.location
   const channelConnectionState = useChannelConnectionState()
   const mediastream = useMediaStreamState()

--- a/packages/client/src/components/World/NetworkInstanceProvisioning.tsx
+++ b/packages/client/src/components/World/NetworkInstanceProvisioning.tsx
@@ -83,10 +83,20 @@ export const NetworkInstanceProvisioning = (props: Props) => {
 
   // 3. once engine is initialised and the server is provisioned, connect the the instance server
   useEffect(() => {
-    if (engineState.isInitialised.value && instanceConnectionState.instanceProvisioned.value)
+    if (
+      engineState.isInitialised.value &&
+      !instanceConnectionState.connected.value &&
+      instanceConnectionState.instanceProvisioned.value &&
+      !instanceConnectionState.instanceServerConnecting.value
+    )
       InstanceConnectionService.connectToInstanceServer('instance')
     console.log('connect to instance server')
-  }, [engineState.isInitialised.value, instanceConnectionState.instanceProvisioned.value])
+  }, [
+    engineState.isInitialised.value,
+    instanceConnectionState.connected.value,
+    instanceConnectionState.instanceServerConnecting.value,
+    instanceConnectionState.instanceProvisioned.value
+  ])
 
   useEffect(() => {
     console.log(
@@ -123,7 +133,9 @@ export const NetworkInstanceProvisioning = (props: Props) => {
   useEffect(() => {
     if (chatState.instanceChannelFetched.value) {
       const channels = chatState.channels.channels.value
-      const instanceChannel = Object.values(channels).find((channel) => channel.channelType === 'instance')
+      const instanceChannel = Object.values(channels).find(
+        (channel) => channel.instanceId === instanceConnectionState.instance.id.value
+      )
       ChannelConnectionService.provisionChannelServer(instanceChannel?.id)
     }
   }, [chatState.instanceChannelFetched.value])

--- a/packages/common/src/interfaces/InstanceServerProvisionResult.ts
+++ b/packages/common/src/interfaces/InstanceServerProvisionResult.ts
@@ -1,4 +1,5 @@
 export interface InstanceServerProvisionResult {
+  id: string
   ipAddress: string
   port: string
 }

--- a/packages/engine/src/networking/utils/chatSystem.ts
+++ b/packages/engine/src/networking/utils/chatSystem.ts
@@ -73,7 +73,8 @@ export function getSubscribedChatSystems(userId): string[] {
 //gets the chat system from a chat message
 export function getChatMessageSystem(text: string): string {
   if (text.startsWith('[emotions]')) return 'emotions_system'
-  else if (text.startsWith('[jl_system]') || text.includes('joined the layer')) return 'jl_system'
+  else if (text.startsWith('[jl_system]') || text.includes('joined the layer') || text.includes('left the layer'))
+    return 'jl_system'
   else if (text.startsWith('[proximity')) return 'proximity_system'
 
   return 'none'

--- a/packages/gameserver/src/SocketWebRTCServerTransport.ts
+++ b/packages/gameserver/src/SocketWebRTCServerTransport.ts
@@ -127,7 +127,7 @@ export class SocketWebRTCServerTransport implements NetworkTransport {
     this.socketIO.of('/').on('connect', async (socket: Socket) => {
       let listenersSetUp = false
 
-      if (!Engine.sceneLoaded && this.app.isChannelInstance !== true) {
+      if (!Engine.sceneLoaded && !this.app.isChannelInstance) {
         await new Promise<void>((resolve) => {
           EngineEvents.instance.once(EngineEvents.EVENTS.SCENE_LOADED, resolve)
         })
@@ -289,7 +289,7 @@ export class SocketWebRTCServerTransport implements NetworkTransport {
     })
 
     // Set up our gameserver according to our current environment
-    const localIp = await getLocalServerIp()
+    const localIp = await getLocalServerIp(this.app.isChannelInstance)
     let stringSubdomainNumber, gsResult
     if (!config.kubernetes.enabled)
       try {

--- a/packages/gameserver/src/channels.ts
+++ b/packages/gameserver/src/channels.ts
@@ -274,8 +274,8 @@ export default (app: Application): void => {
                 console.log('Could not update instance, likely because it is a local one that does not exist')
               }
             }
-            // console.log(`Patching user ${user.id} instanceId to ${app.instance.id}`);
             const instanceIdKey = app.isChannelInstance ? 'channelInstanceId' : 'instanceId'
+            // console.log(`Patching user ${user.id} ${instanceIdKey} to ${app.instance.id}`);
             await app.service('user').patch(userId, {
               [instanceIdKey]: app.instance.id
             })
@@ -309,7 +309,7 @@ export default (app: Application): void => {
                 {
                   targetObjectId: app.instance.id,
                   targetObjectType: 'instance',
-                  text: `[jl_system]${user.name} joined the layer`,
+                  text: `${user.name} joined the layer`,
                   isNotification: true
                 },
                 {
@@ -391,12 +391,12 @@ export default (app: Application): void => {
           if (identityProvider != null && identityProvider.id != null) {
             const userId = identityProvider.userId
             const user = await app.service('user').get(userId)
-            if (app.isChannelInstance !== true)
+            if (!app.isChannelInstance)
               await app.service('message').create(
                 {
                   targetObjectId: app.instance.id,
                   targetObjectType: 'instance',
-                  text: `[jl_system]${user.name} left the layer`,
+                  text: `${user.name} left the layer`,
                   isNotification: true
                 },
                 {
@@ -428,29 +428,26 @@ export default (app: Application): void => {
 
               const user = await app.service('user').get(userId)
               const instanceIdKey = app.isChannelInstance ? 'channelInstanceId' : 'instanceId'
-              if (
-                (Engine.currentWorld.clients.has(userId) && config.kubernetes.enabled) ||
-                process.env.APP_ENV === 'development'
-              )
-                await app
-                  .service('user')
-                  .patch(
-                    null,
-                    {
-                      [instanceIdKey]: null
-                    },
-                    {
-                      query: {
-                        id: user.id,
-                        [instanceIdKey]: instanceId
-                      },
+              // Patch the user's (channel)instanceId to null if they're leaving this instance.
+              // But, don't change their (channel)instanceId if it's already something else.
+              await app
+                .service('user')
+                .patch(
+                  null,
+                  {
+                    [instanceIdKey]: null
+                  },
+                  {
+                    query: {
+                      id: user.id,
                       [instanceIdKey]: instanceId
                     }
-                  )
-                  .catch((err) => {
-                    console.warn("Failed to patch user, probably because they don't have an ID yet")
-                    console.log(err)
-                  })
+                  }
+                )
+                .catch((err) => {
+                  console.warn("Failed to patch user, probably because they don't have an ID yet")
+                  console.log(err)
+                })
               await app.service('instance-attendance').patch(
                 null,
                 {

--- a/packages/server-core/src/hooks/check-party-instance-size.ts
+++ b/packages/server-core/src/hooks/check-party-instance-size.ts
@@ -44,7 +44,7 @@ export default () => {
             logger.info('Spinning up new instance server')
             let selfIpAddress, status
             const emittedIp = !config.kubernetes.enabled
-              ? await getLocalServerIp()
+              ? await getLocalServerIp(false)
               : { ipAddress: status.address, port: status.portsList[0].port }
             if (config.kubernetes.enabled) {
               const serverResult = await (context.app as Application).k8AgonesClient.get('gameservers')
@@ -88,7 +88,7 @@ export default () => {
             logger.info('Putting party users on instance ' + selectedInstance.id)
             const addressSplit = selectedInstance.ipAddress.split(':')
             const emittedIp = !config.kubernetes.enabled
-              ? await getLocalServerIp()
+              ? await getLocalServerIp(false)
               : { ipAddress: addressSplit[0], port: addressSplit[1] }
             await context.app.service('instance-provision').emit('created', {
               userId: partyOwner.userId,

--- a/packages/server-core/src/util/get-local-server-ip.ts
+++ b/packages/server-core/src/util/get-local-server-ip.ts
@@ -5,7 +5,7 @@ interface ServerAddress {
   port: string
 }
 
-export default async (isChannelInstance?: boolean): Promise<ServerAddress> => {
+export default async (isChannelInstance: boolean): Promise<ServerAddress> => {
   const ip = await internalIp.v4()
   return {
     ipAddress: ip!,


### PR DESCRIPTION
## Summary

Much of the front-end was relying on the user's channelInstanceId being correct for getting the instanceChannel
and provisioning an instance for it. However, users often had old channelInstanceIds on them, leading to provisioning
of channel instances that were incorrect. Checks being done to find the instance channel in a user's channel store
were only checking that there was a channel with channelType 'instance', which was often their old instance channel.

Updated instance provisioning to return instance ID as well as address. This ID is used for a number of checks, like
finding the channel that has that instanceId.

Fixed LOADED_CHANNEL handler, which was not returning the right values in order to find duplicates.

Fixed logic to patch user's (channel)instanceId when they leave an instance. It was relying on them still being in
Engine.defaultWorld.clients, but by the time they disconnect, they may no longer be there. It now just tries to
patch a user with that user's ID and that (channel)instanceId, which should ignore any other users and ignore that
user if they're already on a different instance.

Removed some bot text from joined/left messages.

A summary of changes being made in this PR

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

#4374 

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
