### PR TITLE
Exiting the api server on forceRefresh only occurs on dev.

### DIFF
--- a/packages/server-core/src/sequelize.ts
+++ b/packages/server-core/src/sequelize.ts
@@ -97,7 +97,7 @@ export default (app: Application): void => {
         .then(async () => {
           promiseResolve()
           return Promise.resolve().then(() => {
-            if (config.db.forceRefresh) process.exit(0)
+            if (config.db.forceRefresh && process.env.APP_ENV === 'development') process.exit(0)
           })
         })
         .catch((err) => {


### PR DESCRIPTION
## Summary

In production, having the API servers exit during forceRefresh could be problematic,
as their exiting will cause Kubernetes to kill those pods and spin up new ones that
will also be re-seeding the database. This could leave the DB in a partially-seeded state.

Made the process.exit(0) only run if APP_ENV is 'development'.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
