### PR TITLE
Project 'update' Service Resets Default Project

### DIFF
--- a/packages/client-core/src/admin/components/Project/ProjectTable.tsx
+++ b/packages/client-core/src/admin/components/Project/ProjectTable.tsx
@@ -157,9 +157,11 @@ const Projects = () => {
 
   const tryReuploadProjects = async (row: ProjectInterface) => {
     try {
-      if (!row.repositoryPath) return
+      if (!row.repositoryPath && row.name !== 'default-project') return
       const existingProjects = adminProjects.value.find((projects) => projects.name === row.name)!
-      await ProjectService.uploadProject(existingProjects.repositoryPath)
+      await ProjectService.uploadProject(
+        row.name === 'default-project' ? 'default-project' : existingProjects.repositoryPath
+      )
     } catch (err) {
       console.log(err)
     }
@@ -251,7 +253,7 @@ const Projects = () => {
                       {user.userRole.value === 'admin' && (
                         <Button
                           className={styles.checkbox}
-                          disabled={row.repositoryPath === null}
+                          disabled={row.repositoryPath === null && row.name !== 'default-project'}
                           onClick={(e) => tryReuploadProjects(row)}
                           name="stereoscopic"
                           color="primary"

--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -200,6 +200,12 @@ export class Project extends Service {
    */
   // @ts-ignore
   async update(data: { url: string }, params: Params) {
+    if (data.url === 'default-project') {
+      copyDefaultProject()
+      await uploadLocalProjectToProvider('default-project', true)
+      return
+    }
+
     const urlParts = data.url.split('/')
     let projectName = urlParts.pop()
     if (!projectName) throw new Error('Git repo must be plain URL')

--- a/packages/server-core/src/scene.test.ts
+++ b/packages/server-core/src/scene.test.ts
@@ -40,7 +40,7 @@ describe('scene.test', () => {
       metadataOnly: false
     }, params)
     const entities = Object.values(data.scene!.entities)
-    assert.strictEqual(entities.length, 9)
+    assert.strictEqual(entities.length, 8)
   })
 
   it("should add new project", async function() {

--- a/packages/server-core/src/util/seeder/index.ts
+++ b/packages/server-core/src/util/seeder/index.ts
@@ -15,7 +15,7 @@ export default function seeder(services: Array<ServicesSeedConfig>) {
       }
       copyDefaultProject()
       await app.service('project')._seedProject('default-project')
-      await uploadLocalProjectToProvider('default-project', app)
+      await uploadLocalProjectToProvider('default-project')
     }
   }
 }


### PR DESCRIPTION
## Summary

implements an easy way to reset the default project

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

https://github.com/XRFoundation/XREngine/issues/4881

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
