### PR TITLE
Made most Dockerfiles use a multi-stage build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # not slim because we need github depedencies
-FROM node:16-buster
+FROM node:16-buster-slim
 
 RUN apt-get update
 RUN apt-get install build-essential -y

--- a/dockerfiles/analytics/Dockerfile-analytics
+++ b/dockerfiles/analytics/Dockerfile-analytics
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 # not slim because we need github depedencies
-FROM node:16-buster
+FROM node:16-buster-slim as builder
 
 RUN apt update
 # Create app directory
@@ -23,5 +23,10 @@ COPY . .
 # copy then compile the code
 
 ENV APP_ENV=production
+
+FROM node:16-buster-slim as runner
+WORKDIR /app
+
+COPY --from=builder /app ./
 
 CMD ["scripts/start-server.sh"]

--- a/dockerfiles/api/Dockerfile-api
+++ b/dockerfiles/api/Dockerfile-api
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 # not slim because we need github depedencies
-FROM node:16-buster
+FROM node:16-buster-slim as builder
 
 RUN apt update
 # Create app directory
@@ -24,5 +24,10 @@ COPY . .
 # copy then compile the code
 
 ENV APP_ENV=production
+
+FROM node:16-buster-slim as runner
+WORKDIR /app
+
+COPY --from=builder /app ./
 
 CMD ["scripts/start-server.sh"]

--- a/dockerfiles/builder/Dockerfile-builder
+++ b/dockerfiles/builder/Dockerfile-builder
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 # not slim because we need github depedencies
-FROM node:16-buster
+FROM node:16-buster-slim as builder
 
 RUN apt update
 # Create app directory
@@ -24,5 +24,10 @@ COPY . .
 # copy then compile the code
 
 ENV APP_ENV=production
+
+FROM node:16-buster-slim as runner
+WORKDIR /app
+
+COPY --from=builder /app ./
 
 CMD ["scripts/run-builder.sh"]

--- a/dockerfiles/client/Dockerfile-client
+++ b/dockerfiles/client/Dockerfile-client
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 # not slim because we need github depedencies
-FROM node:16-buster
+FROM node:16-buster-slim as builder
 
 RUN apt update
 # Create app directory
@@ -37,5 +37,13 @@ ENV MYSQL_USER=$MYSQL_USER
 RUN npm run build-client
 
 ENV APP_ENV=production
+
+FROM node:16-buster-slim as runner
+WORKDIR /app
+
+COPY --from=builder /app/packages/client ./packages/client
+COPY --from=builder /app/scripts ./scripts
+
+RUN npm install express app-root-path
 
 CMD ["scripts/start-server.sh"]

--- a/dockerfiles/gameserver/Dockerfile-gameserver
+++ b/dockerfiles/gameserver/Dockerfile-gameserver
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 # not slim because we need github depedencies
-FROM node:16-buster
+FROM node:16-buster-slim as builder
 
 RUN apt update
 RUN apt-get install build-essential meson python3-testresources python3-venv python3-pip -y
@@ -26,4 +26,10 @@ COPY . .
 
 ENV APP_ENV=production
 
+FROM node:16-buster-slim as runner
+WORKDIR /app
+
+COPY --from=builder /app ./
+
 CMD ["scripts/start-server.sh"]
+

--- a/dockerfiles/testbot/Dockerfile-testbot
+++ b/dockerfiles/testbot/Dockerfile-testbot
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 # not slim because we need github depedencies
-FROM node:16-buster
+FROM node:16-buster-slim as builder
 
 RUN apt update
 # Create app directory
@@ -22,5 +22,10 @@ RUN npm run install-test-e2e
 COPY . .
 
 ENV APP_ENV=production
+
+FROM node:16-buster-slim as runner
+WORKDIR /app
+
+COPY --from=builder /app ./
 
 CMD ["scripts/start-testbot.sh"]

--- a/packages/bot/Dockerfile
+++ b/packages/bot/Dockerfile
@@ -1,5 +1,5 @@
 # not slim because we need github depedencies
-FROM node:16-buster
+FROM node:16-buster-slim
 
 RUN echo "deb [arch=amd64] http://nginx.org/packages/mainline/ubuntu/ eoan nginx\ndeb-src http://nginx.org/packages/mainline/ubuntu/ eoan nginx" >> /etc/apt/sources.list.d/nginx.list
 RUN wget http://nginx.org/keys/nginx_signing.key

--- a/scripts/setup_aws.sh
+++ b/scripts/setup_aws.sh
@@ -1,6 +1,7 @@
 set -e
 set -x
 
+apt install unzip
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip -q awscliv2.zip
 ./aws/install


### PR DESCRIPTION
## Summary

Client now only uses built files, since all source files aren't needed.

Switched to buster-slim image to save space, manually installing
a couple of tools that are not present in slim image.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [x] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
