### PR TITLE
Fixed project seeding.

### DIFF
--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -26,6 +26,7 @@ const projectsRootFolder = path.join(appRootPath.path, 'packages/projects/projec
 export const copyDefaultProject = () => {
   deleteFolderRecursive(path.join(projectsRootFolder, `default-project`))
   copyFolderRecursiveSync(path.join(appRootPath.path, 'packages/projects/default-project'), projectsRootFolder)
+  return Promise.resolve()
 }
 
 const getRemoteURLFromGitData = (project) => {
@@ -154,7 +155,7 @@ export class Project extends Service {
     if (fs.existsSync(path.resolve(projectsRootFolder, projectName)))
       throw new Error(`[Projects]: Project with name ${projectName} already exists`)
 
-    if (projectName === 'default-project' || projectName === 'template-project')
+    if ((!config.db.forceRefresh && projectName === 'default-project') || projectName === 'template-project')
       throw new Error(`[Projects]: Project name ${projectName} not allowed`)
 
     const projectLocalDirectory = path.resolve(projectsRootFolder, projectName)
@@ -175,7 +176,7 @@ export class Project extends Service {
     packageData.name = projectName
     fs.writeFileSync(path.resolve(projectLocalDirectory, 'package.json'), JSON.stringify(packageData, null, 2))
 
-    await super.create(
+    return super.create(
       {
         thumbnail: packageData.thumbnail,
         name: projectName,
@@ -225,7 +226,7 @@ export class Project extends Service {
     const projectConfig = (await getProjectConfig(projectName)) ?? {}
 
     // Add to DB
-    await super.create(
+    const returned = await super.create(
       {
         thumbnail: projectConfig.thumbnail,
         name: projectName,
@@ -239,6 +240,8 @@ export class Project extends Service {
     if (projectConfig.onEvent) {
       await onProjectEvent(this.app, projectName, projectConfig.onEvent, 'onInstall')
     }
+
+    return returned
   }
 
   /**
@@ -278,22 +281,24 @@ export class Project extends Service {
   }
 
   async remove(id: Id, params: Params) {
-    try {
-      const { name } = await super.get(id, params)
+    if (id) {
+      try {
+        const { name } = await super.get(id, params)
 
-      const projectConfig = await getProjectConfig(name)
+        const projectConfig = await getProjectConfig(name)
 
-      // run project uninstall script
-      if (projectConfig.onEvent) {
-        await onProjectEvent(this.app, name, projectConfig.onEvent, 'onUninstall')
+        // run project uninstall script
+        if (projectConfig.onEvent) {
+          await onProjectEvent(this.app, name, projectConfig.onEvent, 'onUninstall')
+        }
+
+        console.log('[Projects]: removing project', id, name)
+        await deleteProjectFilesInStorageProvider(name)
+        await super.remove(id, params)
+      } catch (e) {
+        console.log(`[Projects]: failed to remove project ${id}`, e)
+        return e
       }
-
-      console.log('[Projects]: removing project', id, name)
-      await deleteProjectFilesInStorageProvider(name)
-      await super.remove(id, params)
-    } catch (e) {
-      console.log(`[Projects]: failed to remove project ${id}`, e)
-      return e
     }
   }
 

--- a/packages/server-core/src/projects/project/project.hooks.ts
+++ b/packages/server-core/src/projects/project/project.hooks.ts
@@ -1,6 +1,6 @@
 import * as authentication from '@feathersjs/authentication'
-import { disallow } from 'feathers-hooks-common'
 import verifyScope from '../../hooks/verify-scope'
+import * as commonHooks from 'feathers-hooks-common'
 
 const { authenticate } = authentication.hooks
 
@@ -9,10 +9,22 @@ export default {
     all: [],
     find: [],
     get: [],
-    create: [authenticate('jwt'), verifyScope('editor', 'write')],
-    update: [authenticate('jwt'), verifyScope('editor', 'write')],
-    patch: [authenticate('jwt'), verifyScope('editor', 'write')],
-    remove: [authenticate('jwt'), verifyScope('editor', 'write')]
+    create: [
+      authenticate('jwt'),
+      commonHooks.iff(commonHooks.isProvider('external'), verifyScope('editor', 'write') as any)
+    ],
+    update: [
+      authenticate('jwt'),
+      commonHooks.iff(commonHooks.isProvider('external'), verifyScope('editor', 'write') as any)
+    ],
+    patch: [
+      authenticate('jwt'),
+      commonHooks.iff(commonHooks.isProvider('external'), verifyScope('editor', 'write') as any)
+    ],
+    remove: [
+      authenticate('jwt'),
+      commonHooks.iff(commonHooks.isProvider('external'), verifyScope('editor', 'write') as any)
+    ]
   },
 
   after: {

--- a/packages/server-core/src/projects/project/project.seed.ts
+++ b/packages/server-core/src/projects/project/project.seed.ts
@@ -1,14 +1,15 @@
 import { copyDefaultProject, getStorageProviderPath } from './project.class'
 
 export const projectSeedData = {
+  path: 'project',
   randomize: false,
   templates: [
-    {
-      copyDefaultProject
-    },
     {
       name: 'default-project',
       storageProviderPath: getStorageProviderPath('default-project')
     }
-  ]
+  ],
+  callback: (result) => {
+    return result.name === 'default-project' ? copyDefaultProject() : Promise.resolve()
+  }
 }

--- a/packages/server-core/src/projects/project/project.service.ts
+++ b/packages/server-core/src/projects/project/project.service.ts
@@ -9,6 +9,8 @@ import * as authentication from '@feathersjs/authentication'
 import fs from 'fs'
 import path from 'path'
 import appRootPath from 'app-root-path'
+import { deleteFolderRecursive } from '../../util/fsHelperFunctions'
+import config from '../../appconfig'
 
 const { authenticate } = authentication.hooks
 
@@ -29,8 +31,11 @@ export default (app: Application): void => {
   }
 
   // copy default project if it doesn't exist
-  if (!fs.existsSync(path.resolve(path.join(appRootPath.path, 'packages/projects/projects/'), 'default-project')))
-    copyDefaultProject()
+  if (
+    config.db.forceRefresh &&
+    fs.existsSync(path.resolve(path.join(appRootPath.path, 'packages/projects/projects/'), 'default-project'))
+  )
+    deleteFolderRecursive(path.join(appRootPath.path, 'packages/projects/projects/', 'default-project'))
 
   const projectClass = new Project(options, app)
   projectClass.docs = projectDocs


### PR DESCRIPTION
## Summary

Project DB seeding wasn't occurring due to missing `path: 'project'`.
Removed copyDefaultProject 'seed', since it didn't appear to be doing much.

Made project verifyScope('editor', 'write') hooks only called from external calls,
so seeding can run.

Made project.remove skip everything if not passed an id, since it tries to run super.get(id),
which will error during the seeding process.

Switched project.service from running copyDefaultProject() if default-project doesn't exist to deleting
default-project on forceRefresh if it does exist. Project seeding should handle the copying during project.create().

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
