### PR TITLE
Check for user entity before setAvatar call

### DIFF
--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -844,7 +844,9 @@ const loadAvatarForUpdatedUser = async (user) => {
       //Find entityId from network objects of updated user and dispatch avatar load event.
       const world = Engine.currentWorld
       const userEntity = world.getUserAvatarEntity(user.id)
-      setAvatar(userEntity, avatarURL)
+      if (userEntity) {
+        setAvatar(userEntity, avatarURL)
+      }
     } else {
       await loadAvatarForUpdatedUser(user)
     }

--- a/packages/engine/src/ecs/classes/World.ts
+++ b/packages/engine/src/ecs/classes/World.ts
@@ -152,9 +152,9 @@ export class World {
   /**
    * Get the user avatar entity (the network object w/ an Avatar component)
    * @param userId
-   * @returns
+   * @returns Entity | undefined
    */
-  getUserAvatarEntity(userId: UserId) {
+  getUserAvatarEntity(userId: UserId): Entity | undefined {
     return this.getOwnedNetworkObjects(userId).find((eid) => {
       return hasComponent(eid, AvatarComponent, this)
     })!

--- a/packages/engine/src/ecs/classes/World.ts
+++ b/packages/engine/src/ecs/classes/World.ts
@@ -152,9 +152,9 @@ export class World {
   /**
    * Get the user avatar entity (the network object w/ an Avatar component)
    * @param userId
-   * @returns Entity | undefined
+   * @returns
    */
-  getUserAvatarEntity(userId: UserId): Entity | undefined {
+  getUserAvatarEntity(userId: UserId) {
     return this.getOwnedNetworkObjects(userId).find((eid) => {
       return hasComponent(eid, AvatarComponent, this)
     })!


### PR DESCRIPTION
## Summary

When there is no entity with AvatarComponent - AuthService is not expecting this.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

...

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
