### PR TITLE
Fixed issues with audio/video systems and gameserver shutdown.

### DIFF
--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -43,7 +43,7 @@ export async function onConnectToInstance(networkTransport: SocketWebRTCClientTr
 
   const authState = accessAuthState()
   const token = authState.authUser.accessToken.value
-  const payload = { userId: Engine.userId, accessToken: token }
+  const payload = { accessToken: token }
 
   const { success } = await new Promise<any>((resolve) => {
     const interval = setInterval(async () => {

--- a/packages/engine/src/initializeEngine.ts
+++ b/packages/engine/src/initializeEngine.ts
@@ -145,6 +145,10 @@ export const initializeMediaServerSystems = async () => {
     {
       type: SystemUpdateType.FIXED_LATE,
       systemModulePromise: import('./ecs/functions/ActionCleanupSystem')
+    },
+    {
+      type: SystemUpdateType.PRE_RENDER,
+      systemModulePromise: import('./networking/systems/MediaStreamSystem')
     }
   )
 
@@ -341,15 +345,8 @@ export const initializeSceneSystems = async () => {
   await initSystems(world, systemsToLoad)
 }
 
-export const initializeRealtimeSystems = async (media = true, pose = true) => {
+export const initializeRealtimeSystems = async (pose = true) => {
   const systemsToLoad: SystemModuleType<any>[] = []
-
-  if (media) {
-    systemsToLoad.push({
-      type: SystemUpdateType.PRE_RENDER,
-      systemModulePromise: import('./networking/systems/MediaStreamSystem')
-    })
-  }
 
   if (pose) {
     systemsToLoad.push(

--- a/packages/gameserver/src/channels.ts
+++ b/packages/gameserver/src/channels.ts
@@ -474,7 +474,9 @@ export default (app: Application): void => {
 
         if (instanceId != null && instance != null) {
           const activeClients = Engine.currentWorld.clients
-          const activeUsers = new Map([...activeClients].filter(([, v]) => v.name !== Engine.userId))
+          const activeUsers = new Map(
+            [...activeClients].filter(([, v]) => v.userId !== Engine.userId && v.userId !== user.id)
+          )
           const activeUsersCount = activeUsers.size
           try {
             await app.service('instance').patch(instanceId, {
@@ -484,7 +486,6 @@ export default (app: Application): void => {
             console.log('Failed to patch instance user count, likely because it was destroyed')
           }
 
-          const user = await app.service('user').get(userId)
           const instanceIdKey = app.isChannelInstance ? 'channelInstanceId' : 'instanceId'
           // Patch the user's (channel)instanceId to null if they're leaving this instance.
           // But, don't change their (channel)instanceId if it's already something else.
@@ -524,6 +525,7 @@ export default (app: Application): void => {
 
           if (activeUsersCount < 1) {
             shutdownTimeout = setTimeout(async () => {
+              engineStarted = false
               console.log('Deleting instance ' + instanceId)
               try {
                 await app.service('instance').patch(instanceId, {

--- a/scripts/start-all-docker.sh
+++ b/scripts/start-all-docker.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+docker start xrengine_db
+docker start xrengine_redis
+docker start xrengine_minikube_db
+docker start xrengine_test_db


### PR DESCRIPTION
## Summary

Gameservers were including the disconnecting user in their list of activeUsers, which would cause them to
never shut down. For local development, added `engineStarted = false` as part of shutdown so that they can
be started anew.

MediaStreamSystem was only being started by initializeRealtimeSystems, which was only ever called by world
servers. Moved its inclusion in startup to initializeMediaServerSystems.

Updated Authorization handler. Previously, it was looking for an accessToken and userId on incoming data, but doing
nothing with the token. Sometimes the client wouldn't have a resolved userId when it made that call, leading
to no Authorization and the process hanging. Removed userId from the call, and now the user is fetched by
authenticating the token.

Fixed some issues that came about from the inclusion of the 'media' client. Since it doesn't have a socket or media value,
references to client.socket!.emit or client.media[whatever] would throw errors - now checking that client.socket is not null.
Also fixed problem in sendCurrentProducers where encountering any client that didn't have media to send or didn't have a
socket would kill iterating over all the clients.

Added a script 'start-all-docker.sh' that tries to start all four local Docker services.

Simplified some boolean comparisons.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
