### PR TITLE
Head decapitation in first person mode

### DIFF
--- a/packages/engine/src/avatar/functions/avatarFunctions.ts
+++ b/packages/engine/src/avatar/functions/avatarFunctions.ts
@@ -32,6 +32,7 @@ import { ArmatureType } from '../../ikrig/enums/ArmatureType'
 import { useWorld } from '../../ecs/functions/SystemHooks'
 import { setObjectLayers } from '../../scene/functions/setObjectLayers'
 import { AvatarProps } from '../../networking/interfaces/WorldState'
+import { insertAfterString, insertBeforeString } from '../../common/functions/string'
 
 export const loadAvatarForEntity = (entity: Entity, avatarDetail: AvatarProps) => {
   AssetLoader.load(
@@ -41,7 +42,7 @@ export const loadAvatarForEntity = (entity: Entity, avatarDetail: AvatarProps) =
       receiveShadow: true
     },
     (gltf: any) => {
-      console.log(gltf.scene)
+      console.log('loadAvatarForEntity', gltf.scene)
       setupAvatar(entity, SkeletonUtils.clone(gltf.scene), avatarDetail.avatarURL)
     }
   )
@@ -85,10 +86,13 @@ const setupAvatar = (entity: Entity, model: any, avatarURL?: string) => {
     if (object.material) {
       // Transparency fix
       object.material.format = RGBAFormat
+      const material = object.material.clone()
+
+      addBoneOpacityParamsToMaterial(material, 5) // Head bone
 
       materialList.push({
         id: object.uuid,
-        material: object.material.clone()
+        material: material
       })
       object.material = DissolveEffect.getDissolveTexture(object)
     }
@@ -208,4 +212,59 @@ export function getDefaultSkeleton(): SkinnedMesh {
   group.add(bones[0]) // we assume that root bone is the first one
 
   return skinnedMesh
+}
+
+/**
+ * Adds opacity setting to a material based on single bone
+ *
+ * @param material
+ * @param boneIndex
+ */
+const addBoneOpacityParamsToMaterial = (material, boneIndex = -1) => {
+  material.transparent = true
+  material.onBeforeCompile = (shader, renderer) => {
+    shader.uniforms.boneIndexToFade = { value: boneIndex }
+    shader.uniforms.boneWeightThreshold = { value: 0.9 }
+    shader.uniforms.boneOpacity = { value: 1.0 }
+
+    // Vertex Uniforms
+    const vertexUniforms = `uniform float boneIndexToFade;
+      uniform float boneWeightThreshold;
+      varying float vSelectedBone;`
+
+    shader.vertexShader = insertBeforeString(shader.vertexShader, 'varying vec3 vViewPosition;', vertexUniforms)
+
+    shader.vertexShader = insertAfterString(
+      shader.vertexShader,
+      '#include <skinning_vertex>',
+      `
+      vSelectedBone = 0.0;
+
+      if((skinIndex.x == boneIndexToFade && skinWeight.x >= boneWeightThreshold) || 
+      (skinIndex.y == boneIndexToFade && skinWeight.y >= boneWeightThreshold) ||
+      (skinIndex.z == boneIndexToFade && skinWeight.z >= boneWeightThreshold) ||
+      (skinIndex.w == boneIndexToFade && skinWeight.w >= boneWeightThreshold)){
+          vSelectedBone = 1.0;
+      }
+      `
+    )
+
+    // Fragment Uniforms
+    const fragUniforms = `varying float vSelectedBone;
+      uniform float boneOpacity;
+      `
+
+    shader.fragmentShader = insertBeforeString(shader.fragmentShader, 'uniform vec3 diffuse;', fragUniforms)
+
+    shader.fragmentShader = insertAfterString(
+      shader.fragmentShader,
+      'vec4 diffuseColor = vec4( diffuse, opacity );',
+      `if(vSelectedBone > 0.0){
+          diffuseColor.a = opacity * boneOpacity;
+      }
+      `
+    )
+
+    material.userData.shader = shader
+  }
 }

--- a/packages/engine/src/camera/systems/CameraSystem.ts
+++ b/packages/engine/src/camera/systems/CameraSystem.ts
@@ -76,10 +76,21 @@ const setAvatarOpacity = (entity: Entity, opacity: number): void => {
   const object3DComponent = getComponent(entity, Object3DComponent)
   object3DComponent?.value.traverse((obj) => {
     if (!(obj as SkinnedMesh).isSkinnedMesh) return
-    const mat = (obj as SkinnedMesh).material as Material
-    if (!mat) return
-    mat.opacity = opacity
-    mat.transparent = opacity < 0.95
+    const material = (obj as SkinnedMesh).material as Material
+    if (!material.userData.shader) return
+    const shader = material.userData.shader
+    shader.uniforms.boneOpacity.value = opacity
+  })
+}
+
+const getAvatarBonePosition = (entity: Entity, name: string, position: Vector3): void => {
+  const object3DComponent = getComponent(entity, Object3DComponent)
+  object3DComponent?.value.traverse((obj) => {
+    const bone = obj as any
+    // TODO: Cache the neck bone reference
+    if (!bone.isBone || !bone.name.toLowerCase().includes(name)) return
+    const el = bone.matrixWorld.elements
+    position.set(el[12], el[13], el[14])
   })
 }
 
@@ -167,18 +178,18 @@ const getMaxCamDistance = (entity: Entity, target: Vector3) => {
 }
 
 const calculateCameraTarget = (entity: Entity, target: Vector3) => {
-  const avatar = getComponent(entity, AvatarComponent)
   const avatarTransform = getComponent(entity, TransformComponent)
   const followCamera = getComponent(entity, FollowCameraComponent)
 
   const minDistanceRatio = Math.min(followCamera.distance / followCamera.minDistance, 1)
   const side = followCamera.shoulderSide ? -1 : 1
   const shoulderOffset = lerp(0, 0.2, minDistanceRatio) * side
-  const heightOffset = lerp(0, 0.25, minDistanceRatio)
+  //const heightOffset = lerp(0, 0.25, minDistanceRatio)
 
-  target.set(shoulderOffset, avatar.avatarHeight + heightOffset, 0)
+  target.set(shoulderOffset, 0.1, 0.2)
   target.applyQuaternion(avatarTransform.rotation)
-  target.add(avatarTransform.position)
+  getAvatarBonePosition(entity, 'neck', tempVec1)
+  target.add(tempVec1)
 }
 
 const updateFollowCamera = (entity: Entity, delta: number) => {

--- a/packages/engine/src/common/functions/string.ts
+++ b/packages/engine/src/common/functions/string.ts
@@ -1,0 +1,25 @@
+/**
+ * Inserts a string before the first occurrence of the search term
+ * @param source
+ * @param searchTerm
+ * @param addition
+ * @returns
+ */
+export function insertBeforeString(source: string, searchTerm: string, addition: string): string {
+  const position = source.indexOf(searchTerm)
+  return [source.slice(0, position), addition, source.slice(position)].join('\n')
+}
+
+/**
+ * Inserts a string after the first occurrence of the search term
+ * @param source
+ * @param searchTerm
+ * @param addition
+ * @returns
+ */
+export function insertAfterString(source: string, searchTerm: string, addition: string): string {
+  const position = source.indexOf(searchTerm)
+  return [source.slice(0, position + searchTerm.length), addition, source.slice(position + searchTerm.length)].join(
+    '\n'
+  )
+}

--- a/packages/engine/src/scene/classes/Ocean.ts
+++ b/packages/engine/src/scene/classes/Ocean.ts
@@ -21,6 +21,7 @@ import {
   PerspectiveCamera
 } from 'three'
 import loadTexture from '../../assets/functions/loadTexture'
+import { insertAfterString, insertBeforeString } from '../../common/functions/string'
 
 const vertexUniforms = `uniform float time;
 uniform sampler2D distortionMap;
@@ -104,18 +105,6 @@ vec3 foam( const in vec3 waterColor )
 
 const pixelData =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII='
-
-function insertBeforeString(source, searchTerm, addition) {
-  const position = source.indexOf(searchTerm)
-  return [source.slice(0, position), addition, source.slice(position)].join('\n')
-}
-
-function insertAfterString(source, searchTerm, addition) {
-  const position = source.indexOf(searchTerm)
-  return [source.slice(0, position + searchTerm.length), addition, source.slice(position + searchTerm.length)].join(
-    '\n'
-  )
-}
 
 function addImageProcess(src: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

Adds a first-person avatar camera and a skinned mesh shader modifier that supports setting opacity of vertexes attached to a specified bone.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg
