### PR TITLE
Fix interactables bounding box

### DIFF
--- a/packages/engine/src/interaction/functions/createBoxComponent.ts
+++ b/packages/engine/src/interaction/functions/createBoxComponent.ts
@@ -6,9 +6,13 @@ import { ColliderComponent } from '../../physics/components/ColliderComponent'
 import { Object3DComponent } from '../../scene/components/Object3DComponent'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { BoundingBoxComponent } from '../components/BoundingBoxComponent'
+import { InteractableComponent } from '../components/InteractableComponent'
 
 export const createBoxComponent = (entity: Entity) => {
-  const dynamic = hasComponent(entity, ColliderComponent) && isDynamicBody(getComponent(entity, ColliderComponent).body)
+  const interactable = getComponent(entity, InteractableComponent)
+  const dynamic =
+    (hasComponent(entity, ColliderComponent) && isDynamicBody(getComponent(entity, ColliderComponent).body)) ||
+    (interactable && interactable.interactionType === 'equippable')
 
   const calcBoundingBox = addComponent(entity, BoundingBoxComponent, { dynamic, box: new Box3() })
 

--- a/packages/engine/src/interaction/systems/InteractiveSystem.ts
+++ b/packages/engine/src/interaction/systems/InteractiveSystem.ts
@@ -59,8 +59,11 @@ export default async function InteractiveSystem(world: World) {
     }
 
     for (const entity of interactiveQuery.exit(world)) {
-      // TODO: Does the Box3 object need to be destroyed before this?
-      removeComponent(entity, BoundingBoxComponent)
+      // this getComponent check is required for handling cases when multiple setEquippedObject cached network action are received
+      // and this exit query could get called with EquippedComponent not being present on the entity
+      if (getComponent(entity, EquippedComponent)) {
+        removeComponent(entity, BoundingBoxComponent)
+      }
       removeComponent(entity, InteractiveFocusedComponent)
       removeComponent(entity, SubFocusedComponent)
     }

--- a/packages/projects/default-project/sky-station.scene.json
+++ b/packages/projects/default-project/sky-station.scene.json
@@ -796,7 +796,9 @@
         {
           "name": "interactable",
           "props": {
-            "interactable": true
+            "interactable": true,
+            "interactionType": "equippable",
+            "intensity": 5
           }
         }
       ],


### PR DESCRIPTION
## Summary

Fix issue where equippables might not be pickable for clients that join the world later.
The reason was the incorrect position of the bounding box for dynamic interactable items and a race condition in the interactive system which resulted in the entity being left with removed bounding box.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
