### PR TITLE
Installing project dependencies in analytics/api/gameserver.

### DIFF
--- a/dockerfiles/analytics/Dockerfile-analytics
+++ b/dockerfiles/analytics/Dockerfile-analytics
@@ -15,6 +15,7 @@ COPY packages/common/package.json ./packages/common/
 COPY packages/engine/package.json ./packages/engine/
 COPY packages/matchmaking/package.json ./packages/matchmaking/
 COPY packages/server-core/package.json ./packages/server-core/
+COPY project-package-jsons ./
 
 RUN npm install --production=false --loglevel notice --legacy-peer-deps
 

--- a/dockerfiles/api/Dockerfile-api
+++ b/dockerfiles/api/Dockerfile-api
@@ -16,6 +16,7 @@ COPY packages/projects/package.json ./packages/projects/
 COPY packages/matchmaking/package.json ./packages/matchmaking/
 COPY packages/server/package.json ./packages/server/
 COPY packages/server-core/package.json ./packages/server-core/
+COPY project-package-jsons ./
 
 RUN npm install --production=false --loglevel notice --legacy-peer-deps
 

--- a/dockerfiles/gameserver/Dockerfile-gameserver
+++ b/dockerfiles/gameserver/Dockerfile-gameserver
@@ -17,6 +17,7 @@ COPY packages/gameserver/package.json ./packages/gameserver/
 COPY packages/matchmaking/package.json ./packages/matchmaking/
 COPY packages/projects/package.json ./packages/projects/
 COPY packages/server-core/package.json ./packages/server-core/
+COPY project-package-jsons ./
 
 RUN npm install --production=false --loglevel notice --legacy-peer-deps
 

--- a/scripts/publish_ecr.sh
+++ b/scripts/publish_ecr.sh
@@ -11,18 +11,18 @@ REGION=$5
 if [ $PRIVATE_ECR == "true" ]
 then
   aws ecr get-login-password --region $REGION | docker login -u AWS --password-stdin $ECR_URL
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-analytics --region $REGION --public false
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-api --region $REGION --public false
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-client --region $REGION --public false
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-gameserver --region $REGION --public false
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-testbot --region $REGION --public false
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-analytics --region $REGION
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-api --region $REGION
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-client --region $REGION
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-gameserver --region $REGION
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-testbot --region $REGION
 else
   aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $ECR_URL
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-analytics --region us-east-1 --public true
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-api --region us-east-1 --public true
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-client --region us-east-1 --public true
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-gameserver --region us-east-1 --public true
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-testbot --region us-east-1 --public true
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-analytics --region us-east-1 --public
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-api --region us-east-1 --public
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-client --region us-east-1 --public
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-gameserver --region us-east-1 --public
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-testbot --region us-east-1 --public
 fi
 
 docker tag $LABEL-analytics $ECR_URL/$REPO_NAME-analytics:$TAG & docker tag $LABEL-analytics $ECR_URL/$REPO_NAME-analytics:latest_$STAGE & \

--- a/scripts/publish_ecr_builder.sh
+++ b/scripts/publish_ecr_builder.sh
@@ -11,10 +11,10 @@ REGION=$5
 if [ $PRIVATE_ECR == "true" ]
 then
   aws ecr get-login-password --region $REGION | docker login -u AWS --password-stdin $ECR_URL
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-builder --region $REGION --public false
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-builder --region $REGION
 else
   aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $ECR_URL
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-builder --region us-east-1 --public true
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-builder --region us-east-1 --public
 fi
 
 docker tag $LABEL $ECR_URL/$REPO_NAME-builder:$TAG


### PR DESCRIPTION
## Summary

For some reason, only client was installing project dependencies.

Fixed publish_ecr.sh and publish_ecr_builder.sh to omit --public flag
on private repos. I thought setting them as booleans would translate them
as booleans, but 'cli' actually just parses whether the flag is present at all.
A summary of changes being made in this PR

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

References to pertaining issue(s)

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @speigg @NateTheGreatt
