### PR TITLE
Add Type and Ref for Bone Structure & Improve Camera Targeting

### DIFF
--- a/packages/engine/src/avatar/AvatarBoneMatching.ts
+++ b/packages/engine/src/avatar/AvatarBoneMatching.ts
@@ -2,7 +2,36 @@
 // This retargeting logic is based exokitxr retargeting system
 // https://github.com/exokitxr/avatars
 
-import { Matrix4, Quaternion, Vector3 } from 'three'
+import { Bone, Matrix4, Quaternion, Vector3 } from 'three'
+
+export type BoneNames =
+  | 'Root'
+  | 'Hips'
+  | 'Spine'
+  | 'Spine1'
+  | 'Spine2'
+  | 'Neck'
+  | 'Head'
+  | 'LeftEye'
+  | 'RightEye'
+  | 'LeftShoulder'
+  | 'LeftArm'
+  | 'LeftForeArm'
+  | 'LeftHand'
+  | 'LeftUpLeg'
+  | 'LeftLeg'
+  | 'LeftFoot'
+  | 'RightShoulder'
+  | 'RightArm'
+  | 'RightForeArm'
+  | 'RightHand'
+  | 'RightUpLeg'
+  | 'RightLeg'
+  | 'RightFoot'
+
+export type BoneStructure = {
+  [bone in BoneNames]: Bone
+}
 
 const _getTailBones = (skeleton) => {
   const result: any[] = []
@@ -382,7 +411,7 @@ function getSkeleton(model) {
   return skeleton
 }
 
-export default function AvatarBoneMatching(model) {
+export default function AvatarBoneMatching(model): BoneStructure {
   try {
     const skeleton = getSkeleton(model)
     const Hips = _findHips(skeleton)
@@ -662,6 +691,6 @@ export default function AvatarBoneMatching(model) {
     return targetModelBones
   } catch (error) {
     console.error(error)
-    return null
+    return null!
   }
 }

--- a/packages/engine/src/avatar/functions/createAvatar.ts
+++ b/packages/engine/src/avatar/functions/createAvatar.ts
@@ -28,9 +28,9 @@ import { createQuaternionProxy, createVector3Proxy } from '../../common/proxies/
 import { ObjectLayers } from '../../scene/constants/ObjectLayers'
 
 const avatarRadius = 0.25
-const avatarHeight = 1.8
-const capsuleHeight = avatarHeight - avatarRadius * 2
-export const avatarHalfHeight = avatarHeight / 2
+const defaultAvatarHeight = 1.8
+const capsuleHeight = defaultAvatarHeight - avatarRadius * 2
+export const defaultAvatarHalfHeight = defaultAvatarHeight / 2
 
 export const createAvatar = (spawnAction: typeof NetworkWorldAction.spawnAvatar.matches._TYPE): Entity => {
   const world = useWorld()
@@ -57,7 +57,7 @@ export const createAvatar = (spawnAction: typeof NetworkWorldAction.spawnAvatar.
   // The visuals group is centered for easy actor tilting
   const tiltContainer = new Group()
   tiltContainer.name = 'Actor (tiltContainer)' + entity
-  tiltContainer.position.setY(avatarHalfHeight)
+  tiltContainer.position.setY(defaultAvatarHalfHeight)
 
   // // Model container is used to reliably ground the actor, as animation can alter the position of the model itself
   const modelContainer = new Group()
@@ -66,8 +66,8 @@ export const createAvatar = (spawnAction: typeof NetworkWorldAction.spawnAvatar.
 
   addComponent(entity, AvatarComponent, {
     ...world.clients.get(userId)?.avatarDetail,
-    avatarHalfHeight,
-    avatarHeight,
+    avatarHalfHeight: defaultAvatarHalfHeight,
+    avatarHeight: defaultAvatarHeight,
     modelContainer,
     isGrounded: false
   })
@@ -105,9 +105,9 @@ export const createAvatar = (spawnAction: typeof NetworkWorldAction.spawnAvatar.
     filterData,
     type: SceneQueryType.Closest,
     hits: [],
-    origin: new Vector3(0, avatarHalfHeight, 0),
+    origin: new Vector3(0, defaultAvatarHalfHeight, 0),
     direction: new Vector3(0, -1, 0),
-    maxDistance: avatarHalfHeight + 0.05,
+    maxDistance: defaultAvatarHalfHeight + 0.05,
     flags
   })
 
@@ -135,7 +135,7 @@ export const createAvatar = (spawnAction: typeof NetworkWorldAction.spawnAvatar.
     transform: {
       translation: {
         x: transform.position.x,
-        y: transform.position.y + avatarHalfHeight,
+        y: transform.position.y + defaultAvatarHalfHeight,
         z: transform.position.z
       },
       rotation: new Quaternion()
@@ -166,7 +166,7 @@ export const createAvatarController = (entity: Entity) => {
     material: world.physics.createMaterial(),
     position: {
       x: position.x,
-      y: position.y + avatarHalfHeight,
+      y: position.y + defaultAvatarHalfHeight,
       z: position.z
     },
     contactOffset: 0.01,
@@ -181,7 +181,7 @@ export const createAvatarController = (entity: Entity) => {
   console.log(controller.getPosition())
 
   const frustumCamera = new PerspectiveCamera(60, 2, 0.1, 3)
-  frustumCamera.position.setY(avatarHalfHeight)
+  frustumCamera.position.setY(defaultAvatarHalfHeight)
   frustumCamera.rotateY(Math.PI)
 
   value.add(frustumCamera)

--- a/packages/engine/src/camera/systems/CameraSystem.ts
+++ b/packages/engine/src/camera/systems/CameraSystem.ts
@@ -177,18 +177,18 @@ const getMaxCamDistance = (entity: Entity, target: Vector3) => {
 }
 
 const calculateCameraTarget = (entity: Entity, target: Vector3) => {
+  const avatar = getComponent(entity, AvatarComponent)
   const avatarTransform = getComponent(entity, TransformComponent)
-  const followCamera = getComponent(entity, FollowCameraComponent)
 
-  const minDistanceRatio = Math.min(followCamera.distance / followCamera.minDistance, 1)
-  const side = followCamera.shoulderSide ? -1 : 1
-  const shoulderOffset = lerp(0, 0.2, minDistanceRatio) * side
+  // const followCamera = getComponent(entity, FollowCameraComponent)
+  // const minDistanceRatio = Math.min(followCamera.distance / followCamera.minDistance, 1)
+  // const side = followCamera.shoulderSide ? -1 : 1
+  // const shoulderOffset = lerp(0, 0.2, minDistanceRatio) * side
   //const heightOffset = lerp(0, 0.25, minDistanceRatio)
 
-  target.set(shoulderOffset, 0.1, 0.2)
+  target.set(0, avatar.avatarHeight, 0.2)
   target.applyQuaternion(avatarTransform.rotation)
-  getAvatarBonePosition(entity, 'neck', tempVec1)
-  target.add(tempVec1)
+  target.add(avatarTransform.position)
 }
 
 const updateFollowCamera = (entity: Entity, delta: number) => {

--- a/packages/engine/src/camera/systems/CameraSystem.ts
+++ b/packages/engine/src/camera/systems/CameraSystem.ts
@@ -26,6 +26,8 @@ import { TargetCameraRotationComponent } from '../components/TargetCameraRotatio
 import { createConeOfVectors } from '../../common/functions/vectorHelpers'
 import { ObjectLayers } from '../../scene/constants/ObjectLayers'
 import { setObjectLayers } from '../../scene/functions/setObjectLayers'
+import { BoneNames } from '../../avatar/AvatarBoneMatching'
+import { IKRigComponent } from '../../ikrig/components/IKRigComponent'
 
 const direction = new Vector3()
 const quaternion = new Quaternion()
@@ -71,7 +73,7 @@ export const rotateViewVectorXZ = (viewVector: Vector3, angle: number, isDegree?
   return viewVector
 }
 
-const setAvatarOpacity = (entity: Entity, opacity: number): void => {
+export const setAvatarOpacity = (entity: Entity, opacity: number): void => {
   const object3DComponent = getComponent(entity, Object3DComponent)
   object3DComponent?.value.traverse((obj) => {
     if (!(obj as SkinnedMesh).isSkinnedMesh) return
@@ -82,18 +84,14 @@ const setAvatarOpacity = (entity: Entity, opacity: number): void => {
   })
 }
 
-const getAvatarBonePosition = (entity: Entity, name: string, position: Vector3): void => {
+export const getAvatarBonePosition = (entity: Entity, name: BoneNames, position: Vector3): void => {
   const object3DComponent = getComponent(entity, Object3DComponent)
-  object3DComponent?.value.traverse((obj) => {
-    const bone = obj as any
-    // TODO: Cache the neck bone reference
-    if (!bone.isBone || !bone.name.toLowerCase().includes(name)) return
-    const el = bone.matrixWorld.elements
-    position.set(el[12], el[13], el[14])
-  })
+  const ikRigComponent = getComponent(entity, IKRigComponent)
+  const el = ikRigComponent.boneStructure[name].matrixWorld.elements
+  position.set(el[12], el[13], el[14])
 }
 
-const updateAvatarOpacity = (entity: Entity) => {
+export const updateAvatarOpacity = (entity: Entity) => {
   if (!entity) return
 
   const followCamera = getComponent(entity, FollowCameraComponent)
@@ -102,7 +100,7 @@ const updateAvatarOpacity = (entity: Entity) => {
   setAvatarOpacity(entity, distanceRatio)
 }
 
-const updateCameraTargetRotation = (entity: Entity, delta: number) => {
+export const updateCameraTargetRotation = (entity: Entity, delta: number) => {
   if (!entity) return
   const followCamera = getComponent(entity, FollowCameraComponent)
   const target = getComponent(entity, TargetCameraRotationComponent)
@@ -119,7 +117,7 @@ const updateCameraTargetRotation = (entity: Entity, delta: number) => {
   followCamera.theta = smoothDamp(followCamera.theta, target.theta, target.thetaVelocity, target.time, delta)
 }
 
-const getMaxCamDistance = (entity: Entity, target: Vector3) => {
+export const getMaxCamDistance = (entity: Entity, target: Vector3) => {
   // Cache the raycast result for 0.1 seconds
   // if (camRayCastCache.maxDistance != -1 && camRayCastClock.getElapsedTime() < 0.1) {
   //   return camRayCastCache
@@ -176,7 +174,7 @@ const getMaxCamDistance = (entity: Entity, target: Vector3) => {
   return camRayCastCache
 }
 
-const calculateCameraTarget = (entity: Entity, target: Vector3) => {
+export const calculateCameraTarget = (entity: Entity, target: Vector3) => {
   const avatar = getComponent(entity, AvatarComponent)
   const avatarTransform = getComponent(entity, TransformComponent)
 
@@ -191,7 +189,7 @@ const calculateCameraTarget = (entity: Entity, target: Vector3) => {
   target.add(avatarTransform.position)
 }
 
-const updateFollowCamera = (entity: Entity, delta: number) => {
+export const updateFollowCamera = (entity: Entity, delta: number) => {
   if (!entity) return
 
   const followCamera = getComponent(entity, FollowCameraComponent)

--- a/packages/engine/src/ikrig/components/IKRigComponent.ts
+++ b/packages/engine/src/ikrig/components/IKRigComponent.ts
@@ -2,10 +2,12 @@ import { createMappedComponent } from '../../ecs/functions/ComponentFunctions'
 import Pose from '../classes/Pose'
 import { Chain } from '../classes/Chain'
 import { Object3D } from 'three'
+import { BoneStructure } from '../../avatar/AvatarBoneMatching'
 
 export type PointData = { index: number }
 
 export type IKRigComponentType = {
+  boneStructure: BoneStructure
   rootParent: Object3D
   tpose: Pose // Starting pose to calculate values from
   pose: Pose // Working pose to apply math to and copy back to bones

--- a/packages/engine/src/ikrig/functions/RigFunctions.ts
+++ b/packages/engine/src/ikrig/functions/RigFunctions.ts
@@ -50,6 +50,7 @@ function _addRig(
   if (hasComponent(entity, IKObj)) removeComponent(entity, IKObj)
   addComponent(entity, IKObj, { ref: skinnedMesh })
   const rig = addComponent(entity, componentClass, {
+    boneStructure: null!,
     rootParent: rootObject,
     tpose: new Pose(rootObject, true), // If Passing a TPose, it must have its world space computed.
     pose: new Pose(rootObject, false),

--- a/packages/engine/src/networking/systems/IncomingNetworkSystem.ts
+++ b/packages/engine/src/networking/systems/IncomingNetworkSystem.ts
@@ -14,7 +14,7 @@ import { pipe } from 'bitecs'
 import { XRHandsInputComponent } from '../../xr/components/XRHandsInputComponent'
 import { Group } from 'three'
 import { AvatarComponent } from '../../avatar/components/AvatarComponent'
-import { avatarHalfHeight } from '../../avatar/functions/createAvatar'
+import { defaultAvatarHalfHeight } from '../../avatar/functions/createAvatar'
 import { NetworkObjectOwnedTag } from '../components/NetworkObjectOwnedTag'
 import { deepEqual } from '../../common/functions/deepEqual'
 import { Engine } from '../../ecs/classes/Engine'
@@ -93,7 +93,7 @@ export const applyUnreliableQueue = (networkInstance: Network) => (world: World)
           const rot = pose.rotation
 
           // TODO: Find a cleaner way to shift the avatar's capsule
-          const yOffset = isAvatar ? avatarHalfHeight : 0
+          const yOffset = isAvatar ? defaultAvatarHalfHeight : 0
 
           collider.body.setGlobalPose(
             {

--- a/packages/engine/src/xr/systems/XRSystem.ts
+++ b/packages/engine/src/xr/systems/XRSystem.ts
@@ -109,7 +109,6 @@ export default async function XRSystem(world: World) {
           if (Math.abs(inputData[1]) < 0.05) {
             inputData[1] = 0
           }
-          console.log(inputData)
           Engine.inputState.set(mapping.axes, {
             type: InputType.TWODIM,
             value: inputData,


### PR DESCRIPTION
## Summary

- adds a type for the bone structure for caching and easy access.
- improves camera targeting by targeting the eye height and removing the shoulder offset to reduce user control complexity

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

https://github.com/XRFoundation/XREngine/issues/4915

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
