### PR TITLE
Changes for benchmark functionality in admin

### DIFF
--- a/packages/client-core/i18n/en/user.json
+++ b/packages/client-core/i18n/en/user.json
@@ -201,6 +201,7 @@
       "projects": "Projects",
       "scenes": "Scenes",
       "avatars": "Avatars",
+      "benchmarking": "Benchmarking",
       "bots": "Bots"
     }
   },
@@ -228,6 +229,7 @@
     "content": "Content Packs",
     "scenes": "Scenes",
     "avatars": "Avatars",
+    "benchmarking": "Benchmarking",
     "bots": "Bots",
     "setting": "Settings"
   },

--- a/packages/client-core/src/admin/adminRoutes.tsx
+++ b/packages/client-core/src/admin/adminRoutes.tsx
@@ -6,6 +6,7 @@ import { AuthService, useAuthState } from '../user/services/AuthService'
 
 const analytic = React.lazy(() => import('./pages/index'))
 const avatars = React.lazy(() => import('./pages/avatars'))
+const benchmarking = React.lazy(() => import('./pages/benchmarking'))
 const groups = React.lazy(() => import('./pages/groups'))
 const instance = React.lazy(() => import('./pages/instance'))
 const invites = React.lazy(() => import('./pages/invites'))
@@ -35,7 +36,8 @@ const ProtectedRoutes = (props: Props) => {
     groups: false,
     instance: false,
     invite: false,
-    globalAvatars: false
+    globalAvatars: false,
+    benchmarking: false
   }
   const scopes = admin?.scopes?.value || []
 
@@ -79,6 +81,7 @@ const ProtectedRoutes = (props: Props) => {
           <Switch>
             <PrivateRoute exact path="/admin" component={analytic} />
             <PrivateRoute exact path="/admin/avatars" component={avatars} />
+            <PrivateRoute exact path="/admin/benchmarking" component={benchmarking} />
             <PrivateRoute exact path="/admin/groups" component={groups} />
             <PrivateRoute exact path="/admin/instance" component={instance} />
             <PrivateRoute exact path="/admin/invites" component={invites} />

--- a/packages/client-core/src/admin/components/Benchmarking/index.tsx
+++ b/packages/client-core/src/admin/components/Benchmarking/index.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect } from 'react'
+import Button from '@mui/material/Button'
+import Grid from '@mui/material/Grid'
+import Typography from '@mui/material/Typography'
+import { useStyles } from './styles'
+import { TestBotService, useTestBotState } from '../../services/TestBotService'
+
+const Benchmarking = () => {
+  const testbotState = useTestBotState()
+  const classes = useStyles()
+  const bots = testbotState.value.bots
+
+  const REFRESH_MS = 10000
+
+  useEffect(() => {
+    TestBotService.fetchTestBot()
+    const interval = setInterval(() => {
+      console.log('Refreshing bot status')
+      TestBotService.fetchTestBot()
+    }, REFRESH_MS)
+
+    return () => clearInterval(interval) // This represents the unmount function, in which you need to clear your interval to prevent memory leaks.
+  }, [])
+
+  return (
+    <div>
+      <Grid container spacing={3}>
+        <Grid item xs={4}>
+          <Button type="button" variant="contained" color="primary">
+            {'Spawn Bots'}
+          </Button>
+        </Grid>
+      </Grid>
+
+      {bots && bots.length > 0 && (
+        <Typography className={classes.secondaryHeading}>
+          Last run status: {bots[0].status} (auto refreshing in 10s)
+        </Typography>
+      )}
+    </div>
+  )
+}
+
+export default Benchmarking

--- a/packages/client-core/src/admin/components/Benchmarking/styles.ts
+++ b/packages/client-core/src/admin/components/Benchmarking/styles.ts
@@ -1,0 +1,13 @@
+import { Theme } from '@mui/material/styles'
+
+import makeStyles from '@mui/styles/makeStyles'
+import createStyles from '@mui/styles/createStyles'
+
+export const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    secondaryHeading: {
+      fontSize: theme.typography.pxToRem(15),
+      color: '#C0C0C0'
+    }
+  })
+)

--- a/packages/client-core/src/admin/components/Project/ProjectTable.tsx
+++ b/packages/client-core/src/admin/components/Project/ProjectTable.tsx
@@ -14,7 +14,6 @@ import Paper from '@mui/material/Paper'
 import { useAuthState } from '../../../user/services/AuthService'
 import { PROJECT_PAGE_LIMIT, useProjectState } from '../../../common/services/ProjectService'
 import { ProjectService } from '../../../common/services/ProjectService'
-import { TestBotService } from '../../services/TestBotService'
 import { GithubAppService, useGithubAppState } from '../../services/GithubAppService'
 import styles from './Projects.module.scss'
 import UploadProjectModal from './UploadProjectModal'
