### PR TITLE
Installing git package in most dockerfiles

### DIFF
--- a/dockerfiles/client/Dockerfile-client
+++ b/dockerfiles/client/Dockerfile-client
@@ -6,7 +6,7 @@ RUN apt update
 # Create app directory
 WORKDIR /app
 
-RUN apt-get -y install python3-pip
+RUN apt-get -y install python3-pip git
 
 COPY package.json .
 COPY packages/client/package.json ./packages/client/

--- a/dockerfiles/gameserver/Dockerfile-gameserver
+++ b/dockerfiles/gameserver/Dockerfile-gameserver
@@ -3,7 +3,7 @@
 FROM node:16-buster-slim as builder
 
 RUN apt update
-RUN apt-get install build-essential meson python3-testresources python3-venv python3-pip -y
+RUN apt-get -y install build-essential meson python3-testresources python3-venv python3-pip git
 # Create app directory
 WORKDIR /app
 

--- a/dockerfiles/testbot/Dockerfile-testbot
+++ b/dockerfiles/testbot/Dockerfile-testbot
@@ -6,7 +6,7 @@ RUN apt update
 # Create app directory
 WORKDIR /app
 
-RUN apt-get -y install python3-pip
+RUN apt-get -y install python3-pip  git
 
 RUN apt update && apt install -y libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 libgbm-dev lsb-release xdg-utils wget
 


### PR DESCRIPTION
## Summary

buster-slim image doesn't have git installed, and it seems it's needed if some
packages are being pulled from Github rather than npm.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
