### PR TITLE
Avatar locomotion smoothness

### DIFF
--- a/packages/engine/src/avatar/animations/AnimationGraph.ts
+++ b/packages/engine/src/avatar/animations/AnimationGraph.ts
@@ -167,10 +167,15 @@ export class AnimationGraph {
       vector2.set(movement.velocity.x, movement.velocity.z).multiplyScalar(1 / delta)
       const speedSqr = vector2.lengthSq()
       if (speedSqr > this.EPSILON) {
-        newStateName =
-          speedSqr < AvatarSettings.instance.walkSpeed * AvatarSettings.instance.walkSpeed
-            ? AvatarStates.WALK
-            : AvatarStates.RUN
+        // TODO: The transition between walk and run animations is not smooth
+        // Most probably because they're not in sync with each other and a very short transition time
+
+        // newStateName =
+        //   speedSqr < AvatarSettings.instance.walkSpeed * AvatarSettings.instance.walkSpeed
+        //     ? AvatarStates.WALK
+        //     : AvatarStates.RUN
+
+        newStateName = AvatarStates.RUN
       } else {
         newStateName = AvatarStates.IDLE
       }


### PR DESCRIPTION
## Summary

The transition between walk and run animations is not smooth.
Most probably because they're not in sync with each other and have a very short transition time.

Fixed the issue by temporarily removing the walk state.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField
