### PR TITLE
Adding override so that MUI modals have `pointer-events: auto`.

### DIFF
--- a/packages/client/src/pages/styles.scss
+++ b/packages/client/src/pages/styles.scss
@@ -312,3 +312,7 @@ body{
     }
   }
 }
+
+[class*=MuiModal-root] {
+  pointer-events: auto
+}


### PR DESCRIPTION
## Summary

Adding override so that MUI modals have `pointer-events: auto`.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
