### PR TITLE
Fixed errors from converting ROOT_REDIRECT to globalThis.

### DIFF
--- a/.env.local.default
+++ b/.env.local.default
@@ -34,6 +34,7 @@ FEATHERS_STORE_KEY=
 VITE_EMAILJS_SERVICE_ID=
 VITE_EMAILJS_TEMPLATE_ID=
 VITE_EMAILJS_USER_ID=
+VITE_ROOT_REDIRECT=false
 VITE_READY_PLAYER_ME_URL=https://xre.readyplayer.me
 # For Local use - 'https://authorization.localhost:33443'
 # For Production use - 'https://authn.io'

--- a/packages/client/src/pages/index.tsx
+++ b/packages/client/src/pages/index.tsx
@@ -6,7 +6,7 @@ import { useHistory, Redirect } from 'react-router-dom'
 import { useTranslation, Trans } from 'react-i18next'
 import { Config } from '@xrengine/common/src/config'
 
-const ROOT_REDIRECT: any = `https://${globalThis.process.env['VITE_ROOT_REDIRECT']}`
+const ROOT_REDIRECT: any = globalThis.process.env['VITE_ROOT_REDIRECT']
 
 export const HomePage = (): any => {
   console.log('homepage')
@@ -18,7 +18,7 @@ export const HomePage = (): any => {
   //   }
   // }, [])
 
-  if (ROOT_REDIRECT !== false && ROOT_REDIRECT !== 'false') {
+  if (ROOT_REDIRECT && ROOT_REDIRECT.length > 0 && ROOT_REDIRECT !== 'false') {
     const redirectParsed = new URL(ROOT_REDIRECT)
     if (redirectParsed.protocol == null) return <Redirect to={ROOT_REDIRECT} />
     else window.location.href = ROOT_REDIRECT

--- a/packages/editor/src/components/configs.ts
+++ b/packages/editor/src/components/configs.ts
@@ -12,7 +12,7 @@ const configs = {
   SERVER_URL: `https://${globalThis.process.env['VITE_SERVER_HOST']}`,
   APP_URL: `https://${globalThis.process.env['VITE_APP_HOST']}`,
   FEATHERS_STORE_KEY: `https://${globalThis.process.env['VITE_FEATHERS_STORE_KEY']}`,
-  ROOT_REDIRECT: `https://${globalThis.process.env['VITE_ROOT_REDIRECT']}`
+  ROOT_REDIRECT: globalThis.process.env['VITE_ROOT_REDIRECT']
 }
 
 export default configs


### PR DESCRIPTION
## Summary

Variable is either 'false' or the full URL, not just the domain. Added better checking
for ROOT_REDIRECT being undefined/null. Added default VITE_ROOT_REDIRECT=false to env.local.default.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
