### PR TITLE
Added pagination to listObjects function.

### DIFF
--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -86,7 +86,7 @@ export class FileBrowserService implements ServiceMethods<any> {
    * @returns
    */
   async remove(path: string, params: Params) {
-    const dirs = await this.store.listObjects(path + '/', true)
+    const dirs = await this.store.listObjects(path + '/', [], true, null!)
     return await this.store.deleteResources([path, ...dirs.Contents.map((a) => a.Key)])
   }
 }

--- a/packages/server-core/src/media/storageprovider/local.storage.ts
+++ b/packages/server-core/src/media/storageprovider/local.storage.ts
@@ -34,7 +34,12 @@ export class LocalStorage implements StorageProviderInterface {
     }
   }
 
-  listObjects = async (prefix: string, recursive = false): Promise<StorageListObjectInterface> => {
+  listObjects = async (
+    prefix: string,
+    results: any[],
+    recursive = false,
+    continuationToken: string
+  ): Promise<StorageListObjectInterface> => {
     const filePath = path.join(appRootPath.path, 'packages', 'server', this.path, prefix)
     if (!fs.existsSync(filePath)) return { Contents: [] }
     const globResult = glob.sync(path.join(filePath, '**/*.*'))

--- a/packages/server-core/src/media/storageprovider/storageProviderUtils.ts
+++ b/packages/server-core/src/media/storageprovider/storageProviderUtils.ts
@@ -5,7 +5,8 @@ const storageProvider = useStorageProvider()
 export const getFileKeysRecursive = async (path: string) => {
   const files: string[] = []
   try {
-    const entries = (await storageProvider.listObjects(path, true)).Contents
+    const response = await storageProvider.listObjects(path, [], true, null!)
+    const entries = response.Contents
     if (entries.length) {
       for (const { Key } of entries) {
         files.push(Key)

--- a/packages/server-core/src/media/storageprovider/storageprovider.interface.ts
+++ b/packages/server-core/src/media/storageprovider/storageprovider.interface.ts
@@ -8,6 +8,8 @@ export interface StorageObjectInterface {
 
 export interface StorageListObjectInterface {
   Prefix?: string
+  IsTruncated?: boolean
+  NextContinuationToken?: string
   Contents: { Key: string }[]
   CommonPrefixes?: { Prefix: string }[]
 }
@@ -72,9 +74,17 @@ export interface StorageProviderInterface {
   /**
    * Get a list of keys under a path
    * @param prefix
+   * @param results
+   * @param recursive
+   * @param continuationToken
    * @returns {Promise<StorageListObjectInterface>}
    */
-  listObjects(prefix: string, recursive?: boolean): Promise<StorageListObjectInterface>
+  listObjects(
+    prefix: string,
+    results,
+    recursive?: boolean,
+    continuationToken?: string
+  ): Promise<StorageListObjectInterface>
 
   /**
    * Puts an object into the store


### PR DESCRIPTION
## Summary

Encountered an XREngine project with more than 1000 files and discovered that S3's ListObjectsV2
maxes out at 1000 objects per call. Implemented pagination to go through every page and only
return the full list of objects in the prefix path.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
