### PR TITLE
Fixed bugs in chat and provisioning.

### DIFF
--- a/packages/client-core/src/common/services/ChannelConnectionService.ts
+++ b/packages/client-core/src/common/services/ChannelConnectionService.ts
@@ -13,6 +13,7 @@ import { MediaStreamService } from '../../media/services/MediaStreamService'
 
 import { createState, DevTools, useState, none, Downgraded } from '@hookstate/core'
 import { InstanceServerProvisionResult } from '@xrengine/common/src/interfaces/InstanceServerProvisionResult'
+import { accessInstanceConnectionState } from '@xrengine/client-core/src/common/services/InstanceConnectionService'
 
 //State
 const state = createState({
@@ -32,6 +33,7 @@ const state = createState({
 })
 
 let connectionSocket = null
+const instanceConnectionState = accessInstanceConnectionState()
 
 store.receptors.push((action: ChannelConnectionActionType): any => {
   state.batch((s) => {
@@ -104,7 +106,9 @@ export const ChannelConnectionService = {
       const channelState = chatState.channels
       const channels = channelState.channels.value
       const channelEntries = Object.entries(channels)
-      const instanceChannel = channelEntries.find((entry) => entry[1].instanceId != null)
+      const instanceChannel = channelEntries.find(
+        (entry) => entry[1].instanceId === instanceConnectionState.instance.id.value
+      )
       const channelConnectionState = accessChannelConnectionState().value
       const instance = channelConnectionState.instance
       const locationId = channelConnectionState.locationId

--- a/packages/client-core/src/social/services/ChatService.ts
+++ b/packages/client-core/src/social/services/ChatService.ts
@@ -40,8 +40,7 @@ const state = createState({
     limit: 5,
     skip: 0,
     total: 0,
-    updateNeeded: true,
-    fetchingInstanceChannel: false
+    updateNeeded: true
   },
   targetObjectType: '',
   targetObject: {} as User | Group | Party | Instance,
@@ -67,12 +66,14 @@ store.receptors.push((action: ChatActionType) => {
         let findIndex
         if (typeof action.channel.id === 'string')
           findIndex = s.channels.channels.findIndex((c) => c.id.value === action.channel.id)
-        let idx = findIndex && findIndex > -1 ? findIndex : s.channels.channels.length
+        let idx = findIndex > -1 ? findIndex : s.channels.channels.length
         s.channels.channels[idx].set(action.channel)
 
         if (action.channelType === 'instance') {
-          // TODO: WHYYY ARE WE DOING ALL THIS??
-          s.channels.fetchingInstanceChannel.set(false)
+          const endedInstanceChannelIndex = s.channels.channels.findIndex(
+            (channel) => channel.channelType.value === 'instance' && channel.id.value !== action.channel.id
+          )
+          if (endedInstanceChannelIndex > -1) s.channels.channels[endedInstanceChannelIndex].set(none)
           s.merge({
             instanceChannelFetched: true,
             instanceChannelFetching: false
@@ -202,7 +203,7 @@ store.receptors.push((action: ChatActionType) => {
         return s.merge({ messageScrollInit: value })
 
       case 'FETCHING_INSTANCE_CHANNEL':
-        return s.channels.merge({ fetchingInstanceChannel: true })
+        return s.merge({ instanceChannelFetching: true })
 
       case 'SET_UPDATE_MESSAGE_SCROLL': {
         return s.merge({ updateMessageScroll: action.value })

--- a/packages/client-core/src/social/services/FriendService.ts
+++ b/packages/client-core/src/social/services/FriendService.ts
@@ -107,7 +107,7 @@ export const FriendService = {
   //   }
   // }
 
-  getFriends: async (search: string, skip?: number, limit?: number) => {
+  getFriends: async (skip?: number, limit?: number) => {
     const dispatch = useDispatch()
     {
       dispatch(FriendAction.fetchingFriends())
@@ -117,8 +117,7 @@ export const FriendService = {
           query: {
             action: 'friends',
             $limit: limit != null ? limit : friendState.friends.limit.value,
-            $skip: skip != null ? skip : friendState.friends.skip.value,
-            search
+            $skip: skip != null ? skip : friendState.friends.skip.value
           }
         })
         dispatch(FriendAction.loadedFriends(friendResult))

--- a/packages/client/src/components/Drawer/Left/index.tsx
+++ b/packages/client/src/components/Drawer/Left/index.tsx
@@ -123,7 +123,7 @@ const LeftDrawer = (props: Props): any => {
 
     useEffect(() => {
       if (friendState.updateNeeded.value === true && friendState.getFriendsInProgress.value !== true) {
-        FriendService.getFriends('', 0)
+        FriendService.getFriends(0)
       }
       /* if (selectedUser.id?.length > 0 && friendState.get('closeDetails') === selectedUser.id) {
         closeDetails()
@@ -167,7 +167,7 @@ const LeftDrawer = (props: Props): any => {
 
     const nextFriendsPage = (): void => {
       if (friendSubState.skip.value + friendSubState.limit.value < friendSubState.total.value) {
-        FriendService.getFriends('', friendSubState.skip.value + friendSubState.limit.value)
+        FriendService.getFriends(friendSubState.skip.value + friendSubState.limit.value)
       }
     }
 

--- a/packages/client/src/components/Drawer/Right/index.tsx
+++ b/packages/client/src/components/Drawer/Right/index.tsx
@@ -222,7 +222,7 @@ const Invites = (props: Props): any => {
 
   const nextFriendsPage = (): void => {
     if (friendSubState.skip.value + friendSubState.limit.value < friendSubState.total.value) {
-      FriendService.getFriends('', friendSubState.skip.value + friendSubState.limit.value)
+      FriendService.getFriends(friendSubState.skip.value + friendSubState.limit.value)
     }
   }
 

--- a/packages/client/src/components/Harmony/index.tsx
+++ b/packages/client/src/components/Harmony/index.tsx
@@ -790,7 +790,7 @@ const Harmony = (props: Props): any => {
 
   const nextFriendsPage = (): void => {
     if (friendSubState.skip.value + friendSubState.limit.value < friendSubState.total.value) {
-      FriendService.getFriends('', friendSubState.skip.value + friendSubState.limit.value)
+      FriendService.getFriends(friendSubState.skip.value + friendSubState.limit.value)
     }
   }
 

--- a/packages/client/src/components/InstanceChat/index.tsx
+++ b/packages/client/src/components/InstanceChat/index.tsx
@@ -59,7 +59,7 @@ const InstanceChat = (props: Props): any => {
     if (
       user?.instanceId?.value === instanceConnectionState.instance.id?.value &&
       instanceConnectionState.connected.value === true &&
-      channelState.fetchingInstanceChannel.value !== true
+      channelState.instanceChannelFetching.value !== true
     ) {
       ChatService.getInstanceChannel()
     }
@@ -67,7 +67,7 @@ const InstanceChat = (props: Props): any => {
     user?.instanceId?.value,
     instanceConnectionState.instance.id?.value,
     instanceConnectionState.connected?.value,
-    channelState.fetchingInstanceChannel.value
+    channelState.instanceChannelFetching.value
   ])
 
   const handleComposingMessageChange = (event: any): void => {

--- a/packages/server-core/src/networking/instance-provision/instance-provision.class.ts
+++ b/packages/server-core/src/networking/instance-provision/instance-provision.class.ts
@@ -200,8 +200,14 @@ export class InstanceProvision implements ServiceMethods<Data> {
       port: ipAddressSplit[1]
     }
   }
+
   /**
-   * A method which get clean up server
+   * A method that attempts to clean up a gameserver that no longer exists
+   * Currently-running gameservers are fetched via Agones client and their IP addresses
+   * compared against that of the instance in question. If there's no match, then the instance
+   * record is out-of date, it should be set to 'ended', and its subdomain provision should be freed.
+   * Returns false if the GS still exists and no cleanup was done, true if the GS does not exist and
+   * a cleanup was performed.
    *
    * @param instance of ipaddress and port
    * @returns {@Boolean}
@@ -288,6 +294,10 @@ export class InstanceProvision implements ServiceMethods<Data> {
         })
         if (channelInstance == null) return getFreeGameserver(this.app, 0, null!, channelId)
         else {
+          if (config.kubernetes.enabled) {
+            const gsCleanup = await this.gsCleanup(channelInstance)
+            if (gsCleanup) return getFreeGameserver(this.app, 0, null!, channelId)
+          }
           const ipAddressSplit = channelInstance.ipAddress.split(':')
           return {
             id: channelInstance.id,
@@ -296,27 +306,6 @@ export class InstanceProvision implements ServiceMethods<Data> {
           }
         }
       } else {
-        if (locationId == null) {
-          throw new BadRequest('Missing location ID')
-        }
-        const location = await this.app.service('location').get(locationId)
-        if (location == null) {
-          throw new BadRequest('Invalid location ID')
-        }
-        if (instanceId != null) {
-          const instance = await this.app.service('instance').get(instanceId)
-          if (instance == null || instance.ended === true) {
-            throw new BadRequest('Invalid instance ID')
-          }
-          if (instance.currentUsers < location.maxUsersPerInstance) {
-            const ipAddressSplit = instance.ipAddress.split(':')
-            return {
-              id: instance.id,
-              ipAddress: ipAddressSplit[0],
-              port: ipAddressSplit[1]
-            }
-          }
-        }
         // Check if JWT resolves to a user
         if (token != null) {
           const authResult = await (this.app.service('authentication') as any).strategies.jwt.authenticate(
@@ -328,6 +317,30 @@ export class InstanceProvision implements ServiceMethods<Data> {
             userId = identityProvider.userId
           } else {
             throw new BadRequest('Invalid user credentials')
+          }
+        }
+        if (locationId == null) {
+          throw new BadRequest('Missing location ID')
+        }
+        const location = await this.app.service('location').get(locationId)
+        if (location == null) {
+          throw new BadRequest('Invalid location ID')
+        }
+        if (instanceId != null) {
+          const instance = await this.app.service('instance').get(instanceId)
+          if (instance == null || instance.ended === true) return getFreeGameserver(this.app, 0, locationId, null!)
+          let gsCleanup
+          if (config.kubernetes.enabled) gsCleanup = await this.gsCleanup(instance)
+          if (
+            (!config.kubernetes.enabled || (config.kubernetes.enabled && !gsCleanup)) &&
+            instance.currentUsers < location.maxUsersPerInstance
+          ) {
+            const ipAddressSplit = instance.ipAddress.split(':')
+            return {
+              id: instance.id,
+              ipAddress: ipAddressSplit[0],
+              port: ipAddressSplit[1]
+            }
           }
         }
         // const user = await this.app.service('user').get(userId)

--- a/packages/server-core/src/social/channel/channel.class.ts
+++ b/packages/server-core/src/social/channel/channel.class.ts
@@ -30,7 +30,7 @@ export class Channel extends Service {
     const userId = loggedInUser.userId
     const Model = (this.app.service('channel') as any).Model
     try {
-      const params = {
+      const subParams = {
         subQuery: false,
         offset: skip,
         limit: limit,
@@ -73,7 +73,13 @@ export class Channel extends Service {
             ]
           },
           {
-            model: this.app.service('message').Model
+            model: this.app.service('message').Model,
+            include: [
+              {
+                model: (this.app.service('user') as any).Model,
+                as: 'sender'
+              }
+            ]
           }
         ],
         where: {
@@ -100,9 +106,9 @@ export class Channel extends Service {
           ]
         }
       }
-      if (query.targetObjectType) (params.where as any).channelType = query.targetObjectType
-      if (query.channelType) (params.where as any).channelType = query.channelType
-      const results = await Model.findAndCountAll(params)
+      if (query.targetObjectType) (subParams.where as any).channelType = query.targetObjectType
+      if (query.channelType) (subParams.where as any).channelType = query.channelType
+      const results = await Model.findAndCountAll(subParams)
 
       if (query.findTargetId === true) {
         const match = _.find(results.rows, (result: any) =>
@@ -121,121 +127,10 @@ export class Channel extends Service {
           limit: limit
         }
       } else {
-        await Promise.all(
-          results.rows.map(async (channel) => {
-            return await new Promise(async (resolve) => {
-              if (channel.channelType === 'user') {
-                // const user1AvatarResult = await this.app.service('static-resource').find({
-                //   query: {
-                //     staticResourceType: 'user-thumbnail',
-                //     userId: channel.userId1
-                //   }
-                // }) as any;
-                //
-                // const user2AvatarResult = await this.app.service('static-resource').find({
-                //   query: {
-                //     staticResourceType: 'user-thumbnail',
-                //     userId: channel.userId2
-                //   }
-                // }) as any;
-                //
-                // if (user1AvatarResult.total > 0) {
-                //   channel.user1.dataValues.avatarUrl = user1AvatarResult.data[0].url;
-                // }
-                //
-                // if (user2AvatarResult.total > 0) {
-                //   channel.user2.dataValues.avatarUrl = user2AvatarResult.data[0].url;
-                // }
-
-                resolve(true)
-              } else if (channel.channelType === 'group') {
-                const groupUsers = await (this.app.service('group-user') as any).Model.findAll({
-                  where: {
-                    groupId: channel.groupId
-                  },
-                  include: [
-                    {
-                      model: (this.app.service('user') as any).Model
-                    }
-                  ]
-                })
-                // await Promise.all(groupUsers.map(async (groupUser) => {
-                //   const avatarResult = await this.app.service('static-resource').find({
-                //     query: {
-                //       staticResourceType: 'user-thumbnail',
-                //       userId: groupUser.userId
-                //     }
-                //   }) as any;
-                //
-                //   if (avatarResult.total > 0) {
-                //     groupUser.dataValues.user.dataValues.avatarUrl = avatarResult.data[0].url;
-                //   }
-                //
-                //   return await Promise.resolve();
-                // }));
-
-                channel.group.dataValues.groupUsers = groupUsers
-                resolve(true)
-              } else if (channel.channelType === 'party') {
-                const partyUsers = await (this.app.service('party-user') as any).Model.findAll({
-                  where: {
-                    partyId: channel.partyId
-                  },
-                  include: [
-                    {
-                      model: (this.app.service('user') as any).Model
-                    }
-                  ]
-                })
-                // await Promise.all(partyUsers.map(async (partyUser) => {
-                //   const avatarResult = await this.app.service('static-resource').find({
-                //     query: {
-                //       staticResourceType: 'user-thumbnail',
-                //       userId: partyUser.userId
-                //     }
-                //   }) as any;
-                //
-                //   if (avatarResult.total > 0) {
-                //     partyUser.dataValues.user.dataValues.avatarUrl = avatarResult.data[0].url;
-                //   }
-                //
-                //   return await Promise.resolve();
-                // }));
-                channel.party.dataValues.partyUsers = partyUsers
-                resolve(true)
-              } else if (channel.channelType === 'instance') {
-                const instanceUsers = await (this.app.service('user') as any).Model.findAll({
-                  where: {
-                    instanceId: channel.instanceId
-                  }
-                })
-                // await Promise.all(instanceUsers.map(async(user) => {
-                //   const avatarResult = await this.app.service('static-resource').find({
-                //     query: {
-                //       staticResourceType: 'user-thumbnail',
-                //       userId: user.id
-                //     }
-                //   }) as any;
-                //
-                //   if (avatarResult.total > 0) {
-                //     user.dataValues.avatarUrl = avatarResult.data[0].url;
-                //   }
-                //
-                //   return await Promise.resolve();
-                // }));
-                channel.instance.dataValues.instanceUsers = instanceUsers
-                resolve(true)
-              }
-            })
-          })
-        )
-
-        return {
-          data: results.rows,
-          total: results.count,
-          skip: skip,
-          limit: limit
+        query.id = {
+          $in: results.rows.map((channel) => channel.id)
         }
+        return super.find(params)
       }
     } catch (err) {
       logger.error('Channel find failed')

--- a/packages/server-core/src/social/channel/channel.hooks.ts
+++ b/packages/server-core/src/social/channel/channel.hooks.ts
@@ -1,5 +1,6 @@
 import * as authentication from '@feathersjs/authentication'
 import { disallow } from 'feathers-hooks-common'
+import addAssociations from '@xrengine/server-core/src/hooks/add-associations'
 
 /**
  *  Don't remove this comment. It's needed to format import lines nicely.
@@ -11,8 +12,70 @@ const { authenticate } = authentication.hooks
 export default {
   before: {
     all: [authenticate('jwt')],
-    find: [],
-    get: [],
+    find: [
+      addAssociations({
+        models: [
+          {
+            model: 'message',
+            include: [
+              {
+                model: 'user',
+                as: 'sender'
+              }
+            ]
+          },
+          {
+            model: 'instance'
+          },
+          {
+            model: 'group'
+          },
+          {
+            model: 'party'
+          },
+          {
+            model: 'user',
+            as: 'user1'
+          },
+          {
+            model: 'user',
+            as: 'user2'
+          }
+        ]
+      })
+    ],
+    get: [
+      addAssociations({
+        models: [
+          {
+            model: 'message',
+            include: [
+              {
+                model: 'user',
+                as: 'sender'
+              }
+            ]
+          },
+          {
+            model: 'instance'
+          },
+          {
+            model: 'group'
+          },
+          {
+            model: 'party'
+          },
+          {
+            model: 'user',
+            as: 'user1'
+          },
+          {
+            model: 'user',
+            as: 'user2'
+          }
+        ]
+      })
+    ],
     create: [disallow('external')],
     update: [disallow('external')],
     patch: [disallow('external')],


### PR DESCRIPTION
## Summary

Added association population to channel service. Updated channel.find
to just use the IDs of its findAll as part of super.find(params) so that
association population is always applied.

Removed search query param from friend finding. It wasn't used, and was causing
problems with new streamlined user.find.

Fixed a bug in ChatServive that was causing LOADED_CHANNEL channel patches to be
added as new, duplicate channels. Also made LOADED_CHANNEL remove existing instance
channel if one exists.

Fixed a bug in ChannelConnectionService that was matching any instance channel in
the channel list, rather than the one with the current instance's id. The above
ChatService fix should render this moot, but just in case, it should handle some
unforeseen circumstance.

Fixed issues with instance-provision being given IDs of invalid/ended/crashed
instances returning those bad instances' IP addresses as if everything was fine.
It now gets a free gameserver if the instance ended/is null, and if it appears to
be valid, performs gsCleanup() on it in case it had crashed. IP address of that instance
is only returned if, after all of this, the GS has been determined to be still running.


## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
