### PR TITLE
added invalidate cache button in project admin page

### DIFF
--- a/packages/client-core/src/admin/components/Project/ProjectTable.tsx
+++ b/packages/client-core/src/admin/components/Project/ProjectTable.tsx
@@ -1,4 +1,5 @@
 import Cached from '@mui/icons-material/Cached'
+import CleaningServicesIcon from '@mui/icons-material/CleaningServices'
 import Cross from '@mui/icons-material/Cancel'
 import Button from '@mui/material/Button'
 import Grid from '@mui/material/Grid'
@@ -36,6 +37,7 @@ const Projects = () => {
     // { id: 'id', numeric: false, disablePadding: true, label: 'ID' },
     { id: 'name', numeric: false, disablePadding: false, label: 'Name' },
     { id: 'update', numeric: false, disablePadding: true, label: 'Update' },
+    { id: 'invalidate', numeric: false, disablePadding: false, label: 'Invalidate Cache' },
     { id: 'remove', numeric: false, disablePadding: false, label: 'Remove' }
   ]
 
@@ -124,6 +126,7 @@ const Projects = () => {
     width: window.innerWidth
   })
   const [popupReuploadConfirmOpen, setPopupReuploadConfirmOpen] = useState(false)
+  const [popupInvalidateConfirmOpen, setPopupInvalidateConfirmOpen] = useState(false)
   const [popupRemoveConfirmOpen, setPopupRemoveConfirmOpen] = useState(false)
   const [project, setProject] = useState<ProjectInterface>(null!)
 
@@ -177,6 +180,14 @@ const Projects = () => {
       console.log(err)
     }
   }
