### PR TITLE
Updated client-core version of react-i18next

### DIFF
--- a/packages/client-core/package.json
+++ b/packages/client-core/package.json
@@ -58,7 +58,7 @@
     "react-apexcharts": "^1.3.9",
     "react-copy-to-clipboard": "^5.0.4",
     "react-ga4": "1.4.1",
-    "react-i18next": "11.14.3",
+    "react-i18next": "11.15.2",
     "react-lottie": "1.2.3",
     "react-material-ui-form-validator": "3.0.0",
     "react-responsive": "9.0.0-beta.4",


### PR DESCRIPTION
## Summary

Seemed to be the cause of most pages' i18 text not being used.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
