### PR TITLE
Added user-api-key service and refactored authentication.

### DIFF
--- a/packages/client-core/i18n/en/user.json
+++ b/packages/client-core/i18n/en/user.json
@@ -133,6 +133,8 @@
       "youAreA": "You are a",
       "showUserId": "Show User ID",
       "hideUserId": "Hide User ID",
+      "showApiKey": "Show API key",
+      "hideApiKey": "Hide API key",
       "logout": "Log out",
       "connectPhone": "Connect your phone number",
       "connectEmail": "Connect your email",

--- a/packages/client-core/src/user/components/UserMenu/UserMenu.module.scss
+++ b/packages/client-core/src/user/components/UserMenu/UserMenu.module.scss
@@ -7,6 +7,15 @@
     color: $PrimaryGreenColor;
 }
 
+.apiRefresh {
+    &:hover {
+        cursor: pointer;
+        color: white;
+        background-color: dimgray;
+        border-radius: 100px;
+    }
+}
+
 .settingContainer {
     position: fixed;
     bottom: 20px;

--- a/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
@@ -11,6 +11,7 @@ import Snackbar from '@mui/material/Snackbar'
 import TextField from '@mui/material/TextField'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
+import RefreshIcon from '@mui/icons-material/Refresh'
 import { validateEmail, validatePhoneNumber } from '@xrengine/common/src/config'
 import * as polyfill from 'credential-handler-polyfill'
 import React, { useEffect, useState } from 'react'
@@ -59,7 +60,9 @@ const ProfileMenu = (props: Props): any => {
   const [error, setError] = useState(false)
   const [errorUsername, setErrorUsername] = useState(false)
   const [showUserId, setShowUserId] = useState(false)
+  const [showApiKey, setShowApiKey] = useState(false)
   const [userIdState, setUserIdState] = useState({ value: '', copied: false, open: false })
+  const [apiKeyState, setApiKeyState] = useState({ value: '', copied: false, open: false })
   const authSettingState = useAdminAuthSettingState()
   const [authSetting] = authSettingState?.authSettings?.value || []
   const [authState, setAuthState] = useState(initialState)
@@ -151,6 +154,10 @@ const ProfileMenu = (props: Props): any => {
   const handleLogout = async (e) => {
     if (changeActiveMenu != null) changeActiveMenu(null)
     else if (setProfileMenuOpen != null) setProfileMenuOpen(false)
+    setShowUserId(false)
+    setShowApiKey(false)
+    setUserIdState({ ...userIdState, open: false })
+    setApiKeyState({ ...apiKeyState, open: false })
     await AuthService.logoutUser()
     // window.location.reload()
   }
@@ -187,8 +194,21 @@ const ProfileMenu = (props: Props): any => {
     setUserIdState({ ...userIdState, value: selfUser.id.value as string })
   }
 
-  const handleClose = () => {
+  const handleShowApiKey = () => {
+    setShowApiKey(!showApiKey)
+    setApiKeyState({ ...apiKeyState, value: selfUser.apiKey?.token?.value })
+  }
+
+  const handleCloseUserId = () => {
     setUserIdState({ ...userIdState, open: false })
+  }
+
+  const handleCloseApiKey = () => {
+    setApiKeyState({ ...apiKeyState, open: false })
+  }
+
+  const refreshApiKey = () => {
+    AuthService.updateApiKey()
   }
 
   const getConnectText = () => {
@@ -292,7 +312,7 @@ const ProfileMenu = (props: Props): any => {
             </span>
 
             <Grid container justifyContent="right">
-              <Grid item xs={6}>
+              <Grid item xs={selfUser.userRole?.value === 'guest' ? 6 : 4}>
                 <h2>
                   {selfUser?.userRole?.value === 'admin'
                     ? t('user:usermenu.profile.youAreAn')
@@ -300,13 +320,28 @@ const ProfileMenu = (props: Props): any => {
                   <span>{selfUser?.userRole?.value}</span>.
                 </h2>
               </Grid>
-              <Grid item container xs={6} alignItems="flex-start" direction="column">
+              <Grid
+                item
+                container
+                xs={selfUser.userRole?.value === 'guest' ? 6 : 4}
+                alignItems="flex-start"
+                direction="column"
+              >
                 <Tooltip title="Show User ID" placement="right">
                   <h2 className={styles.showUserId} onClick={handleShowId}>
                     {showUserId ? t('user:usermenu.profile.hideUserId') : t('user:usermenu.profile.showUserId')}{' '}
                   </h2>
                 </Tooltip>
               </Grid>
+              {selfUser?.apiKey?.id && (
+                <Grid item container xs={4} alignItems="flex-start" direction="column">
+                  <Tooltip title="Show API key" placement="right">
+                    <h2 className={styles.showUserId} onClick={handleShowApiKey}>
+                      {showApiKey ? t('user:usermenu.profile.hideApiKey') : t('user:usermenu.profile.showApiKey')}{' '}
+                    </h2>
+                  </Tooltip>
+                </Grid>
+              )}
             </Grid>
             {selfUser?.userRole.value !== 'guest' && (
               <Grid
@@ -400,6 +435,46 @@ const ProfileMenu = (props: Props): any => {
                         text={userIdState.value}
                         onCopy={() => {
                           setUserIdState({ ...userIdState, copied: true, open: true })
+                        }}
+                      >
+                        <a href="#" className={styles.materialIconBlock}>
+                          <ContentCopyIcon className={styles.primaryForeground} />
+                        </a>
+                      </CopyToClipboard>
+                    </InputAdornment>
+                  )
+                }}
+              />
+            </form>
+          </section>
+        )}
+
+        {showApiKey && (
+          <section className={styles.emailPhoneSection}>
+            <Typography variant="h1" className={styles.panelHeader}>
+              API key
+            </Typography>
+
+            <form>
+              <TextField
+                className={styles.emailField}
+                size="small"
+                placeholder={'API key'}
+                variant="outlined"
+                value={selfUser?.apiKey?.token?.value}
+                onChange={({ target: { value } }) => setApiKeyState({ ...apiKeyState, value, copied: false })}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <RefreshIcon className={styles.apiRefresh} onClick={refreshApiKey} />
+                    </InputAdornment>
+                  ),
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <CopyToClipboard
+                        text={apiKeyState.value}
+                        onCopy={() => {
+                          setApiKeyState({ ...apiKeyState, copied: true, open: true })
                         }}
                       >
                         <a href="#" className={styles.materialIconBlock}>
@@ -514,9 +589,18 @@ const ProfileMenu = (props: Props): any => {
       <Snackbar
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         open={userIdState.open}
-        onClose={handleClose}
+        onClose={handleCloseUserId}
         message="User ID copied"
         key={'top' + 'center'}
+        autoHideDuration={2000}
+      />
+
+      <Snackbar
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        open={apiKeyState.open}
+        onClose={handleCloseApiKey}
+        message="API Key copied"
+        key={'bottom' + 'center'}
         autoHideDuration={2000}
       />
     </div>

--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -5,6 +5,7 @@ import { AvatarInterface } from '@xrengine/common/src/interfaces/AvatarInterface
 import { IdentityProvider, IdentityProviderSeed } from '@xrengine/common/src/interfaces/IdentityProvider'
 import { AssetUploadType } from '@xrengine/common/src/interfaces/UploadAssetInterface'
 import { resolveUser, resolveWalletUser, User, UserSeed, UserSetting } from '@xrengine/common/src/interfaces/User'
+import { UserApiKey } from '@xrengine/common/src/interfaces/UserApiKey'
 import { UserAvatar } from '@xrengine/common/src/interfaces/UserAvatar'
 import { isDev } from '@xrengine/common/src/utils/isDev'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
@@ -105,6 +106,9 @@ store.receptors.push((action: AuthActionType | StoredLocalActionType): void => {
       }
       case 'USERNAME_UPDATED': {
         return s.user.merge({ name: action.name })
+      }
+      case 'USER_API_KEY_UPDATED': {
+        return s.user.merge({ apiKey: action.apiKey })
       }
       case 'USERAVATARID_UPDATED': {
         return s.user.merge({ avatarId: action.avatarId })
@@ -625,7 +629,10 @@ export const AuthService = {
         .finally(() => dispatch(AuthAction.actionProcessing(false)))
     }
   },
-  addConnectionByOauth: async (oauth: 'facebook' | 'google' | 'github' | 'linkedin' | 'twitter', userId: string) => {
+  addConnectionByOauth: async (
+    oauth: 'facebook' | 'google' | 'github' | 'linkedin' | 'twitter' | 'discord',
+    userId: string
+  ) => {
     const dispatch = useDispatch()
     {
       window.open(
@@ -799,6 +806,12 @@ export const AuthService = {
       })
       AuthService.logoutUser()
     }
+  },
+
+  updateApiKey: async () => {
+    const dispatch = useDispatch()
+    const apiKey = await client.service('user-api-key').patch()
+    dispatch(AuthAction.apiKeyUpdated(apiKey))
   }
 }
 
@@ -996,6 +1009,12 @@ export const AuthAction = {
     return {
       type: 'AVATAR_FETCHED' as const,
       avatarList
+    }
+  },
+  apiKeyUpdated: (apiKey: UserApiKey) => {
+    return {
+      type: 'USER_API_KEY_UPDATED' as const,
+      apiKey: apiKey
     }
   }
 }

--- a/packages/common/src/interfaces/User.ts
+++ b/packages/common/src/interfaces/User.ts
@@ -4,6 +4,7 @@ import { LocationBan } from './LocationBan'
 import { Party } from './Party'
 import { UserId } from './UserId'
 import { RelationshipType } from './UserRelationship'
+import { UserApiKey } from './UserApiKey'
 
 export interface UserSetting {
   id: string
@@ -35,6 +36,7 @@ export interface User {
   inviteCode?: string
   party?: Party
   scopes?: UserScope[]
+  apiKey: UserApiKey
 }
 
 export const UserSeed: User = {
@@ -42,6 +44,11 @@ export const UserSeed: User = {
   name: '',
   userRole: '',
   avatarId: '',
+  apiKey: {
+    id: '',
+    token: '',
+    userId: '' as UserId
+  },
   identityProviders: [],
   locationAdmins: []
 }
@@ -66,6 +73,12 @@ export function resolveUser(user: any): User {
       locationBans: user.location_bans
     }
   }
+  if (user?.user_api_key && user.user_api_key.id) {
+    returned = {
+      ...returned,
+      apiKey: user.user_api_key
+    }
+  }
 
   // console.log('Returned user:')
   // console.log(returned)
@@ -81,7 +94,8 @@ export function resolveWalletUser(credentials: any): User {
     avatarId: credentials.user.id,
     identityProviders: [],
     locationAdmins: [],
-    avatarUrl: credentials.user.icon
+    avatarUrl: credentials.user.icon,
+    apiKey: credentials.user.apiKey || { id: '', token: '', userId: '' as UserId }
   }
 
   return returned

--- a/packages/common/src/interfaces/UserApiKey.ts
+++ b/packages/common/src/interfaces/UserApiKey.ts
@@ -1,0 +1,7 @@
+import { UserId } from './UserId'
+
+export interface UserApiKey {
+  id: string
+  token: string
+  userId: UserId
+}

--- a/packages/server-core/src/analytics/analytics/analytics.hooks.ts
+++ b/packages/server-core/src/analytics/analytics/analytics.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '../../hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/hooks/authenticate.ts
+++ b/packages/server-core/src/hooks/authenticate.ts
@@ -1,0 +1,43 @@
+import { HookContext } from '@feathersjs/feathers'
+import * as authentication from '@feathersjs/authentication'
+import config from '../appconfig'
+
+const { authenticate } = authentication.hooks
+
+export default () => {
+  return async (context: HookContext): Promise<HookContext> => {
+    const { params } = context
+    if (!context.params) context.params = {}
+    const authHeader = params.headers?.authorization
+    let authSplit
+    if (authHeader) authSplit = authHeader.split(' ')
+    let token, user
+    if (authSplit) token = authSplit[1]
+    if (token) {
+      const key = await (context.app.service('user-api-key') as any).Model.findOne({
+        where: {
+          token: token
+        }
+      })
+      if (key != null)
+        user = await (context.app.service('user') as any).Model.findOne({
+          where: {
+            id: key.userId
+          }
+        })
+    }
+    if (user) {
+      context.params.user = user
+      return context
+    }
+    context = await authenticate('jwt')(context as any)
+    context.params.user = context.params[config.authentication.entity]
+      ? await (context.app.service('user') as any).Model.findOne({
+          where: {
+            id: context.params[config.authentication.entity].userId
+          }
+        })
+      : {}
+    return context
+  }
+}

--- a/packages/server-core/src/hooks/channel-permission-authenticate.ts
+++ b/packages/server-core/src/hooks/channel-permission-authenticate.ts
@@ -8,7 +8,7 @@ export default () => {
     const { params, app } = context
     console.log(params.query)
     const loggedInUser = extractLoggedInUserFromParams(params)
-    const userId = loggedInUser.userId
+    const userId = loggedInUser.id
     if (!params.query!.channelId) {
       throw new BadRequest('Must provide a channel ID')
     }

--- a/packages/server-core/src/hooks/create-group-owner.ts
+++ b/packages/server-core/src/hooks/create-group-owner.ts
@@ -10,7 +10,7 @@ export default () => {
     await context.app.service('group-user').create({
       groupId: result.id,
       groupUserRank: 'owner',
-      userId: loggedInUser.userId
+      userId: loggedInUser.id
     })
     return context
   }

--- a/packages/server-core/src/hooks/create-party-owner.ts
+++ b/packages/server-core/src/hooks/create-party-owner.ts
@@ -7,8 +7,7 @@ export default () => {
     // Getting logged in user and attaching owner of user
     const { result } = context
 
-    const loggedInUser = extractLoggedInUserFromParams(context.params)
-    const user = await context.app.service('user').get(loggedInUser.userId)
+    const user = extractLoggedInUserFromParams(context.params)
     const ownerUser =
       user.location_admins.length > 0
         ? user.location_admins.find((locationAdmin) => locationAdmin.locationId === result.locationId) != null
@@ -18,17 +17,17 @@ export default () => {
         {
           partyId: result.id,
           isOwner: result.locationId ? ownerUser : true,
-          userId: loggedInUser.userId
+          userId: user.id
         },
         context.params
       )
     } catch (error) {
       console.error(error)
     }
-    await context.app.service('user').patch(loggedInUser.userId, {
+    await context.app.service('user').patch(user.id, {
       partyId: result.id
     })
-    const owner = await context.app.service('user').get(loggedInUser.userId)
+    const owner = await context.app.service('user').get(user.id)
     if (owner.instanceId != null) {
       await context.app.service('party').patch(result.id, { instanceId: owner.instanceId }, context.params)
     }

--- a/packages/server-core/src/hooks/group-permission-authenticate.ts
+++ b/packages/server-core/src/hooks/group-permission-authenticate.ts
@@ -15,7 +15,7 @@ export default () => {
     const groupId =
       path === 'group-user' && method === 'find' ? params.query!.groupId : fetchedGroupId != null ? fetchedGroupId : id
     params.query!.groupId = groupId
-    const userId = path === 'group' ? loggedInUser.userId : params.query!.userId || loggedInUser.userId
+    const userId = path === 'group' ? loggedInUser.id : params.query!.userId || loggedInUser.id
     const groupUserCountResult = await app.service('group-user').find({
       query: {
         groupId: groupId,
@@ -37,7 +37,7 @@ export default () => {
         params.groupUsersRemoved !== true &&
         groupUser.groupUserRank !== 'owner' &&
         groupUser.groupUserRank !== 'admin' &&
-        groupUser.userId !== loggedInUser.userId
+        groupUser.userId !== loggedInUser.id
       ) {
         throw new Forbidden('You must be the owner or an admin of this group to perform that action')
       }

--- a/packages/server-core/src/hooks/group-user-permission-authenticate.ts
+++ b/packages/server-core/src/hooks/group-user-permission-authenticate.ts
@@ -9,7 +9,7 @@ export default () => {
     const { params, app } = context
     const loggedInUser = extractLoggedInUserFromParams(params)
     const groupId = params.query!.groupId
-    const userId = params.query!.userId || loggedInUser.userId
+    const userId = params.query!.userId || loggedInUser.id
     const paramsClone = _.cloneDeep(context.params)
     paramsClone.provider = null!
     if (params.groupUsersRemoved !== true) {

--- a/packages/server-core/src/hooks/invite-remove-authenticate.ts
+++ b/packages/server-core/src/hooks/invite-remove-authenticate.ts
@@ -25,9 +25,9 @@ export default () => {
       }
     }
     if (
-      invite.userId !== loggedInUser?.userId &&
-      invite.inviteeId !== loggedInUser?.userId &&
-      inviteIdentityProviderUser !== loggedInUser?.userId
+      invite.userId !== loggedInUser?.id &&
+      invite.inviteeId !== loggedInUser?.id &&
+      inviteIdentityProviderUser !== loggedInUser?.id
     ) {
       throw new BadRequest('Not the sender or recipient of this invite')
     }

--- a/packages/server-core/src/hooks/matchmaking-restrict-multiple-queueing.ts
+++ b/packages/server-core/src/hooks/matchmaking-restrict-multiple-queueing.ts
@@ -11,7 +11,7 @@ export default (): Hook => {
     const loggedInUser = extractLoggedInUserFromParams(context.params)
     const matchUserResult = await app.service('match-user').find({
       query: {
-        userId: loggedInUser.userId,
+        userId: loggedInUser.id,
         $limit: 1
       }
     })

--- a/packages/server-core/src/hooks/matchmaking-save-ticket.ts
+++ b/packages/server-core/src/hooks/matchmaking-save-ticket.ts
@@ -9,7 +9,7 @@ export default (): Hook => {
     await app.service('match-user').create({
       ticketId: result.id,
       gamemode: data.gamemode,
-      userId: loggedInUser.userId
+      userId: loggedInUser.id
     })
 
     return context

--- a/packages/server-core/src/hooks/message-permission-authenticate.ts
+++ b/packages/server-core/src/hooks/message-permission-authenticate.ts
@@ -11,7 +11,7 @@ export default () => {
       const match = await (app.service('message') as any).Model.findOne({
         where: {
           id: id,
-          senderId: loggedInUser.userId
+          senderId: loggedInUser.id
         }
       })
 

--- a/packages/server-core/src/hooks/party-permission-authenticate.ts
+++ b/packages/server-core/src/hooks/party-permission-authenticate.ts
@@ -26,7 +26,7 @@ export default () => {
         if (params.query == null) params.query = {}
         params.query.partyId = partyId
       }
-      const userId = path === 'party' ? loggedInUser?.userId : params.query?.userId || loggedInUser?.userId || partyId
+      const userId = path === 'party' ? loggedInUser?.id : params.query?.userId || loggedInUser?.id || partyId
       const paramsCopy = _.cloneDeep(params)
       const partyResult = await app.service('party').find(paramsCopy.query)
       const party = partyResult.data[0]
@@ -36,7 +36,7 @@ export default () => {
         if (isAdmin != null) {
           data.isOwner = 1
         }
-        await app.service('user').patch(loggedInUser.userId, {
+        await app.service('user').patch(loggedInUser.id, {
           partyId: data.partyId
         })
       } else {
@@ -62,7 +62,7 @@ export default () => {
               params.partyUsersRemoved !== true &&
               partyUser.isOwner !== true &&
               partyUser.isOwner !== 1 &&
-              partyUser.userId !== loggedInUser.userId
+              partyUser.userId !== loggedInUser.id
             ) {
               throw new Forbidden('You must be the owner of this party to perform that action')
             }

--- a/packages/server-core/src/hooks/party-user-permission-authenticate.ts
+++ b/packages/server-core/src/hooks/party-user-permission-authenticate.ts
@@ -9,7 +9,7 @@ export default () => {
     const { params, app } = context
     const loggedInUser = extractLoggedInUserFromParams(params)
     const partyId = params.query!.partyId
-    const userId = params.query!.userId || loggedInUser.userId
+    const userId = params.query!.userId || loggedInUser.id
     const paramsClone = _.cloneDeep(context.params)
     paramsClone.provider = null!
     if (params.partyUsersRemoved !== true) {

--- a/packages/server-core/src/hooks/restrict-user-role.ts
+++ b/packages/server-core/src/hooks/restrict-user-role.ts
@@ -1,4 +1,5 @@
 import { HookContext } from '@feathersjs/feathers'
+import { extractLoggedInUserFromParams } from '../user/auth-management/auth-management.utils'
 import config from '../appconfig'
 
 // Get the logged in user entity
@@ -10,9 +11,8 @@ export default (userRole: string) => {
     // console.log('restrict user role', context.params)
     if (context.params.isInternal) return context
     // Getting logged in user and attaching owner of user
-    const loggedInUser = context.params[loggedInUserEntity]
-    const user = await context.app.service('user').get(loggedInUser.userId)
-    if (user.userRole !== userRole) {
+    const loggedInUser = extractLoggedInUserFromParams(context.params)
+    if (loggedInUser.userRole !== userRole) {
       throw new Error(`Must be ${userRole} to access this function`)
     }
 

--- a/packages/server-core/src/hooks/send-invite.ts
+++ b/packages/server-core/src/hooks/send-invite.ts
@@ -90,7 +90,6 @@ export default () => {
       const { app, result, params } = context
 
       let token = ''
-      let identityProvider
       if (result.identityProviderType === 'email' || result.identityProviderType === 'sms') {
         token = result.token
       } else {
@@ -99,8 +98,7 @@ export default () => {
       const inviteType = result.inviteType
       const targetObjectId = result.targetObjectId
 
-      const authProvider = extractLoggedInUserFromParams(params)
-      const authUser = await app.service('user').get(authProvider.userId)
+      const authUser = extractLoggedInUserFromParams(params)
 
       if (result.identityProviderType === 'email') {
         await generateEmail(app, result, token, inviteType, authUser.name, targetObjectId)

--- a/packages/server-core/src/hooks/set-loggedin-user-in-body.ts
+++ b/packages/server-core/src/hooks/set-loggedin-user-in-body.ts
@@ -11,17 +11,17 @@ export default (propertyName: string) => {
       context.data = context.data.map((item: any) => {
         return {
           ...item,
-          [propertyName]: loggedInUser.userId
+          [propertyName]: loggedInUser.id
         }
       })
     } else {
       context.data = {
         ...context.data,
-        [propertyName]: loggedInUser.userId
+        [propertyName]: loggedInUser.id
       }
       context.params.body = {
         ...context.params.body,
-        [propertyName]: loggedInUser.userId
+        [propertyName]: loggedInUser.id
       }
     }
 

--- a/packages/server-core/src/hooks/set-loggedin-user-in-query.ts
+++ b/packages/server-core/src/hooks/set-loggedin-user-in-query.ts
@@ -9,7 +9,7 @@ export default (propertyName: string) => {
     const loggedInUser = extractLoggedInUserFromParams(context.params)
     context.params.query = {
       ...context.params.query,
-      [propertyName]: loggedInUser?.userId || null
+      [propertyName]: loggedInUser?.id || null
     }
 
     return context

--- a/packages/server-core/src/hooks/unset-self-party-owner.ts
+++ b/packages/server-core/src/hooks/unset-self-party-owner.ts
@@ -7,8 +7,8 @@ export default () => {
     // Getting logged in user and attaching owner of user
     const { result } = context
     const loggedInUser = extractLoggedInUserFromParams(context.params)
-    if (loggedInUser?.userId != null) {
-      const user = await context.app.service('user').get(loggedInUser.userId)
+    if (loggedInUser?.id != null) {
+      const user = await context.app.service('user').get(loggedInUser.id)
       if (user.partyId) {
         const partyOwnerResult = await context.app.service('party-user').find({
           query: {

--- a/packages/server-core/src/hooks/verify-scope.ts
+++ b/packages/server-core/src/hooks/verify-scope.ts
@@ -7,11 +7,11 @@ export default (currentType: string, scopeToVerify: string) => {
     if (context.params.isInternal) return context
     const loggedInUser = extractLoggedInUserFromParams(context.params)
     if (!loggedInUser) throw new UnauthenticatedException('No logged in user')
-    const user = await context.app.service('user').get(loggedInUser.userId)
+    const user = await context.app.service('user').get(loggedInUser.id)
     if (user.userRole === 'admin') return context
     const scopes = await (context.app.service('scope') as any).Model.findAll({
       where: {
-        userId: loggedInUser.userId
+        userId: loggedInUser.id
       },
       raw: true,
       nest: true

--- a/packages/server-core/src/matchmaking/match-ticket/match-ticket.hooks.ts
+++ b/packages/server-core/src/matchmaking/match-ticket/match-ticket.hooks.ts
@@ -1,4 +1,4 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import setLoggedInUser from '@xrengine/server-core/src/hooks/set-loggedin-user-in-body'
 import matchmakingRestrictMultipleQueueing from '@xrengine/server-core/src/hooks/matchmaking-restrict-multiple-queueing'
 import matchmakingSaveTicket from '@xrengine/server-core/src/hooks/matchmaking-save-ticket'
@@ -7,15 +7,13 @@ import matchmakingRemoveTicket from '@xrengine/server-core/src/hooks/matchmaking
 
 // Don't remove this comment. It's needed to format import lines nicely.
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
     all: [],
     find: [],
-    get: [iff(isProvider('external'), authenticate('jwt') as any, setLoggedInUser('userId') as any)],
+    get: [iff(isProvider('external'), authenticate() as any, setLoggedInUser('userId') as any)],
     create: [
-      iff(isProvider('external'), authenticate('jwt') as any, setLoggedInUser('userId') as any),
+      iff(isProvider('external'), authenticate() as any, setLoggedInUser('userId') as any),
       matchmakingRestrictMultipleQueueing()
       // addUUID()
     ],

--- a/packages/server-core/src/matchmaking/match-user/match-user.hooks.ts
+++ b/packages/server-core/src/matchmaking/match-user/match-user.hooks.ts
@@ -1,18 +1,16 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import setLoggedInUser from '@xrengine/server-core/src/hooks/set-loggedin-user-in-body'
 import setLoggedInUserInQuery from '@xrengine/server-core/src/hooks/set-loggedin-user-in-query'
 import { iff, isProvider } from 'feathers-hooks-common'
-
-const { authenticate } = authentication.hooks
 
 // Don't remove this comment. It's needed to format import lines nicely.
 
 export default {
   before: {
-    all: [authenticate('jwt')],
-    find: [iff(isProvider('external'), authenticate('jwt') as any, setLoggedInUserInQuery('userId') as any)],
+    all: [authenticate()],
+    find: [iff(isProvider('external'), authenticate() as any, setLoggedInUserInQuery('userId') as any)],
     get: [],
-    create: [iff(isProvider('external'), authenticate('jwt') as any, setLoggedInUser('userId') as any)],
+    create: [iff(isProvider('external'), authenticate() as any, setLoggedInUser('userId') as any)],
     update: [],
     patch: [],
     remove: []

--- a/packages/server-core/src/media/static-resource/static-resource.hooks.ts
+++ b/packages/server-core/src/media/static-resource/static-resource.hooks.ts
@@ -1,12 +1,10 @@
 import { HookContext } from '@feathersjs/feathers'
-import { hooks } from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import dauria from 'dauria'
 import replaceThumbnailLink from '@xrengine/server-core/src/hooks/replace-thumbnail-link'
 import attachOwnerIdInQuery from '@xrengine/server-core/src/hooks/set-loggedin-user-in-query'
 import collectAnalytics from '@xrengine/server-core/src/hooks/collect-analytics'
 import restrictUserRole from '../../hooks/restrict-user-role'
-
-const { authenticate } = hooks
 
 export default {
   before: {
@@ -14,7 +12,7 @@ export default {
     find: [collectAnalytics()],
     get: [],
     create: [
-      authenticate('jwt'),
+      authenticate(),
       restrictUserRole('admin'),
       (context: HookContext): HookContext => {
         if (!context.data.uri && context.params.file) {
@@ -30,9 +28,9 @@ export default {
         return context
       }
     ],
-    update: [authenticate('jwt'), restrictUserRole('admin')],
-    patch: [authenticate('jwt'), restrictUserRole('admin'), replaceThumbnailLink()],
-    remove: [authenticate('jwt'), restrictUserRole('admin'), attachOwnerIdInQuery('userId')]
+    update: [authenticate(), restrictUserRole('admin')],
+    patch: [authenticate(), restrictUserRole('admin'), replaceThumbnailLink()],
+    remove: [authenticate(), restrictUserRole('admin'), attachOwnerIdInQuery('userId')]
   },
 
   after: {

--- a/packages/server-core/src/media/upload-media/upload-asset.hooks.ts
+++ b/packages/server-core/src/media/upload-media/upload-asset.hooks.ts
@@ -1,4 +1,4 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import { disallow } from 'feathers-hooks-common'
 import attachOwnerIdInSavingContact from '@xrengine/server-core/src/hooks/set-loggedin-user-in-body'
 import addUriToFile from '@xrengine/server-core/src/hooks/add-uri-to-file'
@@ -6,14 +6,12 @@ import logRequest from '@xrengine/server-core/src/hooks/log-request'
 
 // Don't remove this comment. It's needed to format import lines nicely.
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
     all: [logRequest()],
     find: [disallow()],
     get: [],
-    create: [authenticate('jwt'), attachOwnerIdInSavingContact('userId'), addUriToFile()],
+    create: [authenticate(), attachOwnerIdInSavingContact('userId'), addUriToFile()],
     update: [disallow()],
     patch: [disallow()],
     remove: [disallow()]

--- a/packages/server-core/src/media/upload-media/upload-media.hooks.ts
+++ b/packages/server-core/src/media/upload-media/upload-media.hooks.ts
@@ -1,4 +1,4 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import { disallow } from 'feathers-hooks-common'
 import { SYNC } from 'feathers-sync'
 
@@ -11,14 +11,12 @@ import setResponseStatus from '@xrengine/server-core/src/hooks/set-response-stat
 
 // Don't remove this comment. It's needed to format import lines nicely.
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
     all: [logRequest()],
     find: [disallow()],
     get: [],
-    create: [authenticate('jwt'), attachOwnerIdInSavingContact('userId'), addUriToFile(), makeS3FilesPublic()],
+    create: [authenticate(), attachOwnerIdInSavingContact('userId'), addUriToFile(), makeS3FilesPublic()],
     update: [disallow()],
     patch: [disallow()],
     remove: [disallow()]

--- a/packages/server-core/src/networking/gameserver-subdomain-provision/gameserver-subdomain-provision.hooks.ts
+++ b/packages/server-core/src/networking/gameserver-subdomain-provision/gameserver-subdomain-provision.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '../../hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/networking/instance-attendance/instance-attendance.hooks.ts
+++ b/packages/server-core/src/networking/instance-attendance/instance-attendance.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/networking/instance-provision/instance-provision.hooks.ts
+++ b/packages/server-core/src/networking/instance-provision/instance-provision.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '../../hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [],
     get: [iff(isProvider('external'), restrictUserRole('admin') as any)],
     create: [iff(isProvider('external'), restrictUserRole('admin') as any)],

--- a/packages/server-core/src/networking/instance/instance.hooks.ts
+++ b/packages/server-core/src/networking/instance/instance.hooks.ts
@@ -1,13 +1,11 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import addAssociations from '@xrengine/server-core/src/hooks/add-associations'
 import restrictUserRole from '../../hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [
       addAssociations({
         models: [

--- a/packages/server-core/src/payments/seat/seat.hooks.ts
+++ b/packages/server-core/src/payments/seat/seat.hooks.ts
@@ -1,14 +1,12 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import { HookContext } from '@feathersjs/feathers'
 import { BadRequest, NotFound } from '@feathersjs/errors'
 import { iff, isProvider } from 'feathers-hooks-common'
 // Don't remove this comment. It's needed to format import lines nicely.
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [
       iff(isProvider('external'), (async (context: HookContext): Promise<any> => {
         const { app, params } = context

--- a/packages/server-core/src/payments/subscription/subscription.hooks.ts
+++ b/packages/server-core/src/payments/subscription/subscription.hooks.ts
@@ -1,16 +1,14 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import { disallow } from 'feathers-hooks-common'
 import setLoggedInUser from '@xrengine/server-core/src/hooks/set-loggedin-user-in-body'
 // Don't remove this comment. It's needed to format import lines nicely.
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
     all: [],
-    find: [authenticate('jwt')],
-    get: [authenticate('jwt')],
-    create: [authenticate('jwt'), setLoggedInUser('userId')],
+    find: [authenticate()],
+    get: [authenticate()],
+    create: [authenticate(), setLoggedInUser('userId')],
     update: [disallow('external')],
     patch: [disallow('external')],
     remove: [disallow('external')]

--- a/packages/server-core/src/projects/githubapp/githubapp.hooks.ts
+++ b/packages/server-core/src/projects/githubapp/githubapp.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '../../hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/projects/project/project.hooks.ts
+++ b/packages/server-core/src/projects/project/project.hooks.ts
@@ -1,18 +1,16 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import verifyScope from '../../hooks/verify-scope'
 import { iff, isProvider } from 'feathers-hooks-common'
-
-const { authenticate } = authentication.hooks
 
 export default {
   before: {
     all: [],
     find: [],
     get: [],
-    create: [authenticate('jwt'), iff(isProvider('external'), verifyScope('editor', 'write') as any)],
-    update: [authenticate('jwt'), iff(isProvider('external'), verifyScope('editor', 'write') as any)],
-    patch: [authenticate('jwt'), iff(isProvider('external'), verifyScope('editor', 'write') as any)],
-    remove: [authenticate('jwt'), iff(isProvider('external'), verifyScope('editor', 'write') as any)]
+    create: [authenticate(), iff(isProvider('external'), verifyScope('editor', 'write') as any)],
+    update: [authenticate(), iff(isProvider('external'), verifyScope('editor', 'write') as any)],
+    patch: [authenticate(), iff(isProvider('external'), verifyScope('editor', 'write') as any)],
+    remove: [authenticate(), iff(isProvider('external'), verifyScope('editor', 'write') as any)]
   },
 
   after: {

--- a/packages/server-core/src/projects/project/project.service.ts
+++ b/packages/server-core/src/projects/project/project.service.ts
@@ -5,9 +5,7 @@ import createModel from './project.model'
 import projectDocs from './project.docs'
 import { retriggerBuilderService } from './project-helper'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
-import * as authentication from '@feathersjs/authentication'
-
-const { authenticate } = authentication.hooks
+import authenticate from '../../hooks/authenticate'
 
 declare module '../../../declarations' {
   interface ServiceTypes {
@@ -40,7 +38,7 @@ export default (app: Application): void => {
 
   app.service('project-build').hooks({
     before: {
-      patch: [authenticate('jwt'), restrictUserRole('admin')]
+      patch: [authenticate(), restrictUserRole('admin')]
     }
   })
 

--- a/packages/server-core/src/projects/scene/scene.hooks.ts
+++ b/packages/server-core/src/projects/scene/scene.hooks.ts
@@ -1,18 +1,16 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import setResponseStatusCode from '@xrengine/server-core/src/hooks/set-response-status-code'
 import verifyScope from '../../hooks/verify-scope'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [],
     get: [],
-    create: [authenticate('jwt'), verifyScope('editor', 'write')],
-    update: [authenticate('jwt'), verifyScope('editor', 'write')],
-    patch: [authenticate('jwt'), verifyScope('editor', 'write')],
-    remove: [authenticate('jwt'), verifyScope('editor', 'write')]
+    create: [authenticate(), verifyScope('editor', 'write')],
+    update: [authenticate(), verifyScope('editor', 'write')],
+    patch: [authenticate(), verifyScope('editor', 'write')],
+    remove: [authenticate(), verifyScope('editor', 'write')]
   },
 
   after: {

--- a/packages/server-core/src/route/route/route.hooks.ts
+++ b/packages/server-core/src/route/route/route.hooks.ts
@@ -1,18 +1,16 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '../../hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
-
-const { authenticate } = authentication.hooks
 
 export default {
   before: {
     all: [],
     find: [],
     get: [],
-    create: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    update: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    patch: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    remove: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)]
+    create: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    update: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    patch: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    remove: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)]
   },
 
   after: {

--- a/packages/server-core/src/scope/scope-type/scope-type.hooks.ts
+++ b/packages/server-core/src/scope/scope-type/scope-type.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/scope/scope/scope.hooks.ts
+++ b/packages/server-core/src/scope/scope/scope.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '../../hooks/restrict-user-role'
 import { iff, isProvider, disallow } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/setting/analytics-setting/analytics.hooks.ts
+++ b/packages/server-core/src/setting/analytics-setting/analytics.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/setting/authentication-setting/authentication.class.ts
+++ b/packages/server-core/src/setting/authentication-setting/authentication.class.ts
@@ -14,9 +14,8 @@ export class Authentication extends Service {
   async find(params: Params): Promise<any> {
     const auth = (await super.find()) as any
     const loggedInUser = extractLoggedInUserFromParams(params)
-    const user = await this.app.service('user').get(loggedInUser.userId)
     const data = auth.data.map((el) => {
-      if (user.userRole !== 'admin')
+      if (loggedInUser.userRole !== 'admin')
         return {
           id: el.id,
           entity: el.entity,

--- a/packages/server-core/src/setting/authentication-setting/authentication.hooks.ts
+++ b/packages/server-core/src/setting/authentication-setting/authentication.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [],
     get: [iff(isProvider('external'), restrictUserRole('admin') as any)],
     create: [iff(isProvider('external'), restrictUserRole('admin') as any)],

--- a/packages/server-core/src/setting/aws-setting/aws-setting.hooks.ts
+++ b/packages/server-core/src/setting/aws-setting/aws-setting.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/setting/chargebee-setting/chargebee-setting.hooks.ts
+++ b/packages/server-core/src/setting/chargebee-setting/chargebee-setting.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/setting/client-setting/client-setting.hooks.ts
+++ b/packages/server-core/src/setting/client-setting/client-setting.hooks.ts
@@ -1,18 +1,16 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
-
-const { authenticate } = authentication.hooks
 
 export default {
   before: {
     all: [],
     find: [],
     get: [],
-    create: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    update: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    patch: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    remove: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)]
+    create: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    update: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    patch: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    remove: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)]
   },
 
   after: {

--- a/packages/server-core/src/setting/email-setting/email-setting.hooks.ts
+++ b/packages/server-core/src/setting/email-setting/email-setting.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/setting/game-server-setting/game-server-setting.hooks.ts
+++ b/packages/server-core/src/setting/game-server-setting/game-server-setting.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/setting/redis-setting/redis-setting.hooks.ts
+++ b/packages/server-core/src/setting/redis-setting/redis-setting.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/setting/server-setting/server-setting.hooks.ts
+++ b/packages/server-core/src/setting/server-setting/server-setting.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 import { iff, isProvider } from 'feathers-hooks-common'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt'), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/social/channel/channel.class.ts
+++ b/packages/server-core/src/social/channel/channel.class.ts
@@ -27,7 +27,7 @@ export class Channel extends Service {
     const skip = query?.skip || 0
     const limit = query?.limit || 10
     const loggedInUser = extractLoggedInUserFromParams(params)
-    const userId = loggedInUser.userId
+    const userId = loggedInUser.id
     const Model = (this.app.service('channel') as any).Model
     try {
       const subParams = {

--- a/packages/server-core/src/social/channel/channel.hooks.ts
+++ b/packages/server-core/src/social/channel/channel.hooks.ts
@@ -1,4 +1,4 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import { disallow } from 'feathers-hooks-common'
 import addAssociations from '@xrengine/server-core/src/hooks/add-associations'
 
@@ -7,11 +7,9 @@ import addAssociations from '@xrengine/server-core/src/hooks/add-associations'
  *
  */
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [
       addAssociations({
         models: [

--- a/packages/server-core/src/social/group-user-rank/group-user-rank.hooks.ts
+++ b/packages/server-core/src/social/group-user-rank/group-user-rank.hooks.ts
@@ -1,11 +1,9 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import { disallow } from 'feathers-hooks-common'
-
-const { authenticate } = authentication.hooks
 
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/social/group-user/group-user.hooks.ts
+++ b/packages/server-core/src/social/group-user/group-user.hooks.ts
@@ -1,15 +1,13 @@
 import groupPermissionAuthenticate from '@xrengine/server-core/src/hooks/group-permission-authenticate'
 import groupUserPermissionAuthenticate from '@xrengine/server-core/src/hooks/group-user-permission-authenticate'
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import { isProvider, iff } from 'feathers-hooks-common'
 import { HookContext } from '@feathersjs/feathers'
 import restrictUserRole from '../../hooks/restrict-user-role'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [iff(isProvider('external'), groupUserPermissionAuthenticate() as any)],
     get: [],
     create: [iff(isProvider('external'), restrictUserRole('admin') as any)],

--- a/packages/server-core/src/social/group/group.class.ts
+++ b/packages/server-core/src/social/group/group.class.ts
@@ -33,7 +33,7 @@ export class Group extends Service {
       {
         model: (this.app.service('user') as any).Model,
         where: {
-          id: loggedInUser.userId
+          id: loggedInUser.id
         }
       },
       {
@@ -45,7 +45,7 @@ export class Group extends Service {
       include.push({
         model: (this.app.service('group-user') as any).Model,
         where: {
-          userId: loggedInUser.userId,
+          userId: loggedInUser.id,
           [Op.or]: [
             {
               groupUserRank: 'owner'

--- a/packages/server-core/src/social/group/group.hooks.ts
+++ b/packages/server-core/src/social/group/group.hooks.ts
@@ -1,15 +1,13 @@
 import groupPermissionAuthenticate from '@xrengine/server-core/src/hooks/group-permission-authenticate'
 import createGroupOwner from '@xrengine/server-core/src/hooks/create-group-owner'
 import removeGroupUsers from '@xrengine/server-core/src/hooks/remove-group-users'
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import { HookContext } from '@feathersjs/feathers'
 import logger from '../../logger'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/social/invite/invite.class.ts
+++ b/packages/server-core/src/social/invite/invite.class.ts
@@ -94,7 +94,7 @@ export class Invite extends Service {
     const invite = await this.app.service('invite').get(id)
     if (invite.inviteType === 'friend' && invite.inviteeId != null && !params.preventUserRelationshipRemoval) {
       const selfUser = extractLoggedInUserFromParams(params)
-      const relatedUserId = invite.userId === selfUser.userId ? invite.inviteeId : invite.userId
+      const relatedUserId = invite.userId === selfUser.id ? invite.inviteeId : invite.userId
       await this.app.service('user-relationship').remove(relatedUserId, params)
     }
     return super.remove(id)

--- a/packages/server-core/src/social/invite/invite.hooks.ts
+++ b/packages/server-core/src/social/invite/invite.hooks.ts
@@ -1,4 +1,4 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import { disallow } from 'feathers-hooks-common'
 import generateInvitePasscode from '@xrengine/server-core/src/hooks/generate-invite-passcode'
 import sendInvite from '@xrengine/server-core/src/hooks/send-invite'
@@ -9,17 +9,15 @@ import inviteRemoveAuthenticate from '@xrengine/server-core/src/hooks/invite-rem
 import { iff, isProvider } from 'feathers-hooks-common'
 import logger from '../../logger'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
     all: [],
-    find: [authenticate('jwt'), attachOwnerIdInQuery('userId')],
-    get: [iff(isProvider('external'), authenticate('jwt') as any, attachOwnerIdInQuery('userId') as any)],
-    create: [authenticate('jwt'), attachOwnerIdInBody('userId'), generateInvitePasscode()],
+    find: [authenticate(), attachOwnerIdInQuery('userId')],
+    get: [iff(isProvider('external'), authenticate() as any, attachOwnerIdInQuery('userId') as any)],
+    create: [authenticate(), attachOwnerIdInBody('userId'), generateInvitePasscode()],
     update: [disallow()],
     patch: [disallow()],
-    remove: [authenticate('jwt'), inviteRemoveAuthenticate()]
+    remove: [authenticate(), inviteRemoveAuthenticate()]
   },
 
   after: {

--- a/packages/server-core/src/social/location-ban/location-ban.hooks.ts
+++ b/packages/server-core/src/social/location-ban/location-ban.hooks.ts
@@ -1,14 +1,12 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import { disallow } from 'feathers-hooks-common'
 import { HookContext } from '@feathersjs/feathers'
 import { extractLoggedInUserFromParams } from '../../user/auth-management/auth-management.utils'
 import { Forbidden } from '@feathersjs/errors'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [],
     get: [],
     create: [
@@ -18,7 +16,7 @@ export default {
         const locationAdmins = await app.service('location-admin').find({
           query: {
             locationId: data.locationId,
-            userId: loggedInUser.userId
+            userId: loggedInUser.id
           }
         })
         if (locationAdmins.total === 0) {

--- a/packages/server-core/src/social/location/location.class.ts
+++ b/packages/server-core/src/social/location/location.class.ts
@@ -166,7 +166,6 @@ export class Location extends Service {
       }
     } else if (adminnedLocations) {
       const loggedInUser = extractLoggedInUserFromParams(params)
-      const selfUser = await this.app.service('user').get(loggedInUser.userId)
       const include = [
         {
           model: (this.app.service('location-settings') as any).Model,
@@ -178,11 +177,11 @@ export class Location extends Service {
         }
       ]
 
-      if (selfUser.userRole !== 'admin') {
+      if (loggedInUser.userRole !== 'admin') {
         ;(include as any).push({
           model: (this.app.service('location-admin') as any).Model,
           where: {
-            userId: loggedInUser.userId
+            userId: loggedInUser.id
           }
         })
       }
@@ -257,7 +256,7 @@ export class Location extends Service {
         await (this.app.service('location-admin') as any).Model.create(
           {
             locationId: location.id,
-            userId: loggedInUser.userId
+            userId: loggedInUser.id
           },
           { transaction: t }
         )
@@ -343,7 +342,7 @@ export class Location extends Service {
 
   async remove(id: string, params: Params): Promise<any> {
     if (id != null) {
-      const loggedInUser = extractLoggedInUserFromParams(params)
+      const selfUser = extractLoggedInUserFromParams(params)
       const location = await this.app.service('location').get(id)
       if (location.locationSettingsId != null)
         await this.app.service('location-settings').remove(location.locationSettingsId)
@@ -351,7 +350,7 @@ export class Location extends Service {
         await this.app.service('location-admin').remove(null, {
           query: {
             locationId: id,
-            userId: loggedInUser.userId
+            userId: selfUser.id
           }
         })
       } catch (err) {
@@ -362,8 +361,7 @@ export class Location extends Service {
   }
 
   async makeLobby(params: Params, t): Promise<void> {
-    const loggedInUser = extractLoggedInUserFromParams(params)
-    const selfUser = await this.app.service('user').get(loggedInUser.userId)
+    const selfUser = extractLoggedInUserFromParams(params)
 
     if (!selfUser || selfUser.userRole !== 'admin') throw new Error('Only Admin can set Lobby')
 

--- a/packages/server-core/src/social/location/location.hooks.ts
+++ b/packages/server-core/src/social/location/location.hooks.ts
@@ -1,13 +1,12 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import addAssociations from '@xrengine/server-core/src/hooks/add-associations'
 import { HookContext } from '@feathersjs/feathers'
 import verifyScope from '@xrengine/server-core/src/hooks/verify-scope'
 import { isProvider, iff } from 'feathers-hooks-common'
-const { authenticate } = authentication.hooks
 
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [
       addAssociations({
         models: [

--- a/packages/server-core/src/social/message-status/message-status.hooks.ts
+++ b/packages/server-core/src/social/message-status/message-status.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import { disallow } from 'feathers-hooks-common'
 // Don't remove this comment. It's needed to format import lines nicely.
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [],
     get: [],
     create: [disallow('external')],

--- a/packages/server-core/src/social/message/message.class.ts
+++ b/packages/server-core/src/social/message/message.class.ts
@@ -24,7 +24,7 @@ export class Message extends Service {
     let channel, channelId
     let userIdList: any[] = []
     const loggedInUser = extractLoggedInUserFromParams(params)
-    const userId = loggedInUser?.userId
+    const userId = loggedInUser?.id
     const targetObjectId = data.targetObjectId
     const targetObjectType = data.targetObjectType
     const channelModel = (this.app.service('channel') as any).Model

--- a/packages/server-core/src/social/message/message.hooks.ts
+++ b/packages/server-core/src/social/message/message.hooks.ts
@@ -1,4 +1,4 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import messagePermissionAuthenticate from '@xrengine/server-core/src/hooks/message-permission-authenticate'
 import removeMessageStatuses from '@xrengine/server-core/src/hooks/remove-message-statuses'
 import channelPermissionAuthenticate from '@xrengine/server-core/src/hooks/channel-permission-authenticate'
@@ -6,11 +6,9 @@ import addAssociations from '@xrengine/server-core/src/hooks/add-associations'
 // import { extractLoggedInUserFromParams } from '../../user/auth-management/auth-management.utils'
 // Don't remove this comment. It's needed to format import lines nicely.
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [
       channelPermissionAuthenticate(),
       addAssociations({

--- a/packages/server-core/src/social/party-user/party-user.hooks.ts
+++ b/packages/server-core/src/social/party-user/party-user.hooks.ts
@@ -1,4 +1,4 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import partyPermissionAuthenticate from '@xrengine/server-core/src/hooks/party-permission-authenticate'
 import partyUserPermissionAuthenticate from '@xrengine/server-core/src/hooks/party-user-permission-authenticate'
 import { HookContext } from '@feathersjs/feathers'
@@ -10,11 +10,9 @@ import logger from '../../logger'
 
 // Don't remove this comment. It's needed to format import lines nicely.
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [iff(isProvider('external'), partyUserPermissionAuthenticate() as any)],
     get: [],
     create: [
@@ -22,10 +20,10 @@ export default {
         try {
           const { app, params, data } = context
           const loggedInUser = extractLoggedInUserFromParams(params)
-          const user = await app.service('user').get(loggedInUser.userId)
+          const user = await app.service('user').get(loggedInUser.id)
           const partyUserResult = await app.service('party-user').find({
             query: {
-              userId: loggedInUser.userId
+              userId: loggedInUser.id
             }
           })
 
@@ -36,7 +34,7 @@ export default {
           )
 
           if (data.userId == null) {
-            data.userId = loggedInUser.userId
+            data.userId = loggedInUser.id
           }
           context.params.oldInstanceId = user.instanceId
           return context

--- a/packages/server-core/src/social/party/party.class.ts
+++ b/packages/server-core/src/social/party/party.class.ts
@@ -63,7 +63,7 @@ export class Party extends Service {
       const loggedInUser = extractLoggedInUserFromParams(params)
       const partyUserResult = await this.app.service('party-user').find({
         query: {
-          userId: loggedInUser.userId
+          userId: loggedInUser.id
         }
       })
 

--- a/packages/server-core/src/social/party/party.hooks.ts
+++ b/packages/server-core/src/social/party/party.hooks.ts
@@ -1,4 +1,4 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import { disallow, iff, isProvider } from 'feathers-hooks-common'
 import partyPermissionAuthenticate from '@xrengine/server-core/src/hooks/party-permission-authenticate'
 import createPartyOwner from '@xrengine/server-core/src/hooks/create-party-owner'
@@ -9,11 +9,9 @@ import addAssociations from '../../hooks/add-associations'
 import restrictUserRole from '../../hooks/restrict-user-role'
 // Don't remove this comment. It's needed to format import lines nicely.
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [
       iff(isProvider('external'), restrictUserRole('admin') as any),
       addAssociations({
@@ -36,7 +34,7 @@ export default {
         const loggedInUser = extractLoggedInUserFromParams(context.params)
         const currentPartyUser = await context.app.service('party-user').find({
           query: {
-            userId: loggedInUser.userId
+            userId: loggedInUser.id
           }
         })
         if (currentPartyUser.total > 0) {
@@ -45,7 +43,7 @@ export default {
           } catch (error) {
             console.error(error)
           }
-          await context.app.service('user').patch(loggedInUser.userId, {
+          await context.app.service('user').patch(loggedInUser.id, {
             partyId: null
           })
         }

--- a/packages/server-core/src/user/auth-management/auth-management.hooks.ts
+++ b/packages/server-core/src/user/auth-management/auth-management.hooks.ts
@@ -1,14 +1,13 @@
-import { hooks } from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import { iff } from 'feathers-hooks-common'
 import isAction from '@xrengine/server-core/src/hooks/is-action'
-const { authenticate } = hooks
 
 export default {
   before: {
     all: [],
     find: [],
     get: [],
-    create: [iff(isAction('passwordChange', 'identityChange'), authenticate('jwt') as any)],
+    create: [iff(isAction('passwordChange', 'identityChange'), authenticate() as any)],
     update: [],
     patch: [],
     remove: []

--- a/packages/server-core/src/user/auth-management/auth-management.utils.ts
+++ b/packages/server-core/src/user/auth-management/auth-management.utils.ts
@@ -75,5 +75,5 @@ export const sendSms = async (app: Application, sms: any): Promise<void> => {
  * @author Vyacheslav Solovjov
  */
 export const extractLoggedInUserFromParams = (params: Params): any => {
-  return params[config.authentication.entity]
+  return params.user
 }

--- a/packages/server-core/src/user/avatar/avatar.hooks.ts
+++ b/packages/server-core/src/user/avatar/avatar.hooks.ts
@@ -1,8 +1,7 @@
-import * as authentication from '@feathersjs/authentication'
-const { authenticate } = authentication.hooks
+import authenticate from '../../hooks/authenticate'
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/user/identity-provider/identity-provider.class.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.class.ts
@@ -10,6 +10,7 @@ import { Params } from '@feathersjs/feathers'
 import Paginated from '../../types/PageObject'
 import blockchainTokenGenerator from '../../util/blockchainTokenGenerator'
 import blockchainUserWalletGenerator from '../../util/blockchainUserWalletGenerator'
+import { extractLoggedInUserFromParams } from '../auth-management/auth-management.utils'
 
 interface Data {}
 
@@ -231,7 +232,8 @@ export class IdentityProvider extends Service {
   }
 
   async find(params: Params): Promise<Data[] | Paginated<Data>> {
-    if (params.provider) params.query!.userId = params['identity-provider'].userId
+    const loggedInUser = extractLoggedInUserFromParams(params)
+    if (params.provider) params.query!.userId = loggedInUser.id
     return super.find(params)
   }
 }

--- a/packages/server-core/src/user/identity-provider/identity-provider.hooks.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.hooks.ts
@@ -1,14 +1,8 @@
-import * as feathersAuthentication from '@feathersjs/authentication'
-import { hooks } from '@feathersjs/authentication-local'
+import authenticate from '../../hooks/authenticate'
 import accountService from '../auth-management/auth-management.notifier'
 import { HookContext } from '@feathersjs/feathers'
 import { iff, isProvider } from 'feathers-hooks-common'
 import { NotFound } from '@feathersjs/errors'
-
-const { authenticate } = feathersAuthentication.hooks
-const hashPassword = hooks.hashPassword
-
-const { protect } = hooks
 
 const isPasswordAccountType = () => {
   return (context: HookContext): boolean => {
@@ -52,12 +46,12 @@ const checkIdentityProvider = (): any => {
 export default {
   before: {
     all: [],
-    find: [iff(isProvider('external'), authenticate('jwt') as any)],
-    get: [iff(isProvider('external'), authenticate('jwt') as any, checkIdentityProvider())],
+    find: [iff(isProvider('external'), authenticate() as any)],
+    get: [iff(isProvider('external'), authenticate() as any, checkIdentityProvider())],
     create: [],
-    update: [iff(isProvider('external'), authenticate('jwt') as any, checkIdentityProvider())],
-    patch: [iff(isProvider('external'), authenticate('jwt') as any, checkIdentityProvider())],
-    remove: [iff(isProvider('external'), authenticate('jwt') as any, checkIdentityProvider())]
+    update: [iff(isProvider('external'), authenticate() as any, checkIdentityProvider())],
+    patch: [iff(isProvider('external'), authenticate() as any, checkIdentityProvider())],
+    remove: [iff(isProvider('external'), authenticate() as any, checkIdentityProvider())]
   },
   after: {
     all: [],

--- a/packages/server-core/src/user/inventory-item/inventory-item.hooks.ts
+++ b/packages/server-core/src/user/inventory-item/inventory-item.hooks.ts
@@ -1,6 +1,6 @@
 import addAssociations from '@xrengine/server-core/src/hooks/add-associations'
 import { HookContext } from '@feathersjs/feathers'
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 
 const logRequest = (options = {}) => {
   return async (context: HookContext): Promise<HookContext> => {
@@ -14,8 +14,6 @@ const logRequest = (options = {}) => {
     return context
   }
 }
-
-const { authenticate } = authentication.hooks
 
 export default {
   before: {

--- a/packages/server-core/src/user/services.ts
+++ b/packages/server-core/src/user/services.ts
@@ -10,6 +10,7 @@ import LoginToken from './login-token/login-token.service'
 import MagicLink from './magic-link/magic-link.service'
 import SMS from './sms/sms.service'
 import User from './user/user.service'
+import UserApiKey from './user-api-key/user-api-key.service'
 import UserRelationship from './user-relationship/user-relationship.service'
 import UserRelationshipType from './user-relationship-type/user-relationship-type.service'
 import UserRole from './user-role/user-role.service'
@@ -19,6 +20,7 @@ import UserTrade from './user-trade/user-trade.service'
 
 export default [
   UserRole,
+  UserApiKey,
   User,
   UserSettings,
   IdentityProvider,

--- a/packages/server-core/src/user/strategies/discord.ts
+++ b/packages/server-core/src/user/strategies/discord.ts
@@ -2,7 +2,7 @@ import CustomOAuthStrategy from './custom-oauth'
 import { Params } from '@feathersjs/feathers'
 import config from '../../appconfig'
 import { Application } from '../../../declarations'
-import { AuthenticationRequest, AuthenticationBaseStrategy, AuthenticationResult } from '@feathersjs/authentication'
+import { AuthenticationRequest } from '@feathersjs/authentication'
 
 export class DiscordStrategy extends CustomOAuthStrategy {
   app: Application
@@ -37,6 +37,15 @@ export class DiscordStrategy extends CustomOAuthStrategy {
     await this.app.service('user').patch(entity.userId, {
       userRole: user?.userRole === 'admin' || adminCount === 0 ? 'admin' : 'user'
     })
+    const apiKey = await this.app.service('user-api-key').find({
+      query: {
+        userId: entity.userId
+      }
+    })
+    if ((apiKey as any).total === 0)
+      await this.app.service('user-api-key').create({
+        userId: entity.userId
+      })
     if (entity.type !== 'guest') {
       await this.app.service('identity-provider').remove(identityProvider.id)
       await this.app.service('user').remove(identityProvider.userId)

--- a/packages/server-core/src/user/strategies/facebook.ts
+++ b/packages/server-core/src/user/strategies/facebook.ts
@@ -9,6 +9,7 @@ export class FacebookStrategy extends CustomOAuthStrategy {
     super()
     this.app = app
   }
+
   async getEntityData(profile: any, entity: any, params: Params): Promise<any> {
     const baseData = await super.getEntityData(profile, null, {})
     const userId = params?.query ? params.query.userId : undefined
@@ -35,6 +36,15 @@ export class FacebookStrategy extends CustomOAuthStrategy {
     await this.app.service('user').patch(entity.userId, {
       userRole: user?.userRole === 'admin' || adminCount === 0 ? 'admin' : 'user'
     })
+    const apiKey = await this.app.service('user-api-key').find({
+      query: {
+        userId: entity.userId
+      }
+    })
+    if ((apiKey as any).total === 0)
+      await this.app.service('user-api-key').create({
+        userId: entity.userId
+      })
     if (entity.type !== 'guest') {
       await this.app.service('identity-provider').remove(identityProvider.id)
       await this.app.service('user').remove(identityProvider.userId)

--- a/packages/server-core/src/user/strategies/github.ts
+++ b/packages/server-core/src/user/strategies/github.ts
@@ -36,6 +36,15 @@ export class GithubStrategy extends CustomOAuthStrategy {
     await this.app.service('user').patch(entity.userId, {
       userRole: user?.userRole === 'admin' || adminCount === 0 ? 'admin' : 'user'
     })
+    const apiKey = await this.app.service('user-api-key').find({
+      query: {
+        userId: entity.userId
+      }
+    })
+    if ((apiKey as any).total === 0)
+      await this.app.service('user-api-key').create({
+        userId: entity.userId
+      })
     if (entity.type !== 'guest') {
       await this.app.service('identity-provider').remove(identityProvider.id)
       await this.app.service('user').remove(identityProvider.userId)

--- a/packages/server-core/src/user/strategies/google.ts
+++ b/packages/server-core/src/user/strategies/google.ts
@@ -9,6 +9,7 @@ export class Googlestrategy extends CustomOAuthStrategy {
     super()
     this.app = app
   }
+
   async getEntityData(profile: any, entity: any, params: Params): Promise<any> {
     const baseData = await super.getEntityData(profile, null, {})
     const userId = params?.query ? params.query.userId : undefined
@@ -35,6 +36,15 @@ export class Googlestrategy extends CustomOAuthStrategy {
     await this.app.service('user').patch(entity.userId, {
       userRole: user?.userRole === 'admin' || adminCount === 0 ? 'admin' : 'user'
     })
+    const apiKey = await this.app.service('user-api-key').find({
+      query: {
+        userId: entity.userId
+      }
+    })
+    if ((apiKey as any).total === 0)
+      await this.app.service('user-api-key').create({
+        userId: entity.userId
+      })
     if (entity.type !== 'guest') {
       await this.app.service('identity-provider').remove(identityProvider.id)
       await this.app.service('user').remove(identityProvider.userId)

--- a/packages/server-core/src/user/strategies/linkedin.ts
+++ b/packages/server-core/src/user/strategies/linkedin.ts
@@ -36,6 +36,15 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
     await this.app.service('user').patch(entity.userId, {
       userRole: user?.userRole === 'admin' || adminCount === 0 ? 'admin' : 'user'
     })
+    const apiKey = await this.app.service('user-api-key').find({
+      query: {
+        userId: entity.userId
+      }
+    })
+    if ((apiKey as any).total === 0)
+      await this.app.service('user-api-key').create({
+        userId: entity.userId
+      })
     if (entity.type !== 'guest') {
       await this.app.service('identity-provider').remove(identityProvider.id)
       await this.app.service('user').remove(identityProvider.userId)

--- a/packages/server-core/src/user/strategies/twitter.ts
+++ b/packages/server-core/src/user/strategies/twitter.ts
@@ -36,6 +36,15 @@ export class TwitterStrategy extends CustomOAuthStrategy {
     await this.app.service('user').patch(entity.userId, {
       userRole: user?.userRole === 'admin' || adminCount === 0 ? 'admin' : 'user'
     })
+    const apiKey = await this.app.service('user-api-key').find({
+      query: {
+        userId: entity.userId
+      }
+    })
+    if ((apiKey as any).total === 0)
+      await this.app.service('user-api-key').create({
+        userId: entity.userId
+      })
     if (entity.type !== 'guest') {
       await this.app.service('identity-provider').remove(identityProvider.id)
       await this.app.service('user').remove(identityProvider.userId)

--- a/packages/server-core/src/user/user-api-key/user-api-key.class.ts
+++ b/packages/server-core/src/user/user-api-key/user-api-key.class.ts
@@ -1,0 +1,40 @@
+import { Service, SequelizeServiceOptions } from 'feathers-sequelize'
+import { Application } from '../../../declarations'
+import { Params } from '@feathersjs/feathers'
+import { extractLoggedInUserFromParams } from '../auth-management/auth-management.utils'
+import { v1 } from 'uuid'
+
+/**
+ * This class used to find user-api-keys
+ * and returns founded user-api-keys
+ */
+export class UserApiKey extends Service {
+  app: Application
+  docs: any
+
+  constructor(options: Partial<SequelizeServiceOptions>, app: Application) {
+    super(options)
+    this.app = app
+  }
+
+  async patch(id: string | null, data: any, params: Params) {
+    const loggedInUser = await extractLoggedInUserFromParams(params)
+    if (loggedInUser.userRole === 'admin' && id != null) return super.patch(id, params)
+    const userApiKey = await this.app.service('user-api-key').Model.findOne({
+      where: {
+        userId: loggedInUser.id
+      }
+    })
+    let returned
+    if (userApiKey)
+      returned = await super.patch(userApiKey.id, {
+        token: v1()
+      })
+    else
+      returned = await super.create({
+        userId: loggedInUser.id
+      })
+
+    return returned
+  }
+}

--- a/packages/server-core/src/user/user-api-key/user-api-key.docs.ts
+++ b/packages/server-core/src/user/user-api-key/user-api-key.docs.ts
@@ -1,0 +1,31 @@
+export default {
+  definitions: {
+    user_api_key: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'API key ID'
+        },
+        userId: {
+          type: 'string',
+          description: 'User that owns this API key'
+        },
+        token: {
+          type: 'string',
+          description: 'API key of user'
+        }
+      }
+    },
+    user_api_key_list: {
+      type: 'array',
+      items: { $ref: '#/definitions/user' }
+    }
+  },
+  securities: ['create', 'update', 'patch', 'remove'],
+  operations: {
+    find: {
+      security: [{ bearer: [] }]
+    }
+  }
+}

--- a/packages/server-core/src/user/user-api-key/user-api-key.hooks.ts
+++ b/packages/server-core/src/user/user-api-key/user-api-key.hooks.ts
@@ -1,16 +1,21 @@
 import authenticate from '../../hooks/authenticate'
-import attachOwnerIdInQuery from '@xrengine/server-core/src/hooks/set-loggedin-user-in-query'
-import { iff, isProvider } from 'feathers-hooks-common'
+import attachOwnerIdInQuery from '../../hooks/set-loggedin-user-in-query'
+import { iff, isProvider, disallow } from 'feathers-hooks-common'
+
+/**
+ * This module used to declare and identify database relation
+ * which will be used later in user service
+ */
 
 export default {
   before: {
     all: [authenticate()],
     find: [iff(isProvider('external'), attachOwnerIdInQuery('userId') as any)],
-    get: [],
-    create: [],
-    update: [],
+    get: [iff(isProvider('external'), attachOwnerIdInQuery('userId') as any)],
+    create: [disallow('external')],
+    update: [disallow('external')],
     patch: [],
-    remove: []
+    remove: [disallow('external')]
   },
 
   after: {

--- a/packages/server-core/src/user/user-api-key/user-api-key.model.ts
+++ b/packages/server-core/src/user/user-api-key/user-api-key.model.ts
@@ -1,0 +1,39 @@
+import { DataTypes, Sequelize } from 'sequelize'
+import { Application } from '../../../declarations'
+
+/**
+ * This model contain users information
+ */
+export default (app: Application) => {
+  const sequelizeClient: Sequelize = app.get('sequelizeClient')
+  const UserApiKey = sequelizeClient.define(
+    'user_api_key',
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV1,
+        allowNull: false,
+        primaryKey: true
+      },
+      token: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV1,
+        allowNull: false,
+        unique: true
+      }
+    },
+    {
+      hooks: {
+        beforeCount(options: any): void {
+          options.raw = true
+        }
+      }
+    }
+  )
+
+  ;(UserApiKey as any).associate = (models: any): void => {
+    ;(UserApiKey as any).belongsTo(models.user, { foreignKey: { allowNull: false, onDelete: 'cascade', unique: true } })
+  }
+
+  return UserApiKey
+}

--- a/packages/server-core/src/user/user-api-key/user-api-key.service.ts
+++ b/packages/server-core/src/user/user-api-key/user-api-key.service.ts
@@ -1,0 +1,31 @@
+import { Application } from '../../../declarations'
+import { UserApiKey } from './user-api-key.class'
+import createModel from './user-api-key.model'
+import hooks from './user-api-key.hooks'
+import userDocs from './user-api-key.docs'
+
+declare module '../../../declarations' {
+  /**
+   * Interface for users input
+   */
+  interface ServiceTypes {
+    'user-api-key': UserApiKey
+  }
+}
+
+export default (app: Application): void => {
+  const options = {
+    Model: createModel(app),
+    paginate: app.get('paginate'),
+    multi: true
+  }
+
+  const event = new UserApiKey(options, app)
+  event.docs = userDocs
+
+  app.use('user-api-key', event)
+
+  const service = app.service('user-api-key')
+
+  service.hooks(hooks)
+}

--- a/packages/server-core/src/user/user-inventory/user-inventory.hooks.ts
+++ b/packages/server-core/src/user/user-inventory/user-inventory.hooks.ts
@@ -1,10 +1,9 @@
 import { disallow } from 'feathers-hooks-common'
-import * as authentication from '@feathersjs/authentication'
-const { authenticate } = authentication.hooks
+import authenticate from '../../hooks/authenticate'
 
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/user/user-relationship/user-relationship.hooks.ts
+++ b/packages/server-core/src/user/user-relationship/user-relationship.hooks.ts
@@ -1,12 +1,10 @@
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 import { iff, isProvider } from 'feathers-hooks-common'
 import { HookContext } from '@feathersjs/feathers'
 
-const { authenticate } = authentication.hooks
-
 export default {
   before: {
-    all: [iff(isProvider('external'), authenticate('jwt') as any)],
+    all: [iff(isProvider('external'), authenticate() as any)],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/user/user-settings/user-settings.hooks.ts
+++ b/packages/server-core/src/user/user-settings/user-settings.hooks.ts
@@ -1,10 +1,8 @@
-import * as authentication from '@feathersjs/authentication'
-
-const { authenticate } = authentication.hooks
+import authenticate from '../../hooks/authenticate'
 
 export default {
   before: {
-    all: [authenticate('jwt')],
+    all: [authenticate()],
     find: [],
     get: [],
     create: [],

--- a/packages/server-core/src/user/user-trade/user-trade.hooks.ts
+++ b/packages/server-core/src/user/user-trade/user-trade.hooks.ts
@@ -1,7 +1,7 @@
 import { disallow } from 'feathers-hooks-common'
 //import addAssociations from '@xrengine/server-core/src/hooks/add-associations'
 import { HookContext } from '@feathersjs/feathers'
-import * as authentication from '@feathersjs/authentication'
+import authenticate from '../../hooks/authenticate'
 //import app from "../../../../server/src/app"
 
 /*
@@ -23,8 +23,6 @@ const findRequest = async context => {
   return context
 };
 */
-
-const { authenticate } = authentication.hooks
 
 export default {
   before: {

--- a/packages/server-core/src/user/user/user.class.ts
+++ b/packages/server-core/src/user/user/user.class.ts
@@ -47,7 +47,7 @@ export class User extends Service {
           {
             model: (this.app.service('user-relationship') as any).Model,
             where: {
-              relatedUserId: loggedInUser.userId,
+              relatedUserId: loggedInUser.id,
               userRelationshipType: 'friend'
             }
           }
@@ -61,22 +61,18 @@ export class User extends Service {
     } else if (action === 'layer-users') {
       delete params.query.action
       const loggedInUser = extractLoggedInUserFromParams(params)
-      let user
-      if (loggedInUser) user = await super.get(loggedInUser.userId)
-      params.query.instanceId = params.query.instanceId || user.instanceId || 'intentionalBadId'
+      params.query.instanceId = params.query.instanceId || loggedInUser.instanceId || 'intentionalBadId'
       return super.find(params)
     } else if (action === 'channel-users') {
       delete params.query.action
       const loggedInUser = extractLoggedInUserFromParams(params)
-      let user
-      if (loggedInUser) user = await super.get(loggedInUser.userId)
-      params.query.channelInstanceId = params.query.channelInstanceId || user.channelInstanceId || 'intentionalBadId'
+      params.query.channelInstanceId =
+        params.query.channelInstanceId || loggedInUser.channelInstanceId || 'intentionalBadId'
       return super.find(params)
     } else if (action === 'admin') {
       delete params.query.action
       const loggedInUser = extractLoggedInUserFromParams(params)
-      const user = await super.get(loggedInUser.userId)
-      if (user.userRole !== 'admin') throw new Forbidden('Must be system admin to execute this action')
+      if (loggedInUser.userRole !== 'admin') throw new Forbidden('Must be system admin to execute this action')
 
       // return await super.find(params)
       return super.find(params)
@@ -101,9 +97,7 @@ export class User extends Service {
       return super.find(params)
     } else {
       const loggedInUser = extractLoggedInUserFromParams(params)
-      let user
-      if (loggedInUser) user = await super.get(loggedInUser.userId)
-      if (user?.userRole !== 'admin' && params.isInternal != true)
+      if (loggedInUser?.userRole !== 'admin' && params.isInternal != true)
         return new Forbidden('Must be system admin to execute this action')
       return await super.find(params)
     }

--- a/packages/server-core/src/user/user/user.model.ts
+++ b/packages/server-core/src/user/user/user.model.ts
@@ -67,6 +67,7 @@ export default (app: Application) => {
     ;(User as any).hasMany(models.user_trade, { foreignKey: 'fromUserId', required: true })
     ;(User as any).hasMany(models.user_trade, { foreignKey: 'toUserId', required: true })
     ;(User as any).belongsToMany(models.instance, { through: 'instance_authorized_user' })
+    ;(User as any).hasOne(models.user_api_key)
   }
 
   return User


### PR DESCRIPTION
## Summary

Created user-api-key service. This is mostly just a table containing a token that's
linked to a user.

Updated authentication flow to incorporate API keys. API keys are sent via header
'Authorization: Bearer <token>', just like JWTs. New authenticate.ts first tries to validate
against the user-api-key table, and if it matches, returns the user that owns that token.
If there is no match, it then tries to do JWT authentication.

Whether authenticating with an API key or a JWT, instead of just passing the identity-provider onto
context.params, authenticate.ts now also fetches the authenticated user and puts that at context.params.user,
so that services don't have to do the lookup themselves.

Modified extractLoggedInUserFromParams to return the user from the params instead of the identity-provider. Changed
all implementations of this so that references to loggedInUser.userId become loggedInUser.id, no additional fetches of
the user are performed, etc.

Replaced all other calls to authenticate('jwt') inside service's hooks.ts with authenticate(), referring to
authenticate.ts.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