+  const handleInvalidateCache = async () => {
+    try {
+      setPopupInvalidateConfirmOpen(false)
+      await ProjectService.invalidateProjectCache(project.name)
+    } catch (err) {
+      console.log(err)
+    }
+  }
 
   const onOpenUploadModal = () => {
     GithubAppService.fetchGithubAppRepos()
@@ -213,6 +224,11 @@ const Projects = () => {
     setPopupReuploadConfirmOpen(true)
   }
 
+  const handleOpenInvaliateConfirmation = (row) => {
+    setProject(row)
+    setPopupInvalidateConfirmOpen(true)
+  }
+
   const handleOpenRemoveConfirmation = (row) => {
     setProject(row)
     setPopupRemoveConfirmOpen(true)
@@ -221,6 +237,11 @@ const Projects = () => {
   const handleCloseReuploadModel = () => {
     setProject(null!)
     setPopupReuploadConfirmOpen(false)
+  }
+
+  const handleCloseInvalidateModel = () => {
+    setProject(null!)
+    setPopupInvalidateConfirmOpen(false)
   }
 
   const handleCloseRemoveModel = () => {
@@ -297,6 +318,18 @@ const Projects = () => {
                       {user.userRole.value === 'admin' && (
                         <Button
                           className={styles.checkbox}
+                          onClick={() => handleOpenInvaliateConfirmation(row)}
+                          name="stereoscopic"
+                          color="primary"
+                        >
+                          <CleaningServicesIcon />
+                        </Button>
+                      )}
+                    </TableCell>
+                    <TableCell className={styles.tcell} align="right">
+                      {user.userRole.value === 'admin' && (
+                        <Button
+                          className={styles.checkbox}
                           onClick={() => handleOpenRemoveConfirmation(row)}
                           name="stereoscopic"
                           color="primary"
@@ -336,6 +369,14 @@ const Projects = () => {
           name={project?.name}
           label={'project'}
           type="rebuild"
+        />
+        <ConfirmModel
+          popConfirmOpen={popupInvalidateConfirmOpen}
+          handleCloseModel={handleCloseInvalidateModel}
+          submit={handleInvalidateCache}
+          name={project?.name}
+          label={"storage provider's cache of"}
+          type="invalidates"
         />
         <ConfirmModel
           popConfirmOpen={popupRemoveConfirmOpen}

--- a/packages/client-core/src/admin/components/Project/Projects.module.scss
+++ b/packages/client-core/src/admin/components/Project/Projects.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/imports.module.scss";
+@import '../../../styles/imports.module.scss';
 
 .admin {
   display: flex;
@@ -24,7 +24,7 @@
   }
 }
 
-.buttonConatiner{
+.buttonConatiner {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -88,21 +88,21 @@
 .thead {
   .trow {
     .tcell {
-      color: lighten(white, 0.80);
+      color: lighten(white, 0.8);
       background-color: #343b41;
     }
 
     .tcellSelectable {
-      .currentUser{
-        color: lighten(white, 0.80);
+      .currentUser {
+        color: lighten(white, 0.8);
         background-color: $FacebookBlue;
         padding-top: 5px;
         padding-bottom: 5px;
         &:hover {
-          background-color: #145cee;;
+          background-color: #145cee;
           cursor: pointer;
         }
-       }
+      }
     }
   }
 
@@ -110,7 +110,7 @@
     cursor: pointer;
 
     .tcell {
-      color: lighten(white, 0.80);
+      color: lighten(white, 0.8);
       background-color: black;
     }
   }
@@ -119,11 +119,12 @@
 .tableContainer {
   flex-grow: 1;
   width: 100%;
-  background-color: #43484F;
+  background-color: #43484f;
   //color: #f1f1f1 !important;
 
   * {
     color: #f1f1f1 !important;
+    text-align: center;
   }
 }
 .tablePagination {
@@ -134,7 +135,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  background-color: #15171B !important;
+  background-color: #15171b !important;
   color: #fff !important;
 }
 
@@ -215,7 +216,7 @@
 }
 
 .checkbox {
-  margin: 0px; 
+  margin: 0px;
   padding: 0px;
   color: white;
 }

--- a/packages/client-core/src/common/services/ProjectService.ts
+++ b/packages/client-core/src/common/services/ProjectService.ts
@@ -64,6 +64,15 @@ export const ProjectService = {
   triggerReload: async () => {
     const result = await client.service('project-build').patch({ rebuild: true })
     console.log('Remove project result', result)
+  },
+
+  invalidateProjectCache: async (projectName: string) => {
+    try {
+      await client.service('project-invalidate').patch({ projectName })
+      ProjectService.fetchProjects()
+    } catch (err) {
+      console.log(err)
+    }
   }
 }
 // TODO

--- a/packages/client-core/src/common/services/ProjectService.ts
+++ b/packages/client-core/src/common/services/ProjectService.ts
@@ -66,6 +66,7 @@ export const ProjectService = {
     console.log('Remove project result', result)
   },
 
+  // restricted to admin scope
   invalidateProjectCache: async (projectName: string) => {
     try {
       await client.service('project-invalidate').patch({ projectName })

--- a/packages/server-core/src/projects/project/project.service.ts
+++ b/packages/server-core/src/projects/project/project.service.ts
@@ -5,6 +5,7 @@ import createModel from './project.model'
 import projectDocs from './project.docs'
 import { retriggerBuilderService } from './project-helper'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
+import { useStorageProvider } from '../../media/storageprovider/storageprovider'
 import authenticate from '../../hooks/authenticate'
 
 declare module '../../../declarations' {
@@ -32,6 +33,14 @@ export default (app: Application): void => {
     patch: async ({ rebuild }, params) => {
       if (rebuild) {
         return await retriggerBuilderService(app)
+      }
+    }
+  })
+
+  app.use('project-invalidate', {
+    patch: async ({ projectName }, params) => {
+      if (projectName) {
+        return await useStorageProvider().createInvalidation([`projects/${projectName}*`])
       }
     }
   })

--- a/packages/server-core/src/projects/project/project.service.ts
+++ b/packages/server-core/src/projects/project/project.service.ts
@@ -51,6 +51,12 @@ export default (app: Application): void => {
     }
   })
 
+  app.service('project-invalidate').hooks({
+    before: {
+      patch: [authenticate(), restrictUserRole('admin')]
+    }
+  })
+
   const service = app.service('project')
 
   service.hooks(hooks)


### PR DESCRIPTION
## Summary

_A summary of changes being made in this PR_
Admin can invalidate the storage provider's cache

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References
#4153 

closes https://github.com/XRFoundation/XREngine/issues/4153

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
