### PR TITLE
Fix perf autotuning for Low Power Mode

### DIFF
--- a/packages/client/src/components/Debug/index.tsx
+++ b/packages/client/src/components/Debug/index.tsx
@@ -62,7 +62,7 @@ export const Debug = () => {
             key,
             Object.fromEntries(
               getEntityComponents(Engine.currentWorld, value).reduce((components, C: MappedComponent<any, any>) => {
-                if (C !== NameComponent) components.push([C._name, getComponent(value, C as any)])
+                if (C !== NameComponent) components.push([C._name, { ...getComponent(value, C as any) }])
                 return components
               }, [] as [string, any][])
             )
@@ -97,6 +97,7 @@ export const Debug = () => {
         </button>
         {Network.instance !== null && (
           <div>
+            <div>Tick: {engineState.fixedTick.value}</div>
             <div>
               <h1>Named Entities</h1>
               <JSONTree data={renderNamedEntities()} />

--- a/packages/editor/src/nodes/CameraPropertiesNode.ts
+++ b/packages/editor/src/nodes/CameraPropertiesNode.ts
@@ -35,8 +35,8 @@ export default class CameraPropertiesNode extends EditorNodeMixin(Object3D) {
     node.cameraModeDefault = cameraModeDefault ?? CameraMode.ThirdPerson
     node.startInFreeLook = startInFreeLook ?? false
     node.startCameraDistance = startCameraDistance ?? 5
-    node.minPhi = minPhi ?? 0
-    node.maxPhi = maxPhi ?? 90
+    node.minPhi = minPhi ?? -70
+    node.maxPhi = maxPhi ?? 85
     node.startPhi = startPhi ?? 10
     return node
   }
@@ -61,8 +61,8 @@ export default class CameraPropertiesNode extends EditorNodeMixin(Object3D) {
         cameraMode: this.cameraMode ?? CameraMode.Dynamic,
         cameraModeDefault: this.cameraModeDefault ?? CameraMode.ThirdPerson,
         startInFreeLook: this.startInFreeLook ?? false,
-        minPhi: this.minPhi ?? 0,
-        maxPhi: this.maxPhi ?? 90,
+        minPhi: this.minPhi ?? -70,
+        maxPhi: this.maxPhi ?? 85,
         startPhi: this.startPhi ?? 10
       }
     } as any

--- a/packages/engine/src/audio/systems/PositionalAudioSystem.ts
+++ b/packages/engine/src/audio/systems/PositionalAudioSystem.ts
@@ -99,7 +99,7 @@ export default async function PositionalAudioSystem(world: World): Promise<Syste
     for (const entity of avatarAudioQuery.enter()) {
       const entityNetworkObject = getComponent(entity, NetworkObjectComponent)
       if (entityNetworkObject) {
-        const peerId = entityNetworkObject.uniqueId
+        const peerId = entityNetworkObject.ownerId
         const consumer = MediaStreams.instance?.consumers.find(
           (c: any) => c.appData.peerId === peerId && c.appData.mediaTag === 'cam-audio'
         )
@@ -144,7 +144,7 @@ export default async function PositionalAudioSystem(world: World): Promise<Syste
       const entityNetworkObject = getComponent(entity, NetworkObjectComponent)
       let consumer
       if (entityNetworkObject != null) {
-        const peerId = entityNetworkObject.uniqueId
+        const peerId = entityNetworkObject.ownerId
         consumer = MediaStreams.instance?.consumers.find(
           (c: any) => c.appData.peerId === peerId && c.appData.mediaTag === 'cam-audio'
         )

--- a/packages/engine/src/avatar/AvatarInputSchema.ts
+++ b/packages/engine/src/avatar/AvatarInputSchema.ts
@@ -163,7 +163,7 @@ export const switchShoulderSide: InputBehaviorType = (
   }
 }
 
-export const setTargetCameraRotation = (entity: Entity, phi: number, theta: number) => {
+export const setTargetCameraRotation = (entity: Entity, phi: number, theta: number, time = 0.3) => {
   const cameraRotationTransition = getComponent(entity, TargetCameraRotationComponent)
   if (!cameraRotationTransition) {
     addComponent(entity, TargetCameraRotationComponent, {
@@ -171,11 +171,12 @@ export const setTargetCameraRotation = (entity: Entity, phi: number, theta: numb
       phiVelocity: { value: 0 },
       theta: theta,
       thetaVelocity: { value: 0 },
-      time: 0.3
+      time: time
     })
   } else {
     cameraRotationTransition.phi = phi
     cameraRotationTransition.theta = theta
+    cameraRotationTransition.time = time
   }
 }
 
@@ -427,16 +428,14 @@ const lookByInputAxis: InputBehaviorType = (
   inputValue: InputValue,
   delta: number
 ): void => {
-  const followCamera = getComponent(entity, FollowCameraComponent)
-
-  if (hasComponent(entity, TargetCameraRotationComponent)) {
-    removeComponent(entity, TargetCameraRotationComponent)
-  }
-
-  if (followCamera) {
-    followCamera.theta -= inputValue.value[0] * 100
-    followCamera.phi -= inputValue.value[1] * 100
-  }
+  const target = getComponent(entity, TargetCameraRotationComponent) || getComponent(entity, FollowCameraComponent)
+  if (target)
+    setTargetCameraRotation(
+      entity,
+      target.phi - inputValue.value[1] * 30000 * delta,
+      target.theta - inputValue.value[0] * 30000 * delta,
+      0.1
+    )
 }
 
 const gamepadLook: InputBehaviorType = (entity: Entity): void => {

--- a/packages/engine/src/camera/components/FollowCameraComponent.ts
+++ b/packages/engine/src/camera/components/FollowCameraComponent.ts
@@ -19,6 +19,10 @@ export type FollowCameraComponentType = {
   theta: number
   /** Rotation around Z axis */
   phi: number
+  /** Minimum phi value */
+  minPhi: number
+  /** Maximum phi value */
+  maxPhi: number
   /** Whether looking over left or right shoulder */
   shoulderSide: boolean
   /** Whether the camera auto-rotates toward the target **Default** value is true. */
@@ -36,6 +40,8 @@ export const FollowCameraDefaultValues: FollowCameraComponentType = {
   maxDistance: 7,
   theta: Math.PI,
   phi: 0,
+  minPhi: -70,
+  maxPhi: 85,
   shoulderSide: true,
   locked: true,
   raycaster: new Raycaster()

--- a/packages/engine/src/camera/systems/CameraSystem.ts
+++ b/packages/engine/src/camera/systems/CameraSystem.ts
@@ -39,7 +39,7 @@ const cameraRayCount = 6
 const cameraRays: Vector3[] = []
 const rayConeAngle = Math.PI / 6
 const coneDebugHelpers: ArrowHelper[] = []
-const debugRays = true
+const debugRays = false
 const camRayCastClock = new Clock()
 const camRayCastCache = {
   maxDistance: -1,

--- a/packages/engine/src/camera/systems/CameraSystem.ts
+++ b/packages/engine/src/camera/systems/CameraSystem.ts
@@ -39,7 +39,7 @@ const cameraRayCount = 6
 const cameraRays: Vector3[] = []
 const rayConeAngle = Math.PI / 6
 const coneDebugHelpers: ArrowHelper[] = []
-const debugRays = false
+const debugRays = true
 const camRayCastClock = new Clock()
 const camRayCastCache = {
   maxDistance: -1,
@@ -98,6 +98,8 @@ const updateCameraTargetRotation = (entity: Entity, delta: number) => {
   const target = getComponent(entity, TargetCameraRotationComponent)
   const epsilon = 0.001
 
+  target.phi = Math.min(followCamera.maxPhi, Math.max(followCamera.minPhi, target.phi))
+
   if (Math.abs(target.phi - followCamera.phi) < epsilon && Math.abs(target.theta - followCamera.theta) < epsilon) {
     removeComponent(entity, TargetCameraRotationComponent)
     return
@@ -109,9 +111,9 @@ const updateCameraTargetRotation = (entity: Entity, delta: number) => {
 
 const getMaxCamDistance = (entity: Entity, target: Vector3) => {
   // Cache the raycast result for 0.1 seconds
-  if (camRayCastCache.maxDistance != -1 && camRayCastClock.getElapsedTime() < 0.1) {
-    return camRayCastCache
-  }
+  // if (camRayCastCache.maxDistance != -1 && camRayCastClock.getElapsedTime() < 0.1) {
+  //   return camRayCastCache
+  // }
 
   camRayCastClock.start()
 
@@ -122,6 +124,7 @@ const getMaxCamDistance = (entity: Entity, target: Vector3) => {
   // Raycast to keep the line of sight with avatar
   const cameraTransform = getComponent(Engine.activeCameraEntity, TransformComponent)
   const targetToCamVec = tempVec1.subVectors(cameraTransform.position, target)
+  // followCamera.raycaster.ray.origin.sub(targetToCamVec.multiplyScalar(0.1)) // move origin behind camera
 
   createConeOfVectors(targetToCamVec, cameraRays, rayConeAngle)
 
@@ -184,7 +187,7 @@ const updateFollowCamera = (entity: Entity, delta: number) => {
   const followCamera = getComponent(entity, FollowCameraComponent)
 
   // Limit the pitch
-  followCamera.phi = Math.min(85, Math.max(-70, followCamera.phi))
+  followCamera.phi = Math.min(followCamera.maxPhi, Math.max(followCamera.minPhi, followCamera.phi))
 
   calculateCameraTarget(entity, tempVec)
 
@@ -208,7 +211,7 @@ const updateFollowCamera = (entity: Entity, delta: number) => {
   // }
 
   // Zoom smoothing
-  let smoothingSpeed = isInsideWall ? 0.06 : 0.3
+  let smoothingSpeed = isInsideWall ? 0.01 : 0.3
 
   followCamera.distance = smoothDamp(
     followCamera.distance,

--- a/packages/engine/src/common/classes/GenerateMeshBVHWorker.ts
+++ b/packages/engine/src/common/classes/GenerateMeshBVHWorker.ts
@@ -61,12 +61,6 @@ export class GenerateMeshBVHWorker {
         }
       }
 
-      if ((geometry.attributes.position as InterleavedBufferAttribute).isInterleavedBufferAttribute) {
-        throw new Error(
-          'GenerateMeshBVHWorker: InterleavedBufferAttribute are not supported for the geometry attributes.'
-        )
-      }
-
       const index = geometry.index ? Uint32Array.from(geometry.index.array) : null
       const position = Float32Array.from(geometry.attributes.position.array)
 

--- a/packages/engine/src/common/classes/GenerateMeshBVHWorker.ts
+++ b/packages/engine/src/common/classes/GenerateMeshBVHWorker.ts
@@ -61,10 +61,7 @@ export class GenerateMeshBVHWorker {
         }
       }
 
-      if (
-        (geometry.attributes.position as InterleavedBufferAttribute).isInterleavedBufferAttribute ||
-        (geometry.index && (geometry.index as any as InterleavedBufferAttribute).isInterleavedBufferAttribute)
-      ) {
+      if ((geometry.attributes.position as InterleavedBufferAttribute).isInterleavedBufferAttribute) {
         throw new Error(
           'GenerateMeshBVHWorker: InterleavedBufferAttribute are not supported for the geometry attributes.'
         )

--- a/packages/engine/src/debug/systems/DebugHelpersSystem.ts
+++ b/packages/engine/src/debug/systems/DebugHelpersSystem.ts
@@ -121,21 +121,6 @@ export default async function DebugHelpersSystem(world: World): Promise<System> 
       ikobj.ref.remove(helper)
     }
     for (const entity of avatarDebugQuery.enter()) {
-      const avatar = getComponent(entity, AvatarComponent)
-
-      // view vector
-      const origin = new Vector3(0, 2, 0)
-      const length = 0.5
-      const hex = 0xffff00
-      if (!avatar || !avatar.viewVector) {
-        console.warn('avatar.viewVector is null')
-        continue
-      }
-      // const arrowHelper = new ArrowHelper(avatar.viewVector.clone().normalize(), origin, length, hex)
-      // arrowHelper.visible = avatarDebugEnabled
-      // Engine.scene.add(arrowHelper)
-      // helpersByEntity.viewVector.set(entity, arrowHelper)
-
       // velocity
       const velocityColor = 0x0000ff
       const velocityArrowHelper = new ArrowHelper(new Vector3(), new Vector3(0, 0, 0), 0.5, velocityColor)

--- a/packages/engine/src/ecs/classes/EngineService.ts
+++ b/packages/engine/src/ecs/classes/EngineService.ts
@@ -1,9 +1,11 @@
 import { createState, useState } from '@hookstate/core'
+import { number } from 'ts-matches/lib/mjs/parsers'
 import { InteractionData } from '../../interaction/types/InteractionTypes'
 import { PortalComponent, PortalComponentType } from '../../scene/components/PortalComponent'
 import { EngineEvents } from './EngineEvents'
 
 const state = createState({
+  fixedTick: 0,
   isEngineInitialized: false,
   sceneLoaded: false,
   joinedWorld: false,

--- a/packages/engine/src/ecs/functions/FixedPipelineSystem.ts
+++ b/packages/engine/src/ecs/functions/FixedPipelineSystem.ts
@@ -2,6 +2,7 @@ import { nowMilliseconds } from '../../common/functions/nowMilliseconds'
 import { World } from '../classes/World'
 import { System } from '../classes/System'
 import { SystemUpdateType } from './SystemUpdateType'
+import { accessEngineState } from '../classes/EngineService'
 
 /**
  * System for running simulation logic with fixed time intervals
@@ -31,6 +32,7 @@ export default async function FixedPipelineSystem(world: World, args: { tickRate
     while (!accumulatorDepleted && !timeout && !updatesLimitReached) {
       world.fixedElapsedTime += world.fixedDelta
       world.fixedTick += 1
+      accessEngineState().fixedTick.set(world.fixedTick)
 
       for (const s of world.pipelines[SystemUpdateType.FIXED_EARLY]) s.execute()
       for (const s of world.pipelines[SystemUpdateType.FIXED]) s.execute()

--- a/packages/engine/src/networking/components/NetworkObjectComponent.ts
+++ b/packages/engine/src/networking/components/NetworkObjectComponent.ts
@@ -14,6 +14,11 @@ export type NetworkObjectComponentType = {
   parameters: any
 }
 
-export const NetworkObjectComponent = createMappedComponent<NetworkObjectComponentType>('NetworkObjectComponent', {
+const SCHEMA = {
   networkId: Types.ui32
-})
+}
+
+export const NetworkObjectComponent = createMappedComponent<NetworkObjectComponentType, typeof SCHEMA>(
+  'NetworkObjectComponent',
+  SCHEMA
+)

--- a/packages/engine/src/physics/components/VelocityComponent.ts
+++ b/packages/engine/src/physics/components/VelocityComponent.ts
@@ -1,4 +1,5 @@
 import { Types } from 'bitecs'
+import { create } from 'lodash'
 import { Vector3 } from 'three'
 import { createMappedComponent } from '../../ecs/functions/ComponentFunctions'
 
@@ -12,7 +13,11 @@ export type VelocityComponentType = {
 
 const { f32 } = Types
 const Vector3Schema = { x: f32, y: f32, z: f32 }
-
-export const VelocityComponent = createMappedComponent<VelocityComponentType>('VelocityComponent', {
+const SCHEMA = {
   velocity: Vector3Schema
-})
+}
+
+export const VelocityComponent = createMappedComponent<VelocityComponentType, typeof SCHEMA>(
+  'VelocityComponent',
+  SCHEMA
+)

--- a/packages/engine/src/renderer/WebGLRendererSystem.ts
+++ b/packages/engine/src/renderer/WebGLRendererSystem.ts
@@ -80,7 +80,7 @@ export class EngineRenderer {
   /** Maximum Quality level of the rendered. **Default** value is 5. */
   maxQualityLevel = 5
   /** point at which we downgrade quality level (large delta) */
-  maxRenderDelta = 1000 / 40 // 40 fps = 25 ms
+  maxRenderDelta = 1000 / 28 // 28 fps = 35 ms  (on some devices, rAF updates at 30fps, e.g., Low Power Mode)
   /** point at which we upgrade quality level (small delta) */
   minRenderDelta = 1000 / 55 // 55 fps = 18 ms
   /** Resoulion scale. **Default** value is 1. */
@@ -284,3 +284,5 @@ export default async function WebGLRendererSystem(world: World, props: EngineRen
     if (props.enabled) EngineRenderer.instance.execute(world.delta)
   }
 }
+
+globalThis.EngineRenderer = EngineRenderer

--- a/packages/engine/src/scene/components/PortalComponent.ts
+++ b/packages/engine/src/scene/components/PortalComponent.ts
@@ -5,6 +5,7 @@ export type PortalComponentType = {
   location: string
   linkedPortalId: string
   isPlayerInPortal: boolean
+  displayText: string
   previewMesh: Mesh
   remoteSpawnPosition: Vector3
   remoteSpawnRotation: Quaternion

--- a/packages/engine/src/transform/components/TransformComponent.ts
+++ b/packages/engine/src/transform/components/TransformComponent.ts
@@ -1,6 +1,6 @@
 import { Vector3, Quaternion } from 'three'
 import { createMappedComponent } from '../../ecs/functions/ComponentFunctions'
-import { Types } from 'bitecs'
+import { Types, ComponentType, defineComponent } from 'bitecs'
 
 export type TransformComponentType = {
   position: Vector3
@@ -11,9 +11,16 @@ export type TransformComponentType = {
 const { f32 } = Types
 const Vector3Schema = { x: f32, y: f32, z: f32 }
 const QuaternionSchema = { x: f32, y: f32, z: f32, w: f32 }
-
-export const TransformComponent = createMappedComponent<TransformComponentType>('TransformComponent', {
+const SCHEMA = {
   position: Vector3Schema,
   rotation: QuaternionSchema,
   scale: Vector3Schema
-})
+}
+
+export const TransformComponent = createMappedComponent<TransformComponentType, typeof SCHEMA>(
+  'TransformComponent',
+  SCHEMA
+)
+// createComponent('TransformComponent', SCHEMA).withMap<TransformComponentType>()
+
+globalThis.TransformComponent = TransformComponent

--- a/packages/engine/tests/networking/systems/OutgoingNetworkSystem.perf.test.ts
+++ b/packages/engine/tests/networking/systems/OutgoingNetworkSystem.perf.test.ts
@@ -61,7 +61,6 @@ describe.skip('OutgoingNetworkSystem Performance Tests', async () => {
         scale: new Vector3(),
       })
       addComponent(entity, NetworkObjectComponent, {
-        userId: i as unknown as UserId,
         ownerId: i as unknown as UserId,
         networkId: 0 as NetworkId,
         prefab: '',


### PR DESCRIPTION
## Summary

Some browsers (macOS Safari and iOS Safari) execute requestAnimationFrame callbacks targeting 30fps under certain conditions, e.g., Low Power Mode. 

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
