### PR TITLE
Refactor Database Seeding

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -13,6 +13,7 @@ COPY package.json .
 COPY packages/common/package.json ./packages/common/
 COPY packages/engine/package.json ./packages/engine/
 COPY packages/projects/package.json ./packages/projects/
+COPY packages/server/package.json ./packages/server/
 COPY packages/server-core/package.json ./packages/server-core/
 
 RUN npm install --production=false --loglevel notice --legacy-peer-deps

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
     "precommit": "no-master-commits -b master",
     "make-user-admin": "ts-node scripts/make-user-admin.js",
     "install-projects": "ts-node scripts/install-projects.js",
+    "check-db-exists": "cross-env ts-node --transpile-only scripts/check-db-exists.ts",
+    "init-db-production": "cross-env APP_ENV=production FORCE_DB_REFRESH=true ts-node --transpile-only packages/server/src/index.ts",
     "clean-node-modules": "npx rimraf node_modules && npx rimraf package-lock.json && npx lerna exec npx rimraf node_modules && npx lerna exec npx rimraf package-lock.json",
     "depcheck": "lerna exec --no-bail --stream -- depcheck"
   },

--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -18,8 +18,6 @@
     "exportingMsg": "Exporting project...",
     "exportingError": "Error Exporting Project",
     "exportingErrorMsg": "There was an error when exporting the project.",
-    "warnDefault": "Warning!",
-    "warnDefaultMsg": "The default project is only an example and will be overwritten in a production environment. Please make a new project if you wish to keep your changes.",
     "importLegacy": "Import Legacy World",
     "importLegacyMsg": "Warning! This will overwrite your existing scene! Are you sure you wish to continue?",
     "publishingError": "Error Publishing Project",

--- a/packages/common/src/interfaces/ServicesSeedConfig.ts
+++ b/packages/common/src/interfaces/ServicesSeedConfig.ts
@@ -2,11 +2,7 @@ type ServicesSeedCallback = (obj: any, seed: SeedCallback) => Promise<any>
 type SeedCallback = (ServicesSeedConfig) => Promise<any>
 
 export interface ServicesSeedConfig {
-  count?: number
-  disabled?: boolean
-  delete?: boolean
   path?: string
-  randomize?: boolean
   templates?: any[]
   callback?: ServicesSeedCallback
 }

