### PR TITLE
Fix arrow key default behavior

### DIFF
--- a/packages/client-core/src/components/Layout/Layout.module.scss
+++ b/packages/client-core/src/components/Layout/Layout.module.scss
@@ -1,5 +1,9 @@
 @import "@xrengine/client-core/src/styles/imports.module.scss";
 
+body {
+    overflow: hidden;
+}
+
 .container {
     display: flex;
     flex-direction: row;

--- a/packages/engine/src/input/functions/clientInputListeners.ts
+++ b/packages/engine/src/input/functions/clientInputListeners.ts
@@ -21,14 +21,6 @@ const keys = { 37: 1, 38: 1, 39: 1, 40: 1 }
 function preventDefault(e) {
   e.preventDefault()
 }
-
-function preventDefaultForScrollKeys(e) {
-  if (keys[e.keyCode]) {
-    preventDefault(e)
-    return false
-  }
-}
-
 interface ListenerBindingData {
   domElement: any
   eventName: string
@@ -42,7 +34,6 @@ export const addClientInputListeners = () => {
   const canvas = EngineRenderer.instance.canvas
 
   window.addEventListener('DOMMouseScroll', preventDefault, false)
-  window.addEventListener('keydown', preventDefaultForScrollKeys, false)
   window.addEventListener('touchmove', preventDefault, { capture: true, passive: false })
 
   const addListener = (
@@ -103,7 +94,6 @@ export const removeClientInputListeners = () => {
   if (!boundListeners.length) return
 
   window.removeEventListener('DOMMouseScroll', preventDefault, false)
-  window.removeEventListener('keydown', preventDefaultForScrollKeys, false)
   window.removeEventListener('touchmove', preventDefault, { capture: true })
 
   boundListeners.forEach(({ domElement, eventName, callback }) => {
@@ -111,3 +101,5 @@ export const removeClientInputListeners = () => {
   })
   boundListeners.splice(0, boundListeners.length - 1)
 }
+
+export default {}


### PR DESCRIPTION
We don't want to disable arrow key default behaviors (useful for moving text cursor during input). Page scrolling / bounce issues are addressed by other means.

## Summary

_A summary of changes being made in this PR_

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
