### PR TITLE
Fixed bug with loading spawnpoints and skyboxes that are embedded within gltf models

### DIFF
--- a/packages/engine/src/scene/functions/loaders/SkyboxFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SkyboxFunctions.ts
@@ -53,7 +53,11 @@ export const deserializeSkybox: ComponentDeserializeFunction = (
 ) => {
   if (isClient) {
     json.props.backgroundColor = new Color(json.props.backgroundColor)
-    addComponent(entity, Object3DComponent, { value: new Object3D() })
+    var obj3D = getComponent(entity, Object3DComponent)
+    if (obj3D == null) {
+      obj3D = new Object3D()
+      addComponent(entity, Object3DComponent, { value: obj3D })
+    }
     addComponent(entity, SkyboxComponent, json.props)
     addComponent(entity, DisableTransformTagComponent, {})
     addComponent(entity, IgnoreRaycastTagComponent, {})

--- a/packages/engine/src/scene/functions/loaders/SpawnPointFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SpawnPointFunctions.ts
@@ -22,8 +22,11 @@ const GLTF_PATH = '/static/editor/spawn-point.glb' // Static
 export const deserializeSpawnPoint: ComponentDeserializeFunction = async (entity: Entity) => {
   addComponent(entity, SpawnPointComponent, {})
 
-  const obj3d = new Object3D()
-  addComponent(entity, Object3DComponent, { value: obj3d })
+  var obj3d = getComponent(entity, Object3DComponent)
+  if (obj3d == null) {
+    obj3d = new Object3D()
+    addComponent(entity, Object3DComponent, { value: obj3d })
+  }
 
   if (Engine.isEditor) {
     getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SPAWN_POINT)


### PR DESCRIPTION
## Summary

Added redundancy checks for adding components embedded within gltf models. This fixes an error that occurs when loading a gltf model that has spawn points or skyboxes embedded in them. The fix is very simple and self-contained.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