--- a/packages/editor/src/components/EditorContainer.tsx
+++ b/packages/editor/src/components/EditorContainer.tsx
@@ -472,14 +472,10 @@ const EditorContainer = (props) => {
     const blob = await SceneManager.instance.takeScreenshot(512, 320)
 
     try {
-      if (isDev && projectName === 'default-project')
-        setDialogComponent(<ErrorDialog title={t('editor:warnDefault')} message={t('editor:warnDefaultMsg')} />)
       await saveScene(projectName, sceneName, blob, abortController.signal)
       await saveProject(projectName)
       SceneManager.instance.sceneModified = false
       updateModifiedState()
-
-      if (!(isDev && projectName === 'default-project')) setDialogComponent(null)
     } catch (error) {
       console.error(error)
 

--- a/packages/editor/src/components/EditorContainer.tsx
+++ b/packages/editor/src/components/EditorContainer.tsx
@@ -476,6 +476,7 @@ const EditorContainer = (props) => {
       await saveProject(projectName)
       SceneManager.instance.sceneModified = false
       updateModifiedState()
+      setDialogComponent(null)
     } catch (error) {
       console.error(error)
 

--- a/packages/server-core/declarations.d.ts
+++ b/packages/server-core/declarations.d.ts
@@ -20,6 +20,7 @@ export type Application = ExpressFeathers<ServiceTypes> & {
   agonesSDK: any
   sync: any
   io: any
+  seed: () => Application // function
 
   // Gameserver
   instance: any

--- a/packages/server-core/src/analytics/analytics/analytics.seed.ts
+++ b/packages/server-core/src/analytics/analytics/analytics.seed.ts
@@ -1,6 +1,5 @@
 export const analyticsSeedData = {
   path: 'analytics',
-  randomize: false,
   templates: [
     {
       count: 200,

--- a/packages/server-core/src/appconfig.ts
+++ b/packages/server-core/src/appconfig.ts
@@ -70,8 +70,6 @@ const server = {
   localStorageProvider: process.env.LOCAL_STORAGE_PROVIDER!,
   localStorageProviderPort: process.env.LOCAL_STORAGE_PROVIDER_PORT!,
   corsServerPort: process.env.CORS_SERVER_PORT!,
-  // Used for CI/tests to force Sequelize init an empty database
-  performDryRun: process.env.PERFORM_DRY_RUN === 'true',
   storageProvider: process.env.STORAGE_PROVIDER!,
   gaTrackingId: process.env.GOOGLE_ANALYTICS_TRACKING_ID!,
   hub: {

--- a/packages/server-core/src/media/static-resource-type/static-resource-type.seed.ts
+++ b/packages/server-core/src/media/static-resource-type/static-resource-type.seed.ts
@@ -2,7 +2,6 @@ import config from '../../appconfig'
 
 export const staticResourceTypeSeed = {
   path: 'static-resource-type',
-  randomize: false,
   templates: [
     { type: 'image' },
     { type: 'video' }, // parse metadata for video staticResourceType (eg 360-eac)

--- a/packages/server-core/src/media/storageprovider/local.storage.ts
+++ b/packages/server-core/src/media/storageprovider/local.storage.ts
@@ -13,8 +13,6 @@ import {
 import { FileContentType } from '@xrengine/common/src/interfaces/FileContentType'
 import { getContentType } from '../../util/fileUtils'
 
-const keyPathRegex = /([a-zA-Z0-9/_-]+)\/[a-zA-Z0-9]+.[a-zA-Z0-9]+/
-
 export class LocalStorage implements StorageProviderInterface {
   path = './upload'
   cacheDomain = config.server.localStorageProvider
@@ -53,7 +51,7 @@ export class LocalStorage implements StorageProviderInterface {
 
   putObject = async (params: StorageObjectInterface): Promise<any> => {
     const filePath = path.join(appRootPath.path, 'packages', 'server', this.path, params.Key!)
-    const pathWithoutFileExec = keyPathRegex.exec(filePath)
+    const pathWithoutFile = path.dirname(filePath)
     if (filePath.substr(-1) === '/') {
       if (!fs.existsSync(filePath)) {
         await fs.promises.mkdir(filePath, { recursive: true })
@@ -61,8 +59,7 @@ export class LocalStorage implements StorageProviderInterface {
       }
       return false
     }
-    if (pathWithoutFileExec == null) throw new Error('Invalid file path in local putObject')
-    const pathWithoutFile = pathWithoutFileExec[1]
+    if (pathWithoutFile == null) throw new Error('Invalid file path in local putObject')
     const pathWithoutFileExists = fs.existsSync(pathWithoutFile)
     if (!pathWithoutFileExists) await fs.promises.mkdir(pathWithoutFile, { recursive: true })
     return fs.promises.writeFile(filePath, params.Body)

--- a/packages/server-core/src/payments/seat-status/seat-status.seed.ts
+++ b/packages/server-core/src/payments/seat-status/seat-status.seed.ts
@@ -2,7 +2,6 @@ import config from '../../appconfig'
 
 export const seed = {
   path: 'seat-status',
-  randomize: false,
   templates: [{ status: 'pending' }, { status: 'filled' }]
 }
 

--- a/packages/server-core/src/payments/subscription-level/subscription-level.seed.ts
+++ b/packages/server-core/src/payments/subscription-level/subscription-level.seed.ts
@@ -2,6 +2,5 @@ import config from '../../appconfig'
 
 export const subscriptionLevelSeed = {
   path: 'subscription-level',
-  randomize: false,
   templates: [{ level: 'all' }, { level: 'paid' }]
 }

--- a/packages/server-core/src/payments/subscription-type/subscription-type.seed.ts
+++ b/packages/server-core/src/payments/subscription-type/subscription-type.seed.ts
@@ -107,6 +107,5 @@ const templateMap = config.deployStage ? templatesMap[config.deployStage] : temp
 
 export const subscriptionTypeSeed = {
   path: 'subscription-type',
-  randomize: false,
   templates: templateMap
 }

--- a/packages/server-core/src/projects/project/downloadProjects.ts
+++ b/packages/server-core/src/projects/project/downloadProjects.ts
@@ -12,7 +12,6 @@ export const download = async (projectName) => {
   try {
     // default project is presumed read only
     if (projectName === 'default-project') {
-      await uploadLocalProjectToProvider('default-project')
       return true
     }
 

--- a/packages/server-core/src/projects/project/downloadProjects.ts
+++ b/packages/server-core/src/projects/project/downloadProjects.ts
@@ -4,13 +4,11 @@ import fs from 'fs'
 import path from 'path'
 import { deleteFolderRecursive, writeFileSyncRecursive } from '../../util/fsHelperFunctions'
 import appRootPath from 'app-root-path'
-import { uploadLocalProjectToProvider } from './project.class'
 
 const storageProvider = useStorageProvider()
 
 export const download = async (projectName) => {
   try {
-    // default project is presumed read only
     if (projectName === 'default-project') {
       return true
     }

--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -2,7 +2,6 @@ import { Service, SequelizeServiceOptions } from 'feathers-sequelize'
 import { Application } from '../../../declarations'
 import { Id, Params } from '@feathersjs/feathers'
 import { ProjectInterface } from '@xrengine/common/src/interfaces/ProjectInterface'
-import { ProjectConfigInterface } from '@xrengine/projects/ProjectConfigInterface'
 import fs from 'fs'
 import path from 'path'
 import { isDev } from '@xrengine/common/src/utils/isDev'
@@ -63,22 +62,25 @@ export const uploadLocalProjectToProvider = async (projectName, remove = true) =
   const projectPath = path.resolve(projectsRootFolder, projectName)
   const files = getFilesRecursive(projectPath)
   const results = await Promise.all(
-    files.map((file: string) => {
-      return new Promise(async (resolve) => {
-        try {
-          const fileResult = fs.readFileSync(file)
-          const filePathRelative = file.slice(projectPath.length)
-          await storageProvider.putObject({
-            Body: fileResult,
-            ContentType: getContentType(file),
-            Key: `projects/${projectName}${filePathRelative}`
-          })
-          resolve(getCachedAsset(`projects/${projectName}${filePathRelative}`, storageProvider.cacheDomain))
-        } catch (e) {
-          resolve(null)
-        }
+    files
+      .filter((file) => !file.includes(`projects/${projectName}/.git/`))
+      .map((file: string) => {
+        return new Promise(async (resolve) => {
+          try {
+            const fileResult = fs.readFileSync(file)
+            const filePathRelative = file.slice(projectPath.length)
+            await storageProvider.putObject({
+              Body: fileResult,
+              ContentType: getContentType(file),
+              Key: `projects/${projectName}${filePathRelative}`
+            })
+            resolve(getCachedAsset(`projects/${projectName}${filePathRelative}`, storageProvider.cacheDomain))
+          } catch (e) {
+            console.log(e)
+            resolve(null)
+          }
+        })
       })
-    })
   )
   // console.log('uploadLocalProjectToProvider', results)
   return results.filter((success) => !!success) as string[]
@@ -91,10 +93,6 @@ export class Project extends Service {
   constructor(options: Partial<SequelizeServiceOptions>, app: Application) {
     super(options)
     this.app = app
-
-    if (isDev && !config.db.forceRefresh) {
-      this._fetchDevLocalProjects()
-    }
   }
 
   async _seedProject(projectName: string): Promise<any> {
@@ -116,7 +114,7 @@ export class Project extends Service {
   /**
    * On dev, sync the db with any projects installed locally
    */
-  private async _fetchDevLocalProjects() {
+  async _fetchDevLocalProjects() {
     const dbEntries = (await super.find()) as any
     const data: ProjectInterface[] = dbEntries.data
 

--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -134,7 +134,7 @@ export class Project extends Service {
     for (const projectName of locallyInstalledProjects) {
       if (!data.find((e) => e.name === projectName)) {
         try {
-          promises.push(await this._seedProject(projectName))
+          promises.push(this._seedProject(projectName))
         } catch (e) {
           console.log(e)
         }

--- a/packages/server-core/src/route/route/route.seed.ts
+++ b/packages/server-core/src/route/route/route.seed.ts
@@ -1,6 +1,5 @@
 export const routeSeedData = {
   path: 'route',
-  randomize: false,
   templates: [
     {
       project: 'default-project',

--- a/packages/server-core/src/scope/scope-type/scope-type.seed.ts
+++ b/packages/server-core/src/scope/scope-type/scope-type.seed.ts
@@ -1,6 +1,5 @@
 export const scopeTypeSeed = {
   path: 'scope-type',
-  randomize: false,
   templates: [
     {
       type: 'routes:read'

--- a/packages/server-core/src/sequelize.ts
+++ b/packages/server-core/src/sequelize.ts
@@ -1,16 +1,12 @@
 import config from '@xrengine/server-core/src/appconfig'
 import seeder from '@xrengine/server-core/src/util/seeder'
 import { Sequelize } from 'sequelize'
-import { setTimeout } from 'timers'
 import { Application } from '../declarations'
 import seederConfig from './seeder-config'
 
-const urlRegex = /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_.~#?&//=]*)$/
-
 export default (app: Application): void => {
   try {
-    const { performDryRun } = config.server
-    let { forceRefresh } = config.db
+    const { forceRefresh } = config.db
 
     console.log('Starting app')
 
@@ -30,82 +26,58 @@ export default (app: Application): void => {
       promiseResolve = resolve
       promiseReject = reject
     })
-    // eslint-disable-next-line  @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    app.setup = function (...args: any): Application {
-      sequelize
-        .query('SET FOREIGN_KEY_CHECKS = 0')
-        .then(() => {
-          return sequelize.query("SHOW TABLES LIKE 'user';")
-        })
-        .then(([results]) => {
-          if (results.length === 0) {
-            console.log('User table does not exist.')
-            console.log('Detected unseeded database. Forcing Refresh.')
-            forceRefresh = true
-          }
-        })
-        .then(() => {
-          // Sync to the database
-          for (const model of Object.keys(sequelize.models)) {
-            if (forceRefresh) console.log('creating associations for =>', sequelize.models[model])
-            if (typeof (sequelize.models[model] as any).associate === 'function') {
-              ;(sequelize.models[model] as any).associate(sequelize.models)
-            }
-          }
-          return sequelize
-            .sync({ force: forceRefresh })
-            .then(() => {
-              return (
-                app
-                  .configure(
-                    seeder({
-                      delete: forceRefresh,
-                      disabled: !forceRefresh,
-                      services: seederConfig
-                    })
-                  )
-                  // @ts-ignore
-                  .seed()
-                  .then(() => {
-                    console.log('Server Ready')
-                    return Promise.resolve()
-                  })
-                  .catch((err) => {
-                    console.log('Feathers seeding error')
-                    console.log(err)
-                    promiseReject()
-                    throw err
-                  })
-              )
 
-              if (performDryRun) {
-                setTimeout(() => process.exit(0), 5000)
-              }
-            })
-            .catch((err) => {
-              console.log('Sequelize setup error')
-              console.log(err)
-              promiseReject()
-              throw err
-            })
-        })
-        .then((sync) => {
+    // @ts-ignore
+    app.setup = async function (...args: any) {
+      try {
+        await sequelize.query('SET FOREIGN_KEY_CHECKS = 0')
+        const [results] = await sequelize.query("SHOW TABLES LIKE 'user';")
+        if (results.length === 0) {
+          throw new Error('\n\nUser table does not exist - make sure you have initialised the database\n\n')
+        }
+        // Sync to the database
+        for (const model of Object.keys(sequelize.models)) {
+          if (forceRefresh) console.log('creating associations for =>', sequelize.models[model])
+          if (typeof (sequelize.models[model] as any).associate === 'function') {
+            ;(sequelize.models[model] as any).associate(sequelize.models)
+          }
+        }
+
+        try {
+          // connect to sequelize
+          const sync = await sequelize.sync({ force: forceRefresh })
+
+          // configure seeder and seed
+          try {
+            if (forceRefresh) {
+              await app.configure(seeder(seederConfig)).seed()
+            }
+          } catch (err) {
+            console.log('Feathers seeding error')
+            console.log(err)
+            promiseReject()
+            throw err
+          }
+
           app.set('sequelizeSync', sync)
-          return sequelize.query('SET FOREIGN_KEY_CHECKS = 1')
-        })
-        .then(async () => {
-          promiseResolve()
-          return Promise.resolve().then(() => {
-            if (config.db.forceRefresh && process.env.APP_ENV === 'development') process.exit(0)
-          })
-        })
-        .catch((err) => {
+          await sequelize.query('SET FOREIGN_KEY_CHECKS = 1')
+          console.log('Server Ready')
+        } catch (err) {
           console.log('Sequelize sync error')
           console.log(err)
           promiseReject()
           throw err
-        })
+        }
+
+        promiseResolve()
+        if (forceRefresh) process.exit(0)
+      } catch (err) {
+        console.log('Sequelize setup error')
+        console.log(err)
+        promiseReject()
+        throw err
+      }
+
       return oldSetup.apply(this, args)
     }
   } catch (err) {

--- a/packages/server-core/src/sequelize.ts
+++ b/packages/server-core/src/sequelize.ts
@@ -32,7 +32,7 @@ export default (app: Application): void => {
       try {
         await sequelize.query('SET FOREIGN_KEY_CHECKS = 0')
         const [results] = await sequelize.query("SHOW TABLES LIKE 'user';")
-        if (results.length === 0) {
+        if (!forceRefresh && results.length === 0) {
           throw new Error('\n\nUser table does not exist - make sure you have initialised the database\n\n')
         }
         // Sync to the database

--- a/packages/server-core/src/setting/analytics-setting/analytics.seed.ts
+++ b/packages/server-core/src/setting/analytics-setting/analytics.seed.ts
@@ -1,6 +1,5 @@
 export const analyticsSeed = {
   path: 'analytics-setting',
-  randomize: false,
   templates: [
     {
       enabled: true,

--- a/packages/server-core/src/setting/authentication-setting/authentication.seed.ts
+++ b/packages/server-core/src/setting/authentication-setting/authentication.seed.ts
@@ -2,7 +2,6 @@ import config from '../../appconfig'
 
 export const authenticationSeed = {
   path: 'authentication-setting',
-  randomize: false,
   templates: [
     {
       service: 'identity-provider',

--- a/packages/server-core/src/setting/aws-setting/aws-setting.seed.ts
+++ b/packages/server-core/src/setting/aws-setting/aws-setting.seed.ts
@@ -1,6 +1,5 @@
 export const awsSeed = {
   path: 'aws-setting',
-  randomize: false,
   templates: [
     {
       keys: JSON.stringify({

--- a/packages/server-core/src/setting/chargebee-setting/chargebee-setting.seed.ts
+++ b/packages/server-core/src/setting/chargebee-setting/chargebee-setting.seed.ts
@@ -1,6 +1,5 @@
 export const chargebeeSeed = {
   path: 'chargebee-setting',
-  randomize: false,
   templates: [
     {
       url: process.env.CHARGEBEE_SITE + '.chargebee.com' || 'dummy.not-chargebee.com',

--- a/packages/server-core/src/setting/client-setting/client-setting.seed.ts
+++ b/packages/server-core/src/setting/client-setting/client-setting.seed.ts
@@ -1,6 +1,5 @@
 export const clientSeed = {
   path: 'client-setting',
-  randomize: false,
   templates: [
     {
       logo: process.env.APP_LOGO,

--- a/packages/server-core/src/setting/email-setting/email-setting.seed.ts
+++ b/packages/server-core/src/setting/email-setting/email-setting.seed.ts
@@ -1,6 +1,5 @@
 export const emailSeed = {
   path: 'email-setting',
-  randomize: false,
   templates: [
     {
       smtp: JSON.stringify({

--- a/packages/server-core/src/setting/game-server-setting/game-server-setting.seed.ts
+++ b/packages/server-core/src/setting/game-server-setting/game-server-setting.seed.ts
@@ -1,6 +1,5 @@
 export const gameServerSeed = {
   path: 'game-server-setting',
-  randomize: false,
   templates: [
     {
       clientHost: process.env.APP_HOST,

--- a/packages/server-core/src/setting/redis-setting/redis-setting.seed.ts
+++ b/packages/server-core/src/setting/redis-setting/redis-setting.seed.ts
@@ -1,6 +1,5 @@
 export const redisSeed = {
   path: 'redis-setting',
-  randomize: false,
   templates: [
     {
       enabled: process.env.REDIS_ENABLED === 'true',

--- a/packages/server-core/src/setting/server-setting/server-setting.seed.ts
+++ b/packages/server-core/src/setting/server-setting/server-setting.seed.ts
@@ -38,6 +38,5 @@ server.url =
 
 export const serverSeed = {
   path: 'server-setting',
-  randomize: false,
   templates: [server]
 }

--- a/packages/server-core/src/social/channel-type/channel-type.seed.ts
+++ b/packages/server-core/src/social/channel-type/channel-type.seed.ts
@@ -2,6 +2,5 @@ import config from '../../appconfig'
 
 export const channelTypeSeed = {
   path: 'channel-type',
-  randomize: false,
   templates: [{ type: 'user' }, { type: 'group' }, { type: 'party' }, { type: 'instance' }]
 }

--- a/packages/server-core/src/social/group-user-rank/group-user-rank.seed.ts
+++ b/packages/server-core/src/social/group-user-rank/group-user-rank.seed.ts
@@ -2,6 +2,5 @@ import config from '../../appconfig'
 
 export const groupUserRankSeed = {
   path: 'group-user-rank',
-  randomize: false,
   templates: [{ rank: 'owner' }, { rank: 'admin' }, { rank: 'user' }]
 }

--- a/packages/server-core/src/social/invite-type/invite-type.seed.ts
+++ b/packages/server-core/src/social/invite-type/invite-type.seed.ts
@@ -2,6 +2,5 @@ import config from '../../appconfig'
 
 export const inviteTypeSeed = {
   path: 'invite-type',
-  randomize: false,
   templates: [{ type: 'friend' }, { type: 'group' }, { type: 'party' }]
 }

--- a/packages/server-core/src/social/location-settings/location-settings.seed.ts
+++ b/packages/server-core/src/social/location-settings/location-settings.seed.ts
@@ -1,7 +1,6 @@
 import config from '../../appconfig'
 
 export const locationSettingsSeed = {
-  randomize: false,
   path: 'location-settings',
   templates: [
     {

--- a/packages/server-core/src/social/location-type/location-type.seed.ts
+++ b/packages/server-core/src/social/location-type/location-type.seed.ts
@@ -2,7 +2,6 @@ import config from '../../appconfig'
 
 export const locationTypeSeed = {
   path: 'location-type',
-  randomize: false,
   templates: [
     { type: 'private' },
     { type: 'public' }, // parse metadata for video staticResourceType (eg 360-eac)

--- a/packages/server-core/src/social/location/location.seed.ts
+++ b/packages/server-core/src/social/location/location.seed.ts
@@ -2,7 +2,6 @@ import { locationSettingsSeed } from '../location-settings/location-settings.see
 import { Location } from '@xrengine/common/src/interfaces/Location'
 
 export const locationSeed = {
-  randomize: false,
   path: 'location',
   templates: [
     {

--- a/packages/server-core/src/social/message-status/message-status.seed.ts
+++ b/packages/server-core/src/social/message-status/message-status.seed.ts
@@ -2,7 +2,6 @@ import config from '../../appconfig'
 
 export const messageStatusSeed = {
   path: 'message-status',
-  randomize: false,
   templates: [
     // Default Aframe components
     { type: 'unread' },

--- a/packages/server-core/src/user/inventory-item-type/inventory-item-type.seed.ts
+++ b/packages/server-core/src/user/inventory-item-type/inventory-item-type.seed.ts
@@ -2,7 +2,6 @@ import { inventoryItemType } from './inventoryItemType'
 
 export const inventoryItemTypeSeed = {
   path: 'inventory-item-type',
-  randomize: false,
   templates: [
     { inventoryItemType: inventoryItemType.skill },
     { inventoryItemType: inventoryItemType.weapon },

--- a/packages/server-core/src/user/inventory-item/inventory-item.seed.ts
+++ b/packages/server-core/src/user/inventory-item/inventory-item.seed.ts
@@ -1,6 +1,5 @@
 export const inventoryItemSeed = {
   path: 'inventory-item',
-  randomize: false,
   templates: [
     {
       sid: 'j9o2NLiD',

--- a/packages/server-core/src/user/user-relationship-type/user-relationship-type.seed.ts
+++ b/packages/server-core/src/user/user-relationship-type/user-relationship-type.seed.ts
@@ -1,6 +1,5 @@
 export const userRelationshipTypeSeed = {
   path: 'user-relationship-type',
-  randomize: false,
   templates: [
     { type: 'requested' }, // Default state of relatedUser
     { type: 'friend' },

--- a/packages/server-core/src/user/user-role/user-role.seed.ts
+++ b/packages/server-core/src/user/user-role/user-role.seed.ts
@@ -1,7 +1,6 @@
 import config from '../../appconfig'
 
 export const userRoleSeed = {
-  randomize: false,
   path: 'user-role',
   templates: [{ role: 'admin' }, { role: 'moderator' }, { role: 'user' }, { role: 'guest' }, { role: 'location-admin' }]
 }

--- a/packages/server-core/src/util/seeder/index.ts
+++ b/packages/server-core/src/util/seeder/index.ts
@@ -1,31 +1,16 @@
 import { GeneralError } from '@feathersjs/errors'
+import { ServicesSeedConfig } from '@xrengine/common/src/interfaces/ServicesSeedConfig'
 import { copyDefaultProject, uploadLocalProjectToProvider } from '../../projects/project/project.class'
+import { seedApp } from './seeder'
 
-import Seeder from './seeder'
-
-export default function seeder(opts = {}) {
-  if (opts === false || (opts as any).disabled === true) {
-    return function () {
-      this.seed = () => {
-        console.log('Seeder is disabled, not modifying database.')
-
-        return Promise.resolve([])
-      }
-    }
-  }
-
-  if (!((opts as any).services instanceof Array)) {
-    throw new Error('You must include an array of services to be seeded.')
-  }
-
+export default function seeder(services: Array<ServicesSeedConfig>) {
   return function () {
     const app = this
-    const seeder = new Seeder(app, opts)
     app.seed = async () => {
       copyDefaultProject()
       await uploadLocalProjectToProvider('default-project', app)
       try {
-        await seeder.seedApp()
+        await seedApp(app, services)
       } catch (err) {
         console.log(`Seeding error: ${err}`)
         throw new GeneralError(new Error(err))

--- a/packages/server-core/src/util/seeder/index.ts
+++ b/packages/server-core/src/util/seeder/index.ts
@@ -7,14 +7,15 @@ export default function seeder(services: Array<ServicesSeedConfig>) {
   return function () {
     const app = this
     app.seed = async () => {
-      copyDefaultProject()
-      await uploadLocalProjectToProvider('default-project', app)
       try {
         await seedApp(app, services)
       } catch (err) {
         console.log(`Seeding error: ${err}`)
         throw new GeneralError(new Error(err))
       }
+      copyDefaultProject()
+      await app.service('project')._seedProject('default-project')
+      await uploadLocalProjectToProvider('default-project', app)
     }
   }
 }

--- a/packages/server-core/src/util/seeder/seeder.ts
+++ b/packages/server-core/src/util/seeder/seeder.ts
@@ -1,121 +1,50 @@
+import { ServicesSeedConfig } from '@xrengine/common/src/interfaces/ServicesSeedConfig'
+import { Application } from '../../../declarations'
 import Compiler from './compiler'
+const compiler = new Compiler()
 
-export default class Seeder {
-  app: any
-  opts: any
-  compiler: Compiler
-  constructor(app, opts) {
-    this.app = app
-    this.opts = opts
+const compileTemplate = (template) => {
+  return compiler.compile(template)
+}
 
-    this.compiler = new Compiler()
+export const seedApp = async (app: Application, services: Array<ServicesSeedConfig>) => {
+  console.log('Seeding app...')
+
+  const promises: any[] = []
+
+  for (const cfg of services) {
+    promises.push(seed(app, cfg))
   }
 
-  compileTemplate(template) {
-    return this.compiler.compile(template)
+  return await Promise.all(promises)
+}
+
+const seed = async (app: Application, cfg: ServicesSeedConfig) => {
+  if (!cfg.path) {
+    throw new Error('You must include the path of every service you want to seed.')
+  }
+  if (!cfg.templates) {
+    throw new Error('You must specify an array of templates for seeded objects.')
   }
 
-  seedApp() {
-    console.log('Seeding app...')
+  const service = app.service(cfg.path)
+  await service.remove(null, null)
 
-    return new Promise((resolve, reject) => {
-      const promises: any[] = []
-
-      for (const cfg of this.opts.services) {
-        promises.push(this.seed(cfg))
-      }
-
-      return Promise.all(promises)
-        .then((seeded) => {
-          return resolve(seeded)
-        })
-        .catch(reject)
-    })
+  const pushPromise = async (template) => {
+    const compiled = compileTemplate(template)
+    if (!cfg.path) return []
+    const created = await service.create(compiled, null)
+    if (typeof cfg.callback === 'function') {
+      await cfg.callback(created, (...args) => seed(app, ...args))
+    }
+    return created
   }
 
-  seed(cfg): Promise<any> {
-    return new Promise((resolve, reject) => {
-      if (!cfg.path) {
-        throw new Error('You must include the path of every service you want to seed.')
-      }
-
-      if (!cfg.template && !cfg.templates) {
-        throw new Error('You must specify a template or array of templates for seeded objects.')
-      }
-
-      if (cfg.count && cfg.randomize === false) {
-        throw new Error('You may not specify both randomize = false with count')
-      }
-
-      const service = cfg.path && this.app.service(cfg.path)
-      const params = Object.assign({}, this.opts.params, cfg.params)
-      const count = Number(cfg.count) || 1
-      const randomize = typeof cfg.randomize === 'undefined' ? true : cfg.randomize
-
-      // Delete from service, if necessary
-      const shouldDelete = this.opts.delete !== false && cfg.delete !== false
-
-      const deletePromise = shouldDelete && cfg.path ? service.remove(null, params) : Promise.resolve([])
-
-      return deletePromise
-        .then((deleted) => {
-          const pushPromise = (template) => {
-            return new Promise((resolve, reject) => {
-              const compiled = this.compileTemplate(template)
-
-              if (!cfg.path) resolve([])
-
-              return service
-                .create(compiled, params)
-                .then((created) => {
-                  if (typeof cfg.callback !== 'function') {
-                    return resolve(created)
-                  } else {
-                    return cfg
-                      .callback(created, this.seed.bind(this))
-                      .then((result) => {
-                        return resolve(created)
-                      })
-                      .catch(reject)
-                  }
-                })
-                .catch(reject)
-            })
-          }
-
-          // Now, let's seed the app.
-          const promises: any[] = []
-
-          if (cfg.template && cfg.disabled !== true) {
-            // Single template
-            for (let i = 0; i < count; i++) {
-              promises.push(pushPromise(cfg.template))
-            }
-          } else if (cfg.templates && cfg.disabled !== true) {
-            // Multiple random templates
-            if (randomize) {
-              for (let i = 0; i < count; i++) {
-                const index = Math.floor(Math.random() * cfg.templates.length)
-                const template = cfg.templates[index]
-                promises.push(pushPromise(template))
-              }
-            }
-            // All templates
-            else {
-              for (let i = 0; i < cfg.templates.length; i++) {
-                const template = cfg.templates[i]
-                promises.push(pushPromise(template))
-              }
-            }
-          }
-
-          if (!promises.length) {
-            return resolve([])
-          } else {
-            return Promise.all(promises).then(resolve).catch(reject)
-          }
-        })
-        .catch(reject)
-    })
+  const promises: any[] = []
+  for (let i = 0; i < cfg.templates.length; i++) {
+    const template = cfg.templates[i]
+    promises.push(pushPromise(template))
   }
+
+  return await Promise.all(promises)
 }

--- a/packages/server-core/src/world/scene/scene.class.ts
+++ b/packages/server-core/src/world/scene/scene.class.ts
@@ -92,9 +92,6 @@ export class Scene implements ServiceMethods<any> {
     const { sceneName, sceneData, thumbnailBuffer } = data
     console.log('[scene.update]:', projectName, data)
 
-    if (!isDev && projectName === 'default-project')
-      throw new Error('The default project is read only. Please make a new project if you wish to customise it.')
-
     const project = await this.app.service('project').get(projectName, params)
     if (!project.data) throw new Error(`No project named ${projectName} exists`)
 

--- a/packages/server/scripts/sync-db.sh
+++ b/packages/server/scripts/sync-db.sh
@@ -1,1 +1,0 @@
-PERFORM_DRY_RUN=true FORCE_DB_REFRESH=true node ../lib/

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -20,6 +20,7 @@ import { EventEmitter } from 'events'
 import services from '@xrengine/server-core/src/services'
 import sequelize from '@xrengine/server-core/src/sequelize'
 import { Application } from '@xrengine/server-core/declarations'
+import { isDev } from '@xrengine/common/src/utils/isDev'
 
 const emitter = new EventEmitter()
 
@@ -161,6 +162,10 @@ if (config.server.enabled) {
     app.use('/healthcheck', (req, res) => {
       res.sendStatus(200)
     })
+
+    if (isDev && !config.db.forceRefresh) {
+      app.service('project')._fetchDevLocalProjects()
+    }
   } catch (err) {
     console.log('Server init failure')
     console.log(err)

--- a/scripts/check-db-exists.ts
+++ b/scripts/check-db-exists.ts
@@ -1,0 +1,58 @@
+import dotenv from 'dotenv'
+import cli from 'cli'
+import { Sequelize } from 'sequelize'
+import { spawn } from 'child_process'
+
+dotenv.config()
+const db = {
+  username: process.env.MYSQL_USER ?? 'server',
+  password: process.env.MYSQL_PASSWORD ?? 'password',
+  database: process.env.MYSQL_DATABASE ?? 'xrengine',
+  host: process.env.MYSQL_HOST ?? '127.0.0.1',
+  port: process.env.MYSQL_PORT ?? 3306,
+  dialect: 'mysql'
+} as any
+
+db.url = process.env.MYSQL_URL ?? `mysql://${db.username}:${db.password}@${db.host}:${db.port}/${db.database}`
+
+cli.enable('status')
+
+const sequelize = new Sequelize({
+  ...db,
+  logging: true,
+  define: {
+    freezeTableName: true
+  }
+})
+
+cli.main(async () => {
+  await sequelize.sync()
+
+  const [results] = await sequelize.query("SHOW TABLES LIKE 'user';")
+
+  if (results.length === 0) {
+    console.log('User table not found, seeding the database...')
+
+    const initPromise = new Promise((resolve) => {
+      const initProcess = spawn('npm', ['run', 'init-db-production'])
+      initProcess.once('exit', resolve)
+      initProcess.once('error', resolve)
+      initProcess.once('disconnect', resolve)
+      initProcess.stdout.on('data', (data) => console.log(data.toString()))
+    }).then(console.log)
+
+    await Promise.race([
+      initPromise,
+      new Promise<void>((resolve) => {
+        setTimeout(() => {
+          console.log('WARNING: Initialisation too long to launch!')
+          resolve()
+        }, 3 * 60 * 10000) // timeout after 3 minutes - it needs to be this long as the default project is uploaded to the storage provider in this time
+      })
+    ])
+  } else {
+    console.log('Database found')
+  }
+
+  process.exit(0)
+})

--- a/scripts/check-db-exists.ts
+++ b/scripts/check-db-exists.ts
@@ -1,9 +1,17 @@
-import dotenv from 'dotenv'
+import dotenv from 'dotenv-flow'
 import cli from 'cli'
 import { Sequelize } from 'sequelize'
 import { spawn } from 'child_process'
+import appRootPath from 'app-root-path'
 
-dotenv.config()
+const kubernetesEnabled = process.env.KUBERNETES === 'true'
+if (!kubernetesEnabled) {
+  dotenv.config({
+    path: appRootPath.path,
+    silent: true
+  })
+}
+
 const db = {
   username: process.env.MYSQL_USER ?? 'server',
   password: process.env.MYSQL_PASSWORD ?? 'password',

--- a/scripts/check-db-exists.ts
+++ b/scripts/check-db-exists.ts
@@ -47,7 +47,7 @@ cli.main(async () => {
         setTimeout(() => {
           console.log('WARNING: Initialisation too long to launch!')
           resolve()
-        }, 3 * 60 * 10000) // timeout after 3 minutes - it needs to be this long as the default project is uploaded to the storage provider in this time
+        }, 5 * 60 * 1000) // timeout after 5 minutes - it needs to be this long as the default project is uploaded to the storage provider in this time
       })
     ])
   } else {

--- a/scripts/install-projects.js
+++ b/scripts/install-projects.js
@@ -1,5 +1,4 @@
 import { download } from "@xrengine/server-core/src/projects/project/downloadProjects";
-import { copyDefaultProject } from '@xrengine/server-core/src/projects/project/project.class';
 import dotenv from 'dotenv';
 import Sequelize from 'sequelize';
 
@@ -46,8 +45,6 @@ async function installAllProjects() {
     const projects = await Projects.findAll()
     console.log('found projects', projects)
     
-    copyDefaultProject()
-
     for(const project of projects) {
       await download(project.name)
     }

--- a/scripts/run-builder.sh
+++ b/scripts/run-builder.sh
@@ -13,8 +13,8 @@ cp -v /var/lib/docker/certs/client/* ~/.docker
 touch ./builder-started.txt
 bash ./scripts/setup_helm.sh
 bash ./scripts/setup_aws.sh $AWS_ACCESS_KEY $AWS_SECRET $AWS_REGION $CLUSTER_NAME
-npm run install-projects
 npm run check-db-exists
+npm run install-projects
 bash ./scripts/build_docker.sh $RELEASE_NAME $DOCKER_LABEL $PRIVATE_ECR $AWS_REGION
 npm install -g cli aws-sdk
 bash ./scripts/publish_ecr.sh $RELEASE_NAME ${TAG}__${START_TIME} $DOCKER_LABEL $PRIVATE_ECR $AWS_REGION

--- a/scripts/run-builder.sh
+++ b/scripts/run-builder.sh
@@ -14,6 +14,7 @@ touch ./builder-started.txt
 bash ./scripts/setup_helm.sh
 bash ./scripts/setup_aws.sh $AWS_ACCESS_KEY $AWS_SECRET $AWS_REGION $CLUSTER_NAME
 npm run install-projects
+npm run check-db-exists
 bash ./scripts/build_docker.sh $RELEASE_NAME $DOCKER_LABEL $PRIVATE_ECR $AWS_REGION
 npm install -g cli aws-sdk
 bash ./scripts/publish_ecr.sh $RELEASE_NAME ${TAG}__${START_TIME} $DOCKER_LABEL $PRIVATE_ECR $AWS_REGION


### PR DESCRIPTION
## Summary

- [x] refactors the feathers seeder to be entirely async and removes unused functionality
- [x] seeder must have 'FORCE_DB_REFRESH=true` explicitly set to run
- [x] change deployment flow to do check for unseeded database in builder rather than server pods
- [x] default project is no longer read-only on deployment, as all logical operations and tests are not dependent on it

Adds a couple new commands to the root package.json
`check-db-exists` which queries the database for if the 'users' table exists, if it does, it exits, if it does not, it runs the command
`init-db-production` which runs the API server with `APP_ENV=production` `FORCE_DB_REFRESH=true` which will seed the database and exit

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## QA Steps
```
docker container stop xrengine_db
docker container rm xrengine_db
docker container prune
npm run dev-docker
npm run check-db-exists
npm run install-projects
```
should destroy, recreate and seed database, then exit

## Reviewers

@barankyle 
