### PR TITLE
Allow Physics Debug when canvas is in focus

### DIFF
--- a/packages/client/src/components/Debug/index.tsx
+++ b/packages/client/src/components/Debug/index.tsx
@@ -18,8 +18,10 @@ export const Debug = () => {
     console.log('setup keypress')
     window.addEventListener('keypress', (ev) => {
       if (ev.key === 'p') {
-        togglePhysicsDebug()
-        toggleAvatarDebug()
+        if (document.activeElement?.querySelector('canvas')) {
+          togglePhysicsDebug()
+          toggleAvatarDebug()
+        }
       }
     })
   }


### PR DESCRIPTION
## Summary

check if the canvas element exists in focus before allowing the debug toggle for physics and avatar


## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

[References to pertaining issue(s)](https://github.com/XRFoundation/XREngine/issues/4626)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField 