@@ -222,17 +221,6 @@ const Projects = () => {
               {'Rebuild'}
             </Button>
           </Grid>
-          {/* <Grid item xs={4}>
-            <Button
-              className={styles['open-modal']}
-              type="button"
-              variant="contained"
-              color="primary"
-              onClick={TestBotService.createTestBot}
-            >
-              {'Spawn Bots'}
-            </Button>
-          </Grid> */}
         </Grid>
         <TableContainer className={styles.tableContainer}>
           <Table stickyHeader aria-labelledby="tableTitle" size={'medium'} aria-label="enhanced table">

--- a/packages/client-core/src/admin/pages/benchmarking.tsx
+++ b/packages/client-core/src/admin/pages/benchmarking.tsx
@@ -1,0 +1,14 @@
+import Benchmarking from '../components/Benchmarking'
+import { AuthService } from '../../user/services/AuthService'
+import React, { useEffect } from 'react'
+
+interface Props {}
+
+function benchmarkingRoute(props: Props) {
+  useEffect(() => {
+    AuthService.doLoginAuto(true)
+  }, [])
+  return <Benchmarking />
+}
+
+export default benchmarkingRoute

--- a/packages/client-core/src/user/components/Dashboard/DashboardItems.tsx
+++ b/packages/client-core/src/user/components/Dashboard/DashboardItems.tsx
@@ -11,6 +11,7 @@ import {
   Settings,
   SupervisorAccount,
   Toys,
+  Timeline,
   Shuffle
 } from '@mui/icons-material'
 import RemoveFromQueueIcon from '@mui/icons-material/RemoveFromQueue'
@@ -67,6 +68,11 @@ export const SidebarItems = (allowedRoutes) => [
     name: 'user:dashboard.avatars',
     path: '/admin/avatars',
     icon: <Accessibility style={{ color: 'white' }} />
+  },
+  allowedRoutes.benchmarking && {
+    name: 'user:dashboard.benchmarking',
+    path: '/admin/benchmarking',
+    icon: <Timeline style={{ color: 'white' }} />
   },
   {
     name: 'user:dashboard.setting',

--- a/packages/client-core/src/user/components/Dashboard/DashboardMenuItem.tsx
+++ b/packages/client-core/src/user/components/Dashboard/DashboardMenuItem.tsx
@@ -34,6 +34,7 @@ const DashboardMenuItem = (props: Props) => {
     instance: false,
     invite: false,
     globalAvatars: false,
+    benchmarking: false,
     projects: false
   }
 

--- a/packages/common/src/interfaces/TestBot.ts
+++ b/packages/common/src/interfaces/TestBot.ts
@@ -1,0 +1,4 @@
+export interface TestBot {
+  name: string
+  status: string
+}

--- a/packages/ops/xrengine/Chart.yaml
+++ b/packages/ops/xrengine/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.4.6
+version: 3.4.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/packages/ops/xrengine/templates/api-server-cluster-role.yaml
+++ b/packages/ops/xrengine/templates/api-server-cluster-role.yaml
@@ -12,6 +12,7 @@ rules:
       - pods
       - endpoints
       - deployments
+      - jobs
     verbs:
       - get
       - list
@@ -24,6 +25,18 @@ rules:
       - "apps"
     resources:
       - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - "batch"
+    resources:
+      - jobs
     verbs:
       - get
       - list

--- a/packages/server-core/src/bot/testbot/testbot-helper.ts
+++ b/packages/server-core/src/bot/testbot/testbot-helper.ts
@@ -1,0 +1,16 @@
+import { Application } from '../../../declarations'
+import config from '@xrengine/server-core/src/appconfig'
+
+export const getTestbotPod = async (app: Application) => {
+  if (app.k8DefaultClient) {
+    try {
+      const podsResult = await app.k8DefaultClient.get(
+        `pods?labelSelector=job-name%3D${config.server.releaseName}-xrengine-testbot`
+      )
+      return podsResult
+    } catch (e) {
+      console.log(e)
+      return e
+    }
+  }
+}

--- a/packages/server-core/src/bot/testbot/testbot.hooks.ts
+++ b/packages/server-core/src/bot/testbot/testbot.hooks.ts
@@ -1,0 +1,34 @@
+import verifyScope from '../../hooks/verify-scope'
+import { iff, isProvider } from 'feathers-hooks-common'
+
+export default {
+  before: {
+    all: [iff(isProvider('external'), verifyScope('benchmark', 'write') as any)],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+
+  after: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+
+  error: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  }
+} as any

--- a/packages/server-core/src/bot/testbot/testbot.service.ts
+++ b/packages/server-core/src/bot/testbot/testbot.service.ts
@@ -1,9 +1,21 @@
 import { Application } from '../../../declarations'
+import { getTestbotPod } from './testbot-helper'
 
 export default (app: Application): void => {
   app.use('testbot', {
-    create: () => {
-      return { name: 'Hello' }
+    get: async () => {
+      const result = await getTestbotPod(app)
+      if (result) {
+        const response = result.items.map((item) => {
+          return {
+            name: item.metadata.name,
+            status: item.status.phase
+          }
+        })
+        return response
+      }
+
+      return []
     }
   })
 

--- a/packages/server-core/src/bot/testbot/testbot.service.ts
+++ b/packages/server-core/src/bot/testbot/testbot.service.ts
@@ -1,5 +1,6 @@
 import { Application } from '../../../declarations'
 import { getTestbotPod } from './testbot-helper'
+import hooks from './testbot.hooks'
 
 export default (app: Application): void => {
   app.use('testbot', {
@@ -19,5 +20,7 @@ export default (app: Application): void => {
     }
   })
 
-  // TODO: Need to put authenticate hooks
+  const service = app.service('testbot')
+
+  service.hooks(hooks)
 }

--- a/packages/server-core/src/scope/scope-type/scope-type.seed.ts
+++ b/packages/server-core/src/scope/scope-type/scope-type.seed.ts
@@ -35,6 +35,12 @@ export const scopeTypeSeed = {
       type: 'globalAvatars:write'
     },
     {
+      type: 'benchmarking:read'
+    },
+    {
+      type: 'benchmarking:write'
+    },
+    {
       type: 'groups:read'
     },
     {


### PR DESCRIPTION
## Summary

This PR introduces a Benchmark section in admin panel. The benchmark section will currently show Spawn bots button and Last run status of testbot.

The Spawn bots button which currently does nothing but after a while, once we introduce kubernetes client sdk then this functionality will be implemented.

The Last run status of testbot shows the status of testbot pod in kubernetes cluster. It queries the cluster using api. It is refreshed after every 10 seconds.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [x] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
