### PR TITLE
Hotfix: Add missing world tick in outgoing network state.

### DIFF
--- a/packages/engine/src/networking/systems/OutgoingNetworkSystem.test.ts
+++ b/packages/engine/src/networking/systems/OutgoingNetworkSystem.test.ts
@@ -248,12 +248,12 @@ describe('outgoingNetworkState', () => {
         headPoseRotation: [4,5,6,7],
         leftRayPosition: [1,2,3],
         leftRayRotation: [4,5,6,7],
-        rightRayPosition: [1,2,3],
-        rightRayRotation: [4,5,6,7],
+        rightRayPosition: [10,20,30],
+        rightRayRotation: [40,50,60,70],
         leftGripPosition: [1,2,3],
         leftGripRotation: [4,5,6,7],
-        rightGripPosition: [1,2,3],
-        rightGripRotation: [4,5,6,7],
+        rightGripPosition: [11,21,31],
+        rightGripRotation: [41,51,61,71],
       }],
       handsPose: [{
         ownerId: 'id' as UserId,
@@ -280,7 +280,6 @@ describe('outgoingNetworkState', () => {
     strictEqual(state.pose[0].networkId, 100)
     deepEqual(state.pose[0].position, [1,2,3])
     deepEqual(state.pose[0].rotation, [1,2,3,4])
-    strictEqual(state.pose[0].networkId, 100)
 
     strictEqual(state.controllerPose[0].ownerId, 'id')
     strictEqual(state.controllerPose[0].networkId, 101)
@@ -288,12 +287,12 @@ describe('outgoingNetworkState', () => {
     deepEqual(state.controllerPose[0].headPoseRotation, [4,5,6,7])
     deepEqual(state.controllerPose[0].leftRayPosition, [1,2,3])
     deepEqual(state.controllerPose[0].leftRayRotation, [4,5,6,7])
-    deepEqual(state.controllerPose[0].rightRayPosition, [1,2,3])
-    deepEqual(state.controllerPose[0].rightRayRotation, [4,5,6,7])
+    deepEqual(state.controllerPose[0].rightRayPosition, [10,20,30])
+    deepEqual(state.controllerPose[0].rightRayRotation, [40,50,60,70])
     deepEqual(state.controllerPose[0].leftGripPosition, [1,2,3])
     deepEqual(state.controllerPose[0].leftGripRotation, [4,5,6,7])
-    deepEqual(state.controllerPose[0].rightGripPosition, [1,2,3])
-    deepEqual(state.controllerPose[0].rightGripRotation, [4,5,6,7])
+    deepEqual(state.controllerPose[0].rightGripPosition, [11,21,31])
+    deepEqual(state.controllerPose[0].rightGripRotation, [41,51,61,71])
 
     strictEqual(state.handsPose[0].ownerId, 'id')
     strictEqual(state.handsPose[0].networkId, 102)

--- a/packages/engine/src/networking/systems/OutgoingNetworkSystem.test.ts
+++ b/packages/engine/src/networking/systems/OutgoingNetworkSystem.test.ts
@@ -241,8 +241,33 @@ describe('outgoingNetworkState', () => {
         linearVelocity: [0],
         angularVelocity: [0]
       }],
-      controllerPose: [{} as any],
-      handsPose: [{} as any]
+      controllerPose: [{
+        ownerId: 'id' as UserId,
+        networkId: 101 as NetworkId,
+        headPosePosition: [1,2,3],
+        headPoseRotation: [4,5,6,7],
+        leftRayPosition: [1,2,3],
+        leftRayRotation: [4,5,6,7],
+        rightRayPosition: [1,2,3],
+        rightRayRotation: [4,5,6,7],
+        leftGripPosition: [1,2,3],
+        leftGripRotation: [4,5,6,7],
+        rightGripPosition: [1,2,3],
+        rightGripRotation: [4,5,6,7],
+      }],
+      handsPose: [{
+        ownerId: 'id' as UserId,
+        networkId: 102 as NetworkId, 
+        hands: [{
+          joints: [
+            {
+              key: 'string',
+              position: [1,2,3],
+              rotation: [4,5,6,7],
+            }
+          ]
+        }]
+      }],
     }
     
     const buffer = WorldStateModel.toBuffer(world.outgoingNetworkState)
@@ -250,12 +275,31 @@ describe('outgoingNetworkState', () => {
 
     strictEqual(state.tick, 42)
     strictEqual(state.time, now)
+
     strictEqual(state.pose[0].ownerId, 'id')
     strictEqual(state.pose[0].networkId, 100)
     deepEqual(state.pose[0].position, [1,2,3])
     deepEqual(state.pose[0].rotation, [1,2,3,4])
     strictEqual(state.pose[0].networkId, 100)
-    strictEqual(world.outgoingNetworkState.pose.length, 0)
+
+    strictEqual(state.controllerPose[0].ownerId, 'id')
+    strictEqual(state.controllerPose[0].networkId, 101)
+    deepEqual(state.controllerPose[0].headPosePosition, [1,2,3])
+    deepEqual(state.controllerPose[0].headPoseRotation, [4,5,6,7])
+    deepEqual(state.controllerPose[0].leftRayPosition, [1,2,3])
+    deepEqual(state.controllerPose[0].leftRayRotation, [4,5,6,7])
+    deepEqual(state.controllerPose[0].rightRayPosition, [1,2,3])
+    deepEqual(state.controllerPose[0].rightRayRotation, [4,5,6,7])
+    deepEqual(state.controllerPose[0].leftGripPosition, [1,2,3])
+    deepEqual(state.controllerPose[0].leftGripRotation, [4,5,6,7])
+    deepEqual(state.controllerPose[0].rightGripPosition, [1,2,3])
+    deepEqual(state.controllerPose[0].rightGripRotation, [4,5,6,7])
+
+    strictEqual(state.handsPose[0].ownerId, 'id')
+    strictEqual(state.handsPose[0].networkId, 102)
+    deepEqual(state.handsPose[0].hands[0].joints[0].key, 'string')
+    deepEqual(state.handsPose[0].hands[0].joints[0].position, [1,2,3])
+    deepEqual(state.handsPose[0].hands[0].joints[0].rotation, [4,5,6,7])
     
   })
 

--- a/packages/engine/src/networking/systems/OutgoingNetworkSystem.ts
+++ b/packages/engine/src/networking/systems/OutgoingNetworkSystem.ts
@@ -273,11 +273,15 @@ export const resetNetworkState = (world: World) => {
   const { outgoingNetworkState, previousNetworkState } = world
 
   // copy previous state
+  previousNetworkState.tick = outgoingNetworkState.tick
+  previousNetworkState.time = outgoingNetworkState.time
   previousNetworkState.pose = outgoingNetworkState.pose
   previousNetworkState.controllerPose = outgoingNetworkState.controllerPose
   previousNetworkState.handsPose = outgoingNetworkState.handsPose
 
   // reset current state
+  outgoingNetworkState.tick = world.fixedTick
+  outgoingNetworkState.time = Date.now()
   outgoingNetworkState.pose = []
   outgoingNetworkState.controllerPose = []
   outgoingNetworkState.handsPose = []


### PR DESCRIPTION

## Summary
World fixed tick was removed from the outgoing network state due to which default tick of -1 is sent out each time and results in strange behaviours related to networking.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
