### PR TITLE
Fixed some bugs in user service and MediaStreamService.

### DIFF
--- a/packages/client-core/src/media/services/MediaStreamService.ts
+++ b/packages/client-core/src/media/services/MediaStreamService.ts
@@ -9,9 +9,7 @@ const state = createState({
   isCamAudioEnabled: false,
   isFaceTrackingEnabled: false,
   nearbyLayerUsers: [] as NearbyUser[],
-  consumers: {
-    consumers: []
-  }
+  consumers: []
 })
 
 store.receptors.push((action: MediaStreamActionType): any => {
@@ -24,7 +22,7 @@ store.receptors.push((action: MediaStreamActionType): any => {
       case 'FACE_TRACKING_CHANGED':
         return s.isFaceTrackingEnabled.set(action.isEnable)
       case 'CONSUMERS_CHANGED':
-        return s.consumers.consumers.set(action.consumers)
+        return s.consumers.set(action.consumers)
       case 'NEARBY_LAYER_USERS_CHANGED':
         return s.nearbyLayerUsers.set(action.users)
     }

--- a/packages/client-core/src/user/services/UserService.ts
+++ b/packages/client-core/src/user/services/UserService.ts
@@ -105,40 +105,17 @@ export const UserService = {
     }
   },
 
-  getUsers: async (userId: string, search: string) => {
-    const dispatch = useDispatch()
-    {
-      client
-        .service('user')
-        .find({
-          query: {
-            userId,
-            action: 'withRelation',
-            search
-          }
-        })
-        .then((res: any) => {
-          dispatch(UserAction.loadedUsers(res.data as User[]))
-        })
-        .catch((err: any) => {
-          console.log(err)
-        })
-    }
-  },
-
   getLayerUsers: async (instance = true) => {
     const dispatch = useDispatch()
     {
       const layerUsers = await client.service('user').find({
         query: {
           $limit: 1000,
-          action: instance === true ? 'layer-users' : 'channel-users'
+          action: instance ? 'layer-users' : 'channel-users'
         }
       })
       dispatch(
-        instance === true
-          ? UserAction.loadedLayerUsers(layerUsers.data)
-          : UserAction.loadedChannelLayerUsers(layerUsers.data)
+        instance ? UserAction.loadedLayerUsers(layerUsers.data) : UserAction.loadedChannelLayerUsers(layerUsers.data)
       )
     }
   },

--- a/packages/server-core/src/user/user/user.class.ts
+++ b/packages/server-core/src/user/user/user.class.ts
@@ -26,108 +26,18 @@ export class User extends Service {
    */
 
   async find(params: Params): Promise<any> {
-    const action = params.query?.action
-    const skip = params.query?.$skip ? params.query.$skip : 0
-    const limit = params.query?.$limit ? params.query.$limit : 10
-    const searchUser = params.query?.data
+    if (!params.query) params.query = {}
+    const action = params.query.action
+    const skip = params.query.$skip ? params.query.$skip : 0
+    const limit = params.query.$limit ? params.query.$limit : 10
     // this is a privacy & security vulnerability, please rethink the implementation here and on the front end.
     // if (action === 'inventory') {
     //   delete params.query?.action
     //   // WARNING: we probably dont want to do this
     //   return await super.find(params)
     // } else
-    if (action === 'withRelation') {
-      const userId = params.query?.userId
-      const search = params.query?.search as string
-
-      delete params.query?.action
-      delete params.query?.userId
-      delete params.query?.search
-
-      const UserRelationshipModel = this.app.get('sequelizeClient').models.user_relationship
-      let foundUsers: any
-
-      // TODO: Clean up this inline raw SQL
-      if (search && search !== '') {
-        const where = `id <> :userId 
-          AND (name LIKE :search 
-          OR id IN 
-            (SELECT userId FROM identity_provider 
-            WHERE \`token\` LIKE :search))`
-        const countQuery = `SELECT COUNT(id) FROM \`user\` WHERE ${where}`
-        const dataQuery = `SELECT * FROM \`user\` WHERE ${where} LIMIT :skip, :limit`
-
-        const total = await this.app.get('sequelizeClient').query(countQuery, {
-          type: QueryTypes.SELECT,
-          raw: true,
-          replacements: {
-            userId,
-            search: `%${search}%`
-          }
-        })
-        foundUsers = await this.app.get('sequelizeClient').query(dataQuery, {
-          type: QueryTypes.SELECT,
-          model: this.getModel(params),
-          mapToModel: true,
-          replacements: {
-            userId,
-            search: `%${search}%`,
-            $skip: params.query?.$skip || 0,
-            $limit: params.query?.$limit || 10
-          }
-        })
-
-        foundUsers = {
-          total,
-          $limit: params.query?.$limit || 10,
-          $skip: params.query?.$skip || 0,
-          data: foundUsers
-        }
-      } else {
-        params.query = {
-          ...params.query,
-          id: {
-            $nin: [userId]
-          }
-        }
-
-        foundUsers = await super.find(params)
-      }
-
-      let users
-      if (!Array.isArray(foundUsers)) {
-        users = foundUsers.data
-      } else {
-        users = foundUsers
-      }
-
-      for (const user of users) {
-        const userRelation = await UserRelationshipModel.findOne({
-          where: {
-            userId,
-            relatedUserId: user.id
-          },
-          attributes: ['userRelationshipType']
-        })
-
-        const userInverseRelation = await UserRelationshipModel.findOne({
-          where: {
-            userId: user.id,
-            relatedUserId: userId
-          },
-          attributes: ['userRelationshipType']
-        })
-
-        if (userRelation) {
-          Object.assign(user, { relationType: userRelation.userRelationshipType })
-        }
-        if (userInverseRelation) {
-          Object.assign(user, { inverseRelationType: userInverseRelation.userRelationshipType })
-        }
-      }
-
-      return foundUsers
-    } else if (action === 'friends') {
+    if (action === 'friends') {
+      delete params.query.action
       const loggedInUser = extractLoggedInUserFromParams(params)
       const userResult = await (this.app.service('user') as any).Model.findAndCountAll({
         offset: skip,
@@ -144,112 +54,51 @@ export class User extends Service {
         ]
       })
 
-      await Promise.all(
-        userResult.rows.map((user) => {
-          return new Promise(async (resolve) => {
-            const userAvatarResult = (await this.app.service('static-resource').find({
-              query: {
-                staticResourceType: 'user-thumbnail',
-                userId: user.id
-              }
-            })) as any
-
-            if (userAvatarResult.total > 0) {
-              user.dataValues.avatarUrl = userAvatarResult.data[0].url
-            }
-
-            resolve(true)
-          })
-        })
-      )
-
-      return {
-        skip: skip,
-        limit: limit,
-        total: userResult.count,
-        data: userResult.rows
+      params.query.id = {
+        $in: userResult.rows.map((user) => user.id)
       }
+      return super.find(params)
     } else if (action === 'layer-users') {
+      delete params.query.action
       const loggedInUser = extractLoggedInUserFromParams(params)
       let user
       if (loggedInUser) user = await super.get(loggedInUser.userId)
-      return super.find({
-        query: {
-          $limit: params.query!.$limit || 10,
-          $skip: params.query!.$skip || 0,
-          instanceId: params.query!.instanceId || user.instanceId || 'intentionalBadId'
-        }
-      })
+      params.query.instanceId = params.query.instanceId || user.instanceId || 'intentionalBadId'
+      return super.find(params)
     } else if (action === 'channel-users') {
+      delete params.query.action
       const loggedInUser = extractLoggedInUserFromParams(params)
       let user
       if (loggedInUser) user = await super.get(loggedInUser.userId)
-      return super.find({
-        query: {
-          $limit: params.query!.$limit || 10,
-          $skip: params.query!.$skip || 0,
-          channelInstanceId: params.query!.channelId || user.channelInstanceId || 'intentionalBadId'
-        }
-      })
+      params.query.channelInstanceId = params.query.channelInstanceId || user.channelInstanceId || 'intentionalBadId'
+      return super.find(params)
     } else if (action === 'admin') {
+      delete params.query.action
       const loggedInUser = extractLoggedInUserFromParams(params)
       const user = await super.get(loggedInUser.userId)
       if (user.userRole !== 'admin') throw new Forbidden('Must be system admin to execute this action')
 
-      delete params.query!.action
       // return await super.find(params)
-      const users = await super.find({
-        ...params,
-        include: [
-          {
-            model: (this.app.service('scope') as any).Model,
-            require: false
-          }
-        ],
-        raw: true,
-        nest: true
-      })
-      return users
+      return super.find(params)
     } else if (action === 'search') {
+      const searchUser = params.query.data
+      delete params.query.action
       const searchedUser = await (this.app.service('user') as any).Model.findAll({
         where: {
           name: {
             [Op.like]: `%${searchUser}%`
           }
         },
-        include: [
-          {
-            model: (this.app.service('party') as any).Model,
-            required: false,
-            include: [
-              {
-                model: (this.app.service('location') as any).Model,
-                required: false
-              },
-              {
-                model: (this.app.service('instance') as any).Model,
-                required: false
-              }
-            ]
-          }
-        ],
         raw: true,
         nest: true
       })
-      return {
-        skip: skip,
-        limit: limit,
-        total: searchUser.length,
-        data: searchedUser
+      params.query.id = {
+        $in: searchUser.map((user) => user.id)
       }
+      return super.find(params)
     } else if (action === 'invite-code-lookup') {
-      return super.find({
-        query: {
-          $skip: params.query!.$skip || 0,
-          $limit: params.query!.$limit || 10,
-          inviteCode: params.query!.inviteCode
-        }
-      })
+      delete params.query.action
+      return super.find(params)
     } else {
       const loggedInUser = extractLoggedInUserFromParams(params)
       let user

--- a/packages/server-core/src/user/user/user.hooks.ts
+++ b/packages/server-core/src/user/user/user.hooks.ts
@@ -134,20 +134,18 @@ export default {
     find: [
       (context: HookContext): HookContext => {
         try {
-          if (context.result?.data[0]) {
+          if (context.result?.data) {
             for (let x = 0; x < context.result.data.length; x++) {
               //context.result.data[x].inventory_items.metadata = JSON.parse(context.result.data[x].inventory_items.metadata)
-              for (let i = 0; i < context.result.data[x].inventory_items.length; i++) {
+              for (let i = 0; i < context.result.data[x].inventory_items?.length; i++) {
                 context.result.data[x].inventory_items[i].metadata = JSON.parse(
                   context.result.data[x].inventory_items[i].metadata
                 )
               }
             }
-          } else {
-            context.result.data = []
           }
-        } catch {
-          context.result.data = []
+        } catch (err) {
+          console.log('inventory item parsing error on user.FIND', err)
         }
         return context
       }
@@ -187,20 +185,14 @@ export default {
     get: [
       (context: HookContext): HookContext => {
         try {
-          if (context.result?.data[0]) {
-            for (let x = 0; x < context.result.data.length; x++) {
-              //context.result.data[x].inventory_items.metadata = JSON.parse(context.result.data[x].inventory_items.metadata)
-              for (let i = 0; i < context.result.data[x].inventory_items.length; i++) {
-                context.result.data[x].inventory_items[i].metadata = JSON.parse(
-                  context.result.data[x].inventory_items[i].metadata
-                )
-              }
+          if (context.result) {
+            //context.result.data[x].inventory_items.metadata = JSON.parse(context.result.data[x].inventory_items.metadata)
+            for (let i = 0; i < context.result.inventory_items?.length; i++) {
+              context.result.inventory_items[i].metadata = JSON.parse(context.result.inventory_items[i].metadata)
             }
-          } else {
-            context.result.data = []
           }
-        } catch {
-          context.result.data = []
+        } catch (err) {
+          console.log('inventory item parsing error on user.GET', err)
         }
         return context
       }


### PR DESCRIPTION
## Summary

Inventory system added post-find/get hooks for user service that parses stringified
inventory JSON. This wasn't taking into account if there were no inventory items to parse,
which has been corrected by checking if <data>.inventory_items exists before getting length.
Error handler for this was setting returned data to an empty array, which was not right.
It should just not do anything other than log the error, so that whatever user data was
being returned is returned as it was.

Further reflection on this issue showed that the reason it was occurring was that some of our
custom user find handlers were ignoring all params on the initial call, such as including
associated models. All user.find custom handlers were modified to just alter the query as needed
to get the specified user subset, such as doing a FindAndCountAll if a more complex SQL query
is needed and then adding `id: { $in: <returned ids> }` to the query.

user.GET hook was also written assuming the return structure of a FIND, which was incorrect.
GET just returns the single object that was found, or null

In MediaStreamService.ts, changed consumers.consumers to just consumers. There was no purpose
to this nested structure, and the one useEffect that was listening to MediaStreamService.consumers
wasn't updating properly as a result.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
