### PR TITLE
Fixed bug with loading initial layer users.

### DIFF
--- a/packages/client-core/src/components/World/NetworkInstanceProvisioning.tsx
+++ b/packages/client-core/src/components/World/NetworkInstanceProvisioning.tsx
@@ -136,7 +136,7 @@ export const NetworkInstanceProvisioning = (props: Props) => {
   // periodically listening for users spatially near
   useEffect(() => {
     if (selfUser?.instanceId.value != null && userState.layerUsersUpdateNeeded.value) UserService.getLayerUsers(true)
-  }, [selfUser, userState.layerUsersUpdateNeeded.value])
+  }, [selfUser?.instanceId.value, userState.layerUsersUpdateNeeded.value])
 
   // if a media connection has been provisioned and is ready, connect to it
   useEffect(() => {


### PR DESCRIPTION
## Summary

useEffect that calls getLayerUsers() was listening to selfUser instead
of selfUser.instanceId.value.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
