### PR TITLE
Fix Performance Tuning

### DIFF
--- a/packages/client-core/src/user/components/UserMenu/index.tsx
+++ b/packages/client-core/src/user/components/UserMenu/index.tsx
@@ -79,16 +79,7 @@ const UserMenu = (props: UserMenuProps): any => {
   const [activeLocation, setActiveLocation] = useState(null)
 
   const [userSetting, setUserSetting] = useState(selfUser?.user_setting.value)
-  const [graphics, setGraphicsSetting] = useState({})
   const engineState = useEngineState()
-
-  useEffect(() => {
-    EngineEvents.instance?.addEventListener(EngineRenderer.EVENTS.QUALITY_CHANGED, updateGraphicsSettings)
-
-    return () => {
-      EngineEvents.instance?.removeEventListener(EngineRenderer.EVENTS.QUALITY_CHANGED, updateGraphicsSettings)
-    }
-  }, [])
 
   useEffect(() => {
     setEngineLoaded(true)
@@ -119,11 +110,6 @@ const UserMenu = (props: UserMenuProps): any => {
 
   const handleRemoveAvatar = (keys: [string]): any => {
     return AuthService.removeAvatar(keys)
-  }
-
-  const updateGraphicsSettings = (newSetting: any): void => {
-    const setting = { ...graphics, ...newSetting }
-    setGraphicsSetting(setting)
   }
 
   const setActiveMenu = (e): void => {
@@ -194,9 +180,7 @@ const UserMenu = (props: UserMenuProps): any => {
       case Views.Settings:
         args = {
           setting: userSetting,
-          setUserSettings: setUserSettings,
-          graphics: graphics,
-          setGraphicsSettings: updateGraphicsSettings
+          setUserSettings: setUserSettings
         }
         break
       case Views.Share:

--- a/packages/client-core/src/user/components/UserMenu/menus/SettingMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/SettingMenu.tsx
@@ -9,6 +9,7 @@ import { EngineRendererAction, useEngineRendererState } from '@xrengine/engine/s
 import { useTranslation } from 'react-i18next'
 import { UserSetting } from '@xrengine/common/src/interfaces/User'
 import { dispatchLocal } from '@xrengine/engine/src/networking/functions/dispatchFrom'
+import { EngineRenderer } from '@xrengine/engine/src/renderer/WebGLRendererSystem'
 
 type Props = {
   setting: UserSetting
@@ -18,7 +19,6 @@ type Props = {
 const SettingMenu = (props: Props): JSX.Element => {
   const { t } = useTranslation()
   const rendererState = useEngineRendererState()
-  console.log('SettingMenu-', rendererState.value)
   return (
     <div className={styles.menuPanel}>
       <div className={styles.settingPanel}>
@@ -73,14 +73,13 @@ const SettingMenu = (props: Props): JSX.Element => {
             <Slider
               value={rendererState.qualityLevel.value}
               onChange={(_, value: number) => {
-                console.log('slider', rendererState.qualityLevel.value, value)
                 dispatchLocal(EngineRendererAction.setQualityLevel(value))
                 dispatchLocal(EngineRendererAction.setAutomatic(false))
               }}
               className={styles.slider}
-              min={0.25}
-              max={1}
-              step={0.125}
+              min={1}
+              max={5}
+              step={1}
             />
           </div>
           <div className={`${styles.row} ${styles.FlexWrap}`}>

--- a/packages/client-core/src/user/components/UserMenu/util.tsx
+++ b/packages/client-core/src/user/components/UserMenu/util.tsx
@@ -1,6 +1,5 @@
 import { UserId } from '@xrengine/common/src/interfaces/UserId'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
-import type { Network } from '@xrengine/engine/src/networking/classes/Network'
 
 export const Views = {
   Closed: '',

--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -953,7 +953,6 @@ export const AuthAction = {
     }
   },
   avatarUpdated: (result: any) => {
-    debugger
     const url = result.url
     return {
       type: 'AVATAR_UPDATED' as const,

--- a/packages/engine/src/common/classes/ExponentialAverageCurve.ts
+++ b/packages/engine/src/common/classes/ExponentialAverageCurve.ts
@@ -1,0 +1,15 @@
+export class ExponentialMovingAverage {
+  mean: number
+  multiplier: number
+
+  constructor(timePeriods = 10, startingMean = 16) {
+    this.mean = startingMean
+    this.multiplier = 2 / (timePeriods + 1)
+  }
+
+  update(newValue: number) {
+    const meanIncrement = this.multiplier * (newValue - this.mean)
+    const newMean = this.mean + meanIncrement
+    this.mean = newMean
+  }
+}

--- a/packages/engine/src/ecs/classes/Engine.ts
+++ b/packages/engine/src/ecs/classes/Engine.ts
@@ -44,7 +44,6 @@ export class Engine {
 
   /**
    * Reference to the three.js renderer object.
-   * This is set in {@link initialize.initializeEngine | initializeEngine()}.
    */
   static renderer: WebGLRenderer = null!
   static effectComposer: EffectComposerWithSchema = null!
@@ -55,7 +54,6 @@ export class Engine {
   static directionalLights: DirectionalLight[] = []
   /**
    * Reference to the three.js scene object.
-   * This is set in {@link initialize.initializeEngine | initializeEngine()}.
    */
   static scene: Scene = null!
   static sceneLoaded = false
@@ -70,7 +68,6 @@ export class Engine {
 
   /**
    * Reference to the three.js perspective camera object.
-   * This is set in {@link initialize.initializeEngine | initializeEngine()}.
    */
   static camera: PerspectiveCamera | OrthographicCamera = null!
   static activeCameraEntity: Entity

--- a/packages/engine/src/ecs/classes/EngineService.ts
+++ b/packages/engine/src/ecs/classes/EngineService.ts
@@ -10,7 +10,6 @@ const state = createState({
   loadingProgress: -1,
   connectedWorld: false,
   isTeleporting: null! as ReturnType<typeof PortalComponent.get>,
-
   isPhysicsDebug: false,
   isAvatarDebug: false,
   leaveWorld: false,

--- a/packages/engine/src/renderer/EngineRendererState.ts
+++ b/packages/engine/src/renderer/EngineRendererState.ts
@@ -1,0 +1,102 @@
+import { createState, State, useState } from '@hookstate/core'
+import { ClientStorage } from '../common/classes/ClientStorage'
+import { Engine } from '../ecs/classes/Engine'
+import { dispatchLocal } from '../networking/functions/dispatchFrom'
+import { databasePrefix, RENDERER_SETTINGS } from './EngineRnedererConstants'
+import { EngineRenderer } from './WebGLRendererSystem'
+
+const state = createState({
+  qualityLevel: 5,
+  automatic: true,
+  // usePBR: true,
+  usePostProcessing: true,
+  useShadows: true
+})
+
+type StateType = State<typeof state.value>
+
+export const useEngineRendererState = () => useState(state) as any as typeof state
+export const accessEngineRendererState = () => state
+
+function setUseAutomatic(s: StateType, automatic: boolean) {
+  if (automatic) {
+    EngineRenderer.instance.doAutomaticRenderQuality()
+  }
+  ClientStorage.set(databasePrefix + RENDERER_SETTINGS.AUTOMATIC, automatic)
+  dispatchLocal(EngineRendererAction.setAutomatic(automatic))
+  s.merge({ automatic })
+}
+
+function setResolution(s: StateType, resolution) {
+  EngineRenderer.instance.scaleFactor = resolution
+  Engine.renderer.setPixelRatio(window.devicePixelRatio * EngineRenderer.instance.scaleFactor)
+  EngineRenderer.instance.needsResize = true
+  ClientStorage.set(databasePrefix + RENDERER_SETTINGS.SCALE_FACTOR, EngineRenderer.instance.scaleFactor)
+  s.merge({ qualityLevel: resolution })
+}
+
+function setUseShadows(s: StateType, useShadows) {
+  if (state.useShadows.value === useShadows) return
+
+  Engine.renderer.shadowMap.enabled = useShadows
+  ClientStorage.set(databasePrefix + RENDERER_SETTINGS.USE_SHADOWS, useShadows)
+  s.merge({ useShadows })
+}
+
+function setUsePostProcessing(s: StateType, usePostProcessing) {
+  if (state.usePostProcessing.value === usePostProcessing) return
+
+  usePostProcessing = EngineRenderer.instance.supportWebGL2 && usePostProcessing
+  ClientStorage.set(databasePrefix + RENDERER_SETTINGS.POST_PROCESSING, usePostProcessing)
+  s.merge({ usePostProcessing })
+}
+
+export function EngineRendererReceptor(action: EngineRendererActionType) {
+  state.batch((s) => {
+    switch (action.type) {
+      case 'WEBGL_RENDERER_QUALITY_LEVEL':
+        return setResolution(s, action.qualityLevel)
+      case 'WEBGL_RENDERER_AUTO':
+        return setUseAutomatic(s, action.automatic)
+      // case 'WEBGL_RENDERER_PBR': return s.merge({ usePBR: action.usePBR })
+      case 'WEBGL_RENDERER_POSTPROCESSING':
+        return setUsePostProcessing(s, action.usePostProcessing)
+      case 'WEBGL_RENDERER_SHADOWS':
+        return setUseShadows(s, action.useShadows)
+    }
+  })
+}
+
+export const EngineRendererAction = {
+  setQualityLevel: (qualityLevel: number) => {
+    return {
+      type: 'WEBGL_RENDERER_QUALITY_LEVEL' as const,
+      qualityLevel
+    }
+  },
+  setAutomatic: (automatic: boolean) => {
+    return {
+      type: 'WEBGL_RENDERER_AUTO' as const,
+      automatic
+    }
+  },
+  setPBR: (usePBR: boolean) => {
+    return {
+      type: 'WEBGL_RENDERER_PBR' as const,
+      usePBR
+    }
+  },
+  setPostProcessing: (usePostProcessing: boolean) => {
+    return {
+      type: 'WEBGL_RENDERER_POSTPROCESSING' as const,
+      usePostProcessing
+    }
+  },
+  setShadows: (useShadows: boolean) => {
+    return {
+      type: 'WEBGL_RENDERER_SHADOWS' as const,
+      useShadows
+    }
+  }
+}
+export type EngineRendererActionType = ReturnType<typeof EngineRendererAction[keyof typeof EngineRendererAction]>

--- a/packages/engine/src/renderer/EngineRnedererConstants.ts
+++ b/packages/engine/src/renderer/EngineRnedererConstants.ts
@@ -1,0 +1,9 @@
+export enum RENDERER_SETTINGS {
+  AUTOMATIC = 'automatic',
+  PBR = 'usePBR',
+  POST_PROCESSING = 'usePostProcessing',
+  USE_SHADOWS = 'shadowQuality',
+  SCALE_FACTOR = 'scaleFactor'
+}
+
+export const databasePrefix = 'graphics-settings-'

--- a/packages/engine/src/renderer/WebGLRendererSystem.ts
+++ b/packages/engine/src/renderer/WebGLRendererSystem.ts
@@ -242,7 +242,7 @@ export class EngineRenderer {
 
     if (averageDelta > this.maxRenderDelta && qualityLevel > 1) {
       qualityLevel--
-    } else if (averageDelta < this.minRenderDelta && qualityLevel !== this.maxQualityLevel) {
+    } else if (averageDelta < this.minRenderDelta && qualityLevel < this.maxQualityLevel) {
       qualityLevel++
     }
 

--- a/packages/engine/src/scene/functions/createMap.ts
+++ b/packages/engine/src/scene/functions/createMap.ts
@@ -72,12 +72,4 @@ export async function createMap(entity: Entity, args: MapProps): Promise<void> {
   */
     navTarget: navigationRaycastTarget
   })
-
-  // Force higest resolution. There is a heavy CPU/GPU load while the map is being generated which,
-  // when using the automatic setting, causes the lowest resolution to be selected.
-  EngineEvents.instance.dispatchEvent({ type: EngineRenderer.EVENTS.SET_RESOLUTION, payload: 1 })
-  EngineEvents.instance.dispatchEvent({
-    type: EngineRenderer.EVENTS.SET_USE_AUTOMATIC,
-    payload: false
-  })
 }


### PR DESCRIPTION
## Summary

Fixes performance auto tuning by introducing a proper moving average calculation, clamping the update delta to no more than 50ms to avoid lag spikes disrupting the moving average, 

Also refactors EngineRenderer updateable state to be handled with the FLUX pattern established similarly to the engine events.

Waiting for a react bug to be solved before this is ready for review.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
