### PR TITLE
Fixed errors in WebRTC connections.

### DIFF
--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -15,6 +15,7 @@ import { MediaStreamService } from '../media/services/MediaStreamService'
 import { useDispatch } from '../store'
 import { accessAuthState } from '../user/services/AuthService'
 import { SocketWebRTCClientTransport } from './SocketWebRTCClientTransport'
+import { PUBLIC_STUN_SERVERS } from '@xrengine/engine/src/networking/constants/STUNServers'
 
 export const getChannelTypeIdFromTransport = (networkTransport: SocketWebRTCClientTransport) => {
   const channelConnectionState = accessChannelConnectionState()
@@ -261,6 +262,7 @@ export async function createTransport(networkTransport: SocketWebRTCClientTransp
     channelId: channelId
   })
 
+  if (process.env.NODE_ENV === 'production') transportOptions.iceServers = PUBLIC_STUN_SERVERS
   if (direction === 'recv') transport = await networkTransport.mediasoupDevice.createRecvTransport(transportOptions)
   else if (direction === 'send')
     transport = await networkTransport.mediasoupDevice.createSendTransport(transportOptions)

--- a/packages/engine/src/networking/constants/STUNServers.ts
+++ b/packages/engine/src/networking/constants/STUNServers.ts
@@ -1,0 +1,14 @@
+export const PUBLIC_STUN_SERVERS = [
+  {
+    urls: 'stun:stun.l.google.com:19302'
+  },
+  {
+    urls: 'stun:stun1.l.google.com:19302'
+  },
+  {
+    urls: 'stun:stun.services.mozilla.com:3478'
+  },
+  {
+    urls: 'stun:stun.ucsb.edu:3478'
+  }
+]

--- a/packages/server-core/src/util/get-local-server-ip.ts
+++ b/packages/server-core/src/util/get-local-server-ip.ts
@@ -7,7 +7,7 @@ interface ServerAddress {
 }
 
 export default async (isChannelInstance: boolean): Promise<ServerAddress> => {
-  const ip = configFile.gameserver.hostname
+  const ip = configFile.gameserver.hostname === 'localhost' ? await internalIp.v4() : configFile.gameserver.hostname
   return {
     ipAddress: ip!,
     port: isChannelInstance ? '3032' : '3031'


### PR DESCRIPTION
## Summary

Added a list of public STUN servers to engine networking constants.
createTransport() in SocketWebRTCClientFunctions.ts adds this as 'iceServers' to transportOptions
when creating transports, so that the RTCPeerConnections that are created have specific STUN servers
to get their public IP from. (prior to this there were no explicitly defined STUN servers, and roughly
half the time WebRTC connections failed because they weren't getting a public IP for the client).

Updated get-local-server-ip.ts to use internalIp.v4() if 'localhost' is specified as GAMESERVER_HOST.
If any other value is used, then it just uses that value.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [x] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
