### PR TITLE
Fixes for identity-providers.

### DIFF
--- a/packages/server-core/src/user/identity-provider/identity-provider.class.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.class.ts
@@ -37,8 +37,25 @@ export class IdentityProvider extends Service {
    */
   async create(data: any, params: Params): Promise<any> {
     let { token, type, password } = data
+    let user
 
-    if (params.provider && type !== 'password' && type !== 'email' && type !== 'sms') type = 'guest' //Non-password/magiclink create requests must always be for guests
+    if (params.authentication) {
+      const authResult = await (this.app.service('authentication') as any).strategies.jwt.authenticate(
+        { accessToken: params.authentication.accessToken },
+        {}
+      )
+      if (authResult) {
+        user = await this.app.service('user').get(authResult['identity-provider'].userId)
+      }
+    }
+    if (
+      (!user || user.userRole !== 'admin') &&
+      params.provider &&
+      type !== 'password' &&
+      type !== 'email' &&
+      type !== 'sms'
+    )
+      type = 'guest' //Non-password/magiclink create requests must always be for guests
     let userId = data.userId
     let identityProvider: any
 
@@ -87,6 +104,12 @@ export class IdentityProvider extends Service {
         }
         break
       case 'linkedin':
+        identityProvider = {
+          token: token,
+          type
+        }
+        break
+      case 'discord':
         identityProvider = {
           token: token,
           type
@@ -142,19 +165,25 @@ export class IdentityProvider extends Service {
       }
     })
     const avatars = await this.app.service('avatar').find({ isInternal: true })
-    const result = await super.create(
-      {
-        ...data,
-        ...identityProvider,
-        user: {
-          id: userId,
-          userRole: type === 'guest' ? 'guest' : type === 'admin' || adminCount === 0 ? 'admin' : 'user',
-          inviteCode: type === 'guest' ? null : code,
-          avatarId: avatars[random(avatars.length - 1)].avatarId
-        }
-      },
-      params
-    )
+    let result
+    try {
+      result = await super.create(
+        {
+          ...data,
+          ...identityProvider,
+          user: {
+            id: userId,
+            userRole: type === 'guest' ? 'guest' : type === 'admin' || adminCount === 0 ? 'admin' : 'user',
+            inviteCode: type === 'guest' ? null : code,
+            avatarId: avatars[random(avatars.length - 1)].avatarId
+          }
+        },
+        params
+      )
+    } catch (err) {
+      await this.app.service('user').remove(userId)
+      throw err
+    }
     // DRC
     try {
       if (result.user.userRole !== 'guest') {

--- a/packages/server-core/src/user/identity-provider/identity-provider.model.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.model.ts
@@ -12,7 +12,7 @@ export default (app: Application) => {
         allowNull: false,
         primaryKey: true
       },
-      token: { type: DataTypes.STRING },
+      token: { type: DataTypes.STRING, unique: true },
       password: { type: DataTypes.STRING },
       isVerified: { type: DataTypes.BOOLEAN },
       verifyToken: { type: DataTypes.STRING },
@@ -24,7 +24,7 @@ export default (app: Application) => {
       type: {
         type: DataTypes.STRING,
         allowNull: false,
-        values: ['email', 'sms', 'password', 'github', 'google', 'facebook', 'twitter', 'linkedin', 'auth0']
+        values: ['email', 'sms', 'password', 'discord', 'github', 'google', 'facebook', 'twitter', 'linkedin', 'auth0']
       }
     },
     {


### PR DESCRIPTION
## Summary

Added 'discord' to identity-provider.create as a valid type.

Added ability for admins to create OAuth2 identity-providers.

Made identity-provider.token a unique field.

If identity-provider creation fails, it now removes the user that it created.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
