### PR TITLE
Admin Asset Upload Service

### DIFF
--- a/packages/client-core/src/admin/services/AssetUploadService.ts
+++ b/packages/client-core/src/admin/services/AssetUploadService.ts
@@ -1,0 +1,45 @@
+import { store, useDispatch } from '../../store'
+import { client } from '../../feathers'
+import { createState, useState } from '@hookstate/core'
+import { AssetUploadType } from '@xrengine/common/src/interfaces/UploadAssetInterface'
+
+// const state = createState({})
+
+// store.receptors.push((action: AssetUploadActionType): any => {
+//   state.batch((s) => {
+//     switch (action.type) {
+//       case 'ADMIN_ASSET_UPLOADED':
+//         return
+//     }
+//   }, action.type)
+// })
+
+// export const accessAssetUploadState = () => state
+
+// export const useAssetUploadState = () => useState(state) as any as typeof state
+
+//Service
+export const AdminAssetUploadService = {
+  uploadAssets: async (files: Blob[], args: any[]) => {
+    const uploadArguments: AssetUploadType = {
+      type: 'admin-file-upload',
+      files,
+      args
+    }
+    const result = await client.service('asset-upload').create(uploadArguments)
+    const dispatch = useDispatch()
+    dispatch(AssetUploadAction.fetchedAssets(result))
+  }
+}
+
+//Action
+export const AssetUploadAction = {
+  fetchedAssets: (data: string[]) => {
+    return {
+      type: 'ADMIN_ASSET_UPLOADED' as const,
+      staticResource: data
+    }
+  }
+}
+
+export type AssetUploadActionType = ReturnType<typeof AssetUploadAction[keyof typeof AssetUploadAction]>

--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -30,7 +30,7 @@ import { IdentityProviderSeed } from '@xrengine/common/src/interfaces/IdentityPr
 import { AuthUserSeed } from '@xrengine/common/src/interfaces/AuthUser'
 import { UserAvatar } from '@xrengine/common/src/interfaces/UserAvatar'
 import { accessStoredLocalState, StoredLocalAction, StoredLocalActionType } from '../../util/StoredLocalState'
-import { AssetUploadArguments } from '@xrengine/common/src/interfaces/UploadAssetInterface'
+import { AssetUploadType } from '@xrengine/common/src/interfaces/UploadAssetInterface'
 import { userPatched } from '../functions/userPatched'
 import { dispatchFrom } from '@xrengine/engine/src/networking/functions/dispatchFrom'
 import { NetworkWorldAction } from '@xrengine/engine/src/networking/functions/NetworkWorldAction'
@@ -673,11 +673,12 @@ export const AuthService = {
     }
   },
   uploadAvatarModel: async (avatar: Blob, thumbnail: Blob, avatarName: string, isPublicAvatar?: boolean) => {
-    const uploadArguments: AssetUploadArguments = {
+    const uploadArguments: AssetUploadType = {
+      type: 'user-avatar-upload',
       files: [avatar, thumbnail],
       args: {
         avatarName,
-        isPublicAvatar
+        isPublicAvatar: !!isPublicAvatar
       }
     }
     const response = await client.service('upload-asset').create(uploadArguments)

--- a/packages/common/src/interfaces/UploadAssetInterface.ts
+++ b/packages/common/src/interfaces/UploadAssetInterface.ts
@@ -1,4 +1,24 @@
-export type AssetUploadArguments = {
+export type AvatarUploadType = {
+  type: 'user-avatar-upload'
   files: (Blob | Buffer)[]
-  args: any
+  args: {
+    avatarName: string
+    isPublicAvatar: boolean
+  }
 }
+
+export type AdminAssetUploadArgumentsType = {
+  key: string
+  contentType: string
+  staticResourceType: string
+  userId?: string
+  name?: string
+}
+
+export type AdminAssetUploadType = {
+  type: 'admin-file-upload'
+  files: (Blob | Buffer)[]
+  args: Array<AdminAssetUploadArgumentsType>
+}
+
+export type AssetUploadType = AvatarUploadType | AdminAssetUploadType

--- a/packages/server-core/src/media/upload-media/upload-asset.service.ts
+++ b/packages/server-core/src/media/upload-media/upload-asset.service.ts
@@ -4,6 +4,10 @@ import { Params } from '@feathersjs/feathers'
 import hooks from './upload-asset.hooks'
 import express from 'express'
 import { AvatarUploadArguments } from '../../user/avatar/avatar-helper'
+import restrictUserRole from '../../hooks/restrict-user-role'
+import { AdminAssetUploadArgumentsType, AssetUploadType } from '@xrengine/common/src/interfaces/UploadAssetInterface'
+import { useStorageProvider } from '../storageprovider/storageprovider'
+import { getCachedAsset } from '../storageprovider/getCachedAsset'
 
 const multipartMiddleware = multer({ limits: { fieldSize: Infinity } })
 
@@ -13,9 +17,68 @@ declare module '../../../declarations' {
   }
 }
 
-type UploadedAsset = {
-  userId: string
-} & any
+export const addGenericAssetToS3AndStaticResources = async (
+  app: Application,
+  file: Buffer,
+  args: AdminAssetUploadArgumentsType
+) => {
+  const provider = useStorageProvider()
+  // make userId optional and safe for feathers create
+  const userIdQuery = args.userId ? { userId: args.userId } : {}
+
+  const existingAsset = await app.service('static-resource').find({
+    query: {
+      staticResourceType: args.staticResourceType,
+      // safely spread conditional params so we can query by name if it is given, otherwise fall back to key
+      ...(args.name ? { name: args.name } : { key: args.key }),
+      ...userIdQuery
+    }
+  })
+
+  const promises: Promise<any>[] = []
+
+  // upload asset to storage provider
+  promises.push(
+    provider.putObject({
+      Key: args.key,
+      Body: file,
+      ContentType: args.contentType
+    })
+  )
+
+  // add asset to static resources
+  const assetURL = getCachedAsset(args.key, provider.cacheDomain)
+  if (existingAsset.data.length) {
+    promises.push(provider.deleteResources([existingAsset.data[0].id]))
+    promises.push(
+      app.service('static-resource').patch(
+        existingAsset.data[0].id,
+        {
+          url: assetURL,
+          key: args.key
+        },
+        { isInternal: true }
+      )
+    )
+  } else {
+    promises.push(
+      app.service('static-resource').create(
+        {
+          name: args.name ?? null,
+          mimeType: args.contentType,
+          url: assetURL,
+          key: args.key,
+          staticResourceType: args.staticResourceType,
+          ...userIdQuery
+        },
+        { isInternal: true }
+      )
+    )
+  }
+
+  await Promise.all(promises)
+  return assetURL
+}
 
 export default (app: Application): void => {
   app.use(
@@ -29,9 +92,10 @@ export default (app: Application): void => {
       next()
     },
     {
-      create: async (data: UploadedAsset, params?: Params) => {
-        // console.log('\n\nupload-asset', data, params, '\n\n')
-        if (data.args?.avatarName) {
+      create: async (data: AssetUploadType, params?: Params) => {
+        console.log('\n\nupload-asset', data, '\n\n')
+        // console.log(params)
+        if (data.type === 'user-avatar-upload') {
           return await app.service('avatar').create(
             {
               avatar: data.files[0],
@@ -39,6 +103,11 @@ export default (app: Application): void => {
               ...data.args
             } as AvatarUploadArguments,
             null!
+          )
+        } else if (data.type === 'admin-file-upload') {
+          if (!(await restrictUserRole('admin')({ app, params } as any))) return
+          return Promise.all(
+            data.files.map((file, i) => addGenericAssetToS3AndStaticResources(app, file as Buffer, data.args[i]))
           )
         }
       }

--- a/packages/server-core/src/media/upload-media/upload-asset.service.ts
+++ b/packages/server-core/src/media/upload-media/upload-asset.service.ts
@@ -39,10 +39,14 @@ export const addGenericAssetToS3AndStaticResources = async (
 
   // upload asset to storage provider
   promises.push(
-    provider.putObject({
-      Key: args.key,
-      Body: file,
-      ContentType: args.contentType
+    new Promise<void>(async (resolve) => {
+      await provider.createInvalidation([args.key])
+      await provider.putObject({
+        Key: args.key,
+        Body: file,
+        ContentType: args.contentType
+      })
+      resolve()
     })
   )
 

--- a/packages/server-core/src/user/avatar/avatar-helper.ts
+++ b/packages/server-core/src/user/avatar/avatar-helper.ts
@@ -7,6 +7,7 @@ import { getCachedAsset } from '../../media/storageprovider/getCachedAsset'
 import { CommonKnownContentTypes } from '@xrengine/common/src/utils/CommonKnownContentTypes'
 import fs from 'fs'
 import path from 'path'
+import { addGenericAssetToS3AndStaticResources } from '../../media/upload-media/upload-asset.service'
 
 const provider = useStorageProvider()
 
@@ -47,110 +48,25 @@ export const uploadAvatarStaticResource = async (app: Application, data: AvatarU
   // const thumbnail = await generateAvatarThumbnail(data.avatar as Buffer)
   // if (!thumbnail) throw new Error('Thumbnail generation failed - check the model')
 
-  // make userId optional and safe for feathers create
-  const userIdQuery = data.userId ? { userId: data.userId } : {}
   const name = data.avatarName ?? 'Avatar-' + Math.round(Math.random() * 10000)
 
-  const [existingModel, existingThumbnail] = await Promise.all([
-    app.service('static-resource').find({
-      query: {
-        name,
-        staticResourceType: 'avatar',
-        ...userIdQuery
-      }
-    }),
-    app.service('static-resource').find({
-      query: {
-        name,
-        staticResourceType: 'user-thumbnail',
-        ...userIdQuery
-      }
-    })
-  ])
+  const modelPromise = addGenericAssetToS3AndStaticResources(app, data.avatar, {
+    userId: data.userId!,
+    key: `${key}.glb`,
+    staticResourceType: 'avatar',
+    contentType: CommonKnownContentTypes.glb,
+    name
+  })
 
-  console.log(existingModel, existingThumbnail)
+  const thumbnailPromise = addGenericAssetToS3AndStaticResources(app, data.thumbnail, {
+    userId: data.userId!,
+    key: `${key}.png`,
+    staticResourceType: 'user-thumbnail',
+    contentType: CommonKnownContentTypes.png,
+    name
+  })
 
-  const promises: Promise<any>[] = []
-
-  // upload model to storage provider
-  promises.push(
-    provider.putObject({
-      Key: `${key}.glb`,
-      Body: data.avatar as Buffer,
-      ContentType: CommonKnownContentTypes.glb
-    })
-  )
-
-  // add model to static resources
-  const avatarURL = getCachedAsset(`${key}.glb`, provider.cacheDomain)
-  if (existingModel.data.length) {
-    promises.push(provider.deleteResources([existingModel.data[0].id]))
-    promises.push(
-      app.service('static-resource').patch(
-        existingModel.data[0].id,
-        {
-          url: avatarURL,
-          key: `${key}.glb`
-        },
-        { isInternal: true }
-      )
-    )
-  } else {
-    promises.push(
-      app.service('static-resource').create(
-        {
-          name: data.avatarName,
-          mimeType: CommonKnownContentTypes.glb,
-          url: avatarURL,
-          key: `${key}.glb`,
-          staticResourceType: 'avatar',
-          ...userIdQuery
-        },
-        { isInternal: true }
-      )
-    )
-  }
-
-  // upload thumbnail to storage provider
-  promises.push(
-    provider.putObject({
-      Key: `${key}.png`,
-      Body: data.thumbnail as Buffer,
-      ContentType: CommonKnownContentTypes.png
-    })
-  )
-
-  // add thumbnail to static resources
-  const thumbnailURL = getCachedAsset(`${key}.png`, provider.cacheDomain)
-  if (existingThumbnail.data.length) {
-    promises.push(provider.deleteResources([existingThumbnail.data[0].id]))
-    promises.push(
-      app.service('static-resource').patch(
-        existingThumbnail.data[0].id,
-        {
-          url: thumbnailURL,
-          key: `${key}.png`
-        },
-        { isInternal: true }
-      )
-    )
-  } else {
-    promises.push(
-      app.service('static-resource').create(
-        {
-          name: data.avatarName,
-          mimeType: CommonKnownContentTypes.png,
-          url: thumbnailURL,
-          key: `${key}.png`,
-          staticResourceType: 'user-thumbnail',
-          ...userIdQuery
-        },
-        { isInternal: true }
-      )
-    )
-  }
-
-  await Promise.all(promises)
+  const [avatarURL, thumbnailURL] = await Promise.all([modelPromise, thumbnailPromise])
 
   console.log('Successfully uploaded avatar!', avatarURL)
 


### PR DESCRIPTION
## Summary

- Adds an arbitrary static resource & s3 upload service for admins to the `upload-asset` service.
- Refactors user avatar uploading to use this new functionality

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
