### PR TITLE
Add test for putting and listing over 1000 objects in s3

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "npmClient": "npm",
   "scripts": {
-    "check": "npm run lint && npm run check-errors && npm run test:packages && npm run build-client",
+    "check": "npm run lint && npm run check-errors && npm run test && npm run build-client",
     "check-errors": "lerna run check-errors --parallel",
     "start": "npm run dev",
     "local": "npm run dev-docker && cross-env VITE_LOCAL_BUILD=true concurrently npm:dev-agones \"cd packages/server && npm run start\" \"cd packages/gameserver && npm run start\" \"cd packages/client && npm run local\" \"cd packages/server && npm run serve-local-files\"",
@@ -84,7 +84,7 @@
   "pre-push": [
     "check-errors",
     "pretest",
-    "test:packages",
+    "test",
     "build-client"
   ],
   "lint-staged": {

--- a/packages/server-core/src/media/storageprovider/local.storage.ts
+++ b/packages/server-core/src/media/storageprovider/local.storage.ts
@@ -18,6 +18,7 @@ const keyPathRegex = /([a-zA-Z0-9/_-]+)\/[a-zA-Z0-9]+.[a-zA-Z0-9]+/
 export class LocalStorage implements StorageProviderInterface {
   path = './upload'
   cacheDomain = config.server.localStorageProvider
+  _store = fsStore(path.join(appRootPath.path, 'packages', 'server', this.path))
 
   constructor() {
     // make upload folder if it doesnt already exist
@@ -70,7 +71,7 @@ export class LocalStorage implements StorageProviderInterface {
   createInvalidation = async (): Promise<any> => Promise.resolve()
 
   getProvider = (): StorageProviderInterface => this
-  getStorage = (): BlobStore => fsStore(path.join(appRootPath.path, 'packages', 'server', this.path))
+  getStorage = (): BlobStore => this._store
 
   checkObjectExistence = (key: string): Promise<any> => {
     return new Promise((resolve, reject) => {

--- a/packages/server-core/tests/storageprovider/storageprovider.test.ts
+++ b/packages/server-core/tests/storageprovider/storageprovider.test.ts
@@ -22,7 +22,7 @@ describe('storageprovider', () => {
   storageProviders.push(new LocalStorage())
   if(process.env.STORAGE_S3_TEST_RESOURCE_BUCKET && process.env.STORAGE_AWS_ACCESS_KEY_ID && process.env.STORAGE_AWS_ACCESS_KEY_SECRET)
     storageProviders.push(new S3Provider())
-  console.log(process.env.STORAGE_S3_TEST_RESOURCE_BUCKET, process.env.STORAGE_AWS_ACCESS_KEY_ID, process.env.STORAGE_AWS_ACCESS_KEY_SECRET)
+
   storageProviders.forEach((provider) => {
     before(async function () {
       await providerBeforeTest(provider, testFolderName, folderKeyTemp, folderKeyTemp2)


### PR DESCRIPTION
## Summary

Adds test for putting and listing over 1000 objects in s3

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm run pretest`
3. `npm run test`

## Reviewers

@barankyle @Abhishek-Pathak-Here 
