### PR TITLE
Removing server client from gameserver shutdown check.

### DIFF
--- a/packages/gameserver/src/channels.ts
+++ b/packages/gameserver/src/channels.ts
@@ -441,7 +441,8 @@ export default (app: Application): void => {
         console.log('user instanceId: ' + user.instanceId)
 
         if (instanceId != null && instance != null) {
-          const activeUsers = Engine.currentWorld.clients
+          const activeClients = Engine.currentWorld.clients
+          const activeUsers = new Map([...activeClients].filter(([, v]) => v.name !== 'server'))
           const activeUsersCount = activeUsers.size
           try {
             await app.service('instance').patch(instanceId, {


### PR DESCRIPTION
## Summary

This client will never leave a world server, so it needs to be ignored when checking how many users
are still on the server.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
