### PR TITLE
New netcode hotfix

### DIFF
--- a/packages/engine/src/avatar/functions/createAvatar.ts
+++ b/packages/engine/src/avatar/functions/createAvatar.ts
@@ -39,15 +39,13 @@ export const createAvatar = (spawnAction: typeof NetworkWorldAction.spawnAvatar.
   const entity = world.getNetworkObject(spawnAction.$from, spawnAction.networkId)
 
   const position = createVector3Proxy(TransformComponent.position, entity)
-
   const rotation = createQuaternionProxy(TransformComponent.rotation, entity)
-  // todo: figure out why scale makes avatar disappear
-  // const scale = createVector3Proxy(TransformComponent.scale, entity)
-  const scale = new Vector3().copy(new Vector3(1, 1, 1))
+  const scale = createVector3Proxy(TransformComponent.scale, entity)
 
   const transform = addComponent(entity, TransformComponent, { position, rotation, scale })
   transform.position.copy(spawnAction.parameters.position)
   transform.rotation.copy(spawnAction.parameters.rotation)
+  transform.scale.copy(new Vector3(1, 1, 1))
 
   const velocity = createVector3Proxy(VelocityComponent.velocity, entity)
 

--- a/packages/engine/src/scene/functions/loaders/TransformFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/TransformFunctions.test.ts
@@ -8,8 +8,7 @@ import { createEntity } from '../../../ecs/functions/EntityFunctions'
 import { TransformComponent } from '../../../transform/components/TransformComponent'
 import { deserializeTransform } from './TransformFunctions'
 
-// need to control for rounding point errors with SoA
-const EPSILON = 10e-5
+const EPSILON = 10e-8
 
 describe('TransformFunctions', () => {
   it('deserializeTransform', () => {
@@ -22,7 +21,7 @@ describe('TransformFunctions', () => {
     const sceneComponentData = {
       position: { x: 1, y: 2, z: 3 },
       rotation: { x: euler.x, y: euler.y, z: euler.z },
-      scale: { x: 0.1, y: 0.2, z: 0.3 }
+      scale: { x: 1.25, y: 2.5, z: 5 }
     }
     const sceneComponent: ComponentJson = {
       name: 'transform',
@@ -43,8 +42,8 @@ describe('TransformFunctions', () => {
     assert(Math.abs(rotation.z) - Math.abs(quat.z) < EPSILON)
     assert(Math.abs(rotation.w) - Math.abs(quat.w) < EPSILON)
 
-    assert(scale.x - 0.1 < EPSILON)
-    assert(scale.y - 0.2 < EPSILON)
-    assert(scale.z - 0.3 < EPSILON)
+    assert.equal(scale.x, 1.25)
+    assert.equal(scale.y, 2.5)
+    assert.equal(scale.z, 5)
   })
 })

--- a/packages/engine/src/scene/functions/loaders/TransformFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/TransformFunctions.test.ts
@@ -8,7 +8,8 @@ import { createEntity } from '../../../ecs/functions/EntityFunctions'
 import { TransformComponent } from '../../../transform/components/TransformComponent'
 import { deserializeTransform } from './TransformFunctions'
 
-const EPSILON = 10e-9
+// need to control for rounding point errors with SoA
+const EPSILON = 10e-5
 
 describe('TransformFunctions', () => {
   it('deserializeTransform', () => {
@@ -42,8 +43,8 @@ describe('TransformFunctions', () => {
     assert(Math.abs(rotation.z) - Math.abs(quat.z) < EPSILON)
     assert(Math.abs(rotation.w) - Math.abs(quat.w) < EPSILON)
 
-    assert.equal(scale.x, 0.1)
-    assert.equal(scale.y, 0.2)
-    assert.equal(scale.z, 0.3)
+    assert(scale.x - 0.1 < EPSILON)
+    assert(scale.y - 0.2 < EPSILON)
+    assert(scale.z - 0.3 < EPSILON)
   })
 })

--- a/packages/engine/src/scene/functions/loaders/TransformFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/TransformFunctions.ts
@@ -6,6 +6,7 @@ import { ComponentDeserializeFunction, ComponentSerializeFunction } from '../../
 import { TransformComponent, TransformComponentType } from '../../../transform/components/TransformComponent'
 import { Engine } from '../../../ecs/classes/Engine'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
+import { createQuaternionProxy, createVector3Proxy } from '../../../common/proxies/three'
 
 export const SCENE_COMPONENT_TRANSFORM = 'transform'
 export const SCENE_COMPONENT_TRANSFORM_DEFAULT_VALUES = {
@@ -22,7 +23,15 @@ export const deserializeTransform: ComponentDeserializeFunction = (
   json: ComponentJson<TransformComponentType>
 ) => {
   const props = parseTransformProperties(json.props)
-  addComponent(entity, TransformComponent, props)
+
+  const position = createVector3Proxy(TransformComponent.position, entity)
+  const rotation = createQuaternionProxy(TransformComponent.rotation, entity)
+  const scale = createVector3Proxy(TransformComponent.scale, entity)
+
+  const transform = addComponent(entity, TransformComponent, { position, rotation, scale })
+  transform.position.copy(props.position)
+  transform.rotation.copy(props.rotation)
+  transform.scale.copy(props.scale)
 
   if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_TRANSFORM)
 }


### PR DESCRIPTION
## Summary

Fix issue where any scene object other than avatars were not syncing over the network because vector proxification required by the new netcode was not being done for their transform components.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

@HexaField @NateTheGreatt @speigg 
