### PR TITLE
Cap frame deltas to 1/30 seconds

### DIFF
--- a/packages/engine/src/common/functions/Timer.ts
+++ b/packages/engine/src/common/functions/Timer.ts
@@ -13,10 +13,7 @@ const TimerConfig = {
   MAX_DELTA: 1 / 10
 }
 
-export function Timer(
-  update: TimerUpdateCallback,
-  _config: Partial<typeof TimerConfig> = {}
-): { start: Function; stop: Function; clear: Function } {
+export function Timer(update: TimerUpdateCallback, _config: Partial<typeof TimerConfig> = {}) {
   const config = Object.assign({}, TimerConfig, _config)
 
   let lastTime = null

--- a/packages/engine/src/common/functions/Timer.ts
+++ b/packages/engine/src/common/functions/Timer.ts
@@ -9,6 +9,8 @@ type TimerUpdateCallback = (delta: number, elapsedTime: number) => any
 const TPS_REPORTS_ENABLED = false
 const TPS_REPORT_INTERVAL_MS = 10000
 
+const MAX_DELTA = 1 / 30
+
 export function Timer(update: TimerUpdateCallback): { start: Function; stop: Function; clear: Function } {
   let lastTime = null
   let elapsedTime = 0
@@ -45,7 +47,7 @@ export function Timer(update: TimerUpdateCallback): { start: Function; stop: Fun
 
     Engine.xrFrame = xrFrame
     if (lastTime !== null) {
-      delta = (time - lastTime) / 1000
+      delta = Math.min((time - lastTime) / 1000, MAX_DELTA)
 
       elapsedTime += delta
 

--- a/packages/engine/src/common/functions/Timer.ts
+++ b/packages/engine/src/common/functions/Timer.ts
@@ -9,9 +9,16 @@ type TimerUpdateCallback = (delta: number, elapsedTime: number) => any
 const TPS_REPORTS_ENABLED = false
 const TPS_REPORT_INTERVAL_MS = 10000
 
-const MAX_DELTA = 1 / 30
+const TimerConfig = {
+  MAX_DELTA: 1 / 10
+}
 
-export function Timer(update: TimerUpdateCallback): { start: Function; stop: Function; clear: Function } {
+export function Timer(
+  update: TimerUpdateCallback,
+  _config: Partial<typeof TimerConfig> = {}
+): { start: Function; stop: Function; clear: Function } {
+  const config = Object.assign({}, TimerConfig, _config)
+
   let lastTime = null
   let elapsedTime = 0
   let delta = 0
@@ -47,7 +54,7 @@ export function Timer(update: TimerUpdateCallback): { start: Function; stop: Fun
 
     Engine.xrFrame = xrFrame
     if (lastTime !== null) {
-      delta = Math.min((time - lastTime) / 1000, MAX_DELTA)
+      delta = Math.min((time - lastTime) / 1000, config.MAX_DELTA)
 
       elapsedTime += delta
 


### PR DESCRIPTION
## Summary

It's standard and best practice to cap frame deltas so that they don't break animation or lerping when the frame deltas get too large. This does not affect logic in fixed systems. 

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
