### PR TITLE
Fixed a bug with creating magiclink identity-providers.

### DIFF
--- a/packages/server-core/src/user/identity-provider/identity-provider.class.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.class.ts
@@ -36,7 +36,7 @@ export class IdentityProvider extends Service {
   async create(data: any, params: Params): Promise<any> {
     let { token, type, password } = data
 
-    if (params.provider && type !== 'password') type = 'guest' //Non-password create requests must always be for guests
+    if (params.provider && type !== 'password' && type !== 'email' && type !== 'sms') type = 'guest' //Non-password/magiclink create requests must always be for guests
     let userId = data.userId
     let identityProvider: any
 


### PR DESCRIPTION
## Summary

Prior security lockdown to only allow guest user creation for external identity-provider create's
that weren't of type 'password' omitted the fact that email and sms requests also have a params.provider,
and so need to be let through as their type and not type 'guest'.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
