### PR TITLE
push client input events onto a queue

### DIFF
--- a/packages/client-core/src/common/components/TouchGamepad/index.tsx
+++ b/packages/client-core/src/common/components/TouchGamepad/index.tsx
@@ -77,24 +77,6 @@ export const TouchGamepad: FunctionComponent<TouchGamepadProps> = () => {
     })
 
     stickLeft.on('move', (e, data) => {
-      const canvasElement = EngineRenderer.instance?.canvas
-      if (!canvasElement) return
-      //@ts-ignore
-      if (canvasElement.addEventListener) {
-        addClientInputListeners(canvasElement)
-      } else {
-        if ((canvasElement as any).attachEvent) {
-          ;(canvasElement as any)
-            .attachEvent('touchstart', function (e) {
-              handleTouch(e)
-              handleTouchMove(e)
-            })(canvasElement as any)
-            .attachEvent('touchend', handleTouch)
-            .attachEvent('touchcancel', handleTouch)
-            .attachEvent('touchmove', handleTouchMove)
-        }
-      }
-
       const event = new CustomEvent('touchstickmove', {
         detail: {
           stick: GamepadAxis.Left,

--- a/packages/engine/src/ecs/classes/Engine.ts
+++ b/packages/engine/src/ecs/classes/Engine.ts
@@ -78,7 +78,7 @@ export class Engine {
    */
   static audioListener: any = null
 
-  static inputQueue = new Map<string, { callback: (event: Event) => void; event: Event }>()
+  static inputQueue = [] as Array<{ callback: (event: Event) => void; event: Event }>
   static inputState = new Map<any, InputValue>()
   static prevInputState = new Map<any, InputValue>()
 

--- a/packages/engine/src/ecs/classes/Engine.ts
+++ b/packages/engine/src/ecs/classes/Engine.ts
@@ -78,6 +78,7 @@ export class Engine {
    */
   static audioListener: any = null
 
+  static inputQueue = new Map<string, { callback: (event: Event) => void; event: Event }>()
   static inputState = new Map<any, InputValue>()
   static prevInputState = new Map<any, InputValue>()
 

--- a/packages/engine/src/ecs/classes/Engine.ts
+++ b/packages/engine/src/ecs/classes/Engine.ts
@@ -78,7 +78,6 @@ export class Engine {
    */
   static audioListener: any = null
 
-  static inputQueue = [] as Array<{ callback: (event: Event) => void; event: Event }>
   static inputState = new Map<any, InputValue>()
   static prevInputState = new Map<any, InputValue>()
 

--- a/packages/engine/src/initializeEngine.ts
+++ b/packages/engine/src/initializeEngine.ts
@@ -20,7 +20,7 @@ import { EngineEvents } from './ecs/classes/EngineEvents'
 import { reset } from './ecs/functions/EngineFunctions'
 import { initSystems, SystemModuleType } from './ecs/functions/SystemFunctions'
 import { SystemUpdateType } from './ecs/functions/SystemUpdateType'
-import { addClientInputListeners, removeClientInputListeners } from './input/functions/clientInputListeners'
+import { removeClientInputListeners } from './input/functions/clientInputListeners'
 import { Network } from './networking/classes/Network'
 import { FontManager } from './xrui/classes/FontManager'
 import { createWorld, World } from './ecs/classes/World'
@@ -81,9 +81,6 @@ export const initializeBrowser = () => {
     Engine.hasJoinedWorld = true
   }
   receiveActionOnce(EngineEvents.EVENTS.JOINED_WORLD, joinedWorld)
-
-  const canvas = document.querySelector('canvas')!
-  addClientInputListeners(canvas)
 
   setupInitialClickListener()
 

--- a/packages/engine/src/input/functions/clientInputListeners.ts
+++ b/packages/engine/src/input/functions/clientInputListeners.ts
@@ -14,6 +14,7 @@ import {
   handleWindowFocus
 } from '../schema/ClientInputSchema'
 import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
+import { isClient } from '../../common/functions/isClient'
 
 const supportsPassive = (function () {
   let supportsPassiveValue = false
@@ -51,6 +52,7 @@ interface ListenerBindingData {
 const boundListeners: ListenerBindingData[] = []
 
 export const addClientInputListeners = () => {
+  if (!isClient) return
   const canvas = EngineRenderer.instance.canvas
 
   window.addEventListener('DOMMouseScroll', preventDefault, false)

--- a/packages/engine/src/input/functions/clientInputListeners.ts
+++ b/packages/engine/src/input/functions/clientInputListeners.ts
@@ -13,7 +13,6 @@ import {
   handleVisibilityChange,
   handleWindowFocus
 } from '../schema/ClientInputSchema'
-import { Engine } from '../../ecs/classes/Engine'
 import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 
 const supportsPassive = (function () {
@@ -58,19 +57,15 @@ export const addClientInputListeners = () => {
   window.addEventListener('keydown', preventDefaultForScrollKeys, false)
 
   const addListener = (domElement, eventName, callback: (event: Event) => void, passive = false) => {
-    const listener = (event: Event) => {
-      Engine.inputQueue.push({ callback, event })
-    }
-
     if (passive && supportsPassive) {
-      domElement.addEventListener(eventName, listener, { passive })
+      domElement.addEventListener(eventName, callback, { passive })
     } else {
-      domElement.addEventListener(eventName, listener)
+      domElement.addEventListener(eventName, callback)
     }
     boundListeners.push({
       domElement,
       eventName,
-      callback: listener
+      callback
     })
   }
 

--- a/packages/engine/src/input/functions/clientInputListeners.ts
+++ b/packages/engine/src/input/functions/clientInputListeners.ts
@@ -59,7 +59,7 @@ export const addClientInputListeners = () => {
 
   const addListener = (domElement, eventName, callback: (event: Event) => void, passive = false) => {
     const listener = (event: Event) => {
-      Engine.inputQueue.set(eventName, { callback, event })
+      Engine.inputQueue.push({ callback, event })
     }
 
     if (passive && supportsPassive) {

--- a/packages/engine/src/input/systems/ClientInputSystem.ts
+++ b/packages/engine/src/input/systems/ClientInputSystem.ts
@@ -28,10 +28,10 @@ export default async function ClientInputSystem(world: World) {
     }
 
     // run all queued events detected since the last frame
-    for (const { callback, event } of Engine.inputQueue.values()) {
+    for (const { callback, event } of Engine.inputQueue) {
       callback(event)
     }
-    Engine.inputQueue.clear()
+    Engine.inputQueue = []
 
     // for continuous input, figure out if the current data and previous data is the same
     Engine.inputState.forEach((value: InputValue, key: InputAlias) => {

--- a/packages/engine/src/input/systems/ClientInputSystem.ts
+++ b/packages/engine/src/input/systems/ClientInputSystem.ts
@@ -27,12 +27,6 @@ export default async function ClientInputSystem(world: World) {
       handleGamepads()
     }
 
-    // run all queued events detected since the last frame
-    for (const { callback, event } of Engine.inputQueue) {
-      callback(event)
-    }
-    Engine.inputQueue = []
-
     // for continuous input, figure out if the current data and previous data is the same
     Engine.inputState.forEach((value: InputValue, key: InputAlias) => {
       if (Engine.prevInputState.has(key)) {


### PR DESCRIPTION
## Summary

When the animation frame rate and the DOM input rate are not the same, we were discarding all but the last event between each frame. Now these are put on a queue, and are all processed inside the ECS loop.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References



## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@speigg 
