### PR TITLE
fix entity undefined in data reader

### DIFF
--- a/packages/engine/src/networking/serialization/DataReader.test.ts
+++ b/packages/engine/src/networking/serialization/DataReader.test.ts
@@ -449,6 +449,55 @@ describe('DataReader', () => {
     strictEqual(TransformComponent.rotation.y[entity], 0)
     strictEqual(TransformComponent.rotation.z[entity], 0)
     strictEqual(TransformComponent.rotation.w[entity], 0)
+
+    // should update the view cursor accordingly
+    strictEqual(view.cursor, 204)
+  })
+
+  it('should not readEntity if entity is undefined', () => {
+    // this test does not configure the entity in the network objects nor give it the network components
+    // it should not read from network but update the cursor
+
+    const view = createViewCursor()
+    const entity = createEntity()
+    const networkId = 5678 as NetworkId
+    const userId = 'user Id' as UserId
+    Engine.userId = userId
+    const userIndex = 0
+
+    Engine.currentWorld.userIndexToUserId = new Map([[userIndex, userId]])
+    Engine.currentWorld.userIdToUserIndex = new Map([[userId, userIndex]])
+
+    const [x, y, z, w] = [1.5, 2.5, 3.5, 4.5]
+
+    const transform = addComponent(entity, TransformComponent, {
+      position: createVector3Proxy(TransformComponent.position, entity).set(x, y, z),
+      rotation: createQuaternionProxy(TransformComponent.rotation, entity).set(x, y, z, w),
+      scale: new Vector3(1, 1, 1)
+    })
+
+    writeEntity(view, userIndex, networkId, entity)
+
+    view.cursor = 0
+
+    // reset data on transform component
+    transform.position.set(0, 0, 0)
+    transform.rotation.set(0, 0, 0, 0)
+
+    // read entity will populate data stored in 'view'
+    readEntity(view, Engine.currentWorld)
+
+    // should no repopulate as entity is not listed in network entities
+    strictEqual(TransformComponent.position.x[entity], 0)
+    strictEqual(TransformComponent.position.y[entity], 0)
+    strictEqual(TransformComponent.position.z[entity], 0)
+    strictEqual(TransformComponent.rotation.x[entity], 0)
+    strictEqual(TransformComponent.rotation.y[entity], 0)
+    strictEqual(TransformComponent.rotation.z[entity], 0)
+    strictEqual(TransformComponent.rotation.w[entity], 0)
+
+    // should update the view cursor accordingly
+    strictEqual(view.cursor, 204)
   })
 
   it('should readEntities', () => {

--- a/packages/engine/src/networking/serialization/DataReader.ts
+++ b/packages/engine/src/networking/serialization/DataReader.ts
@@ -149,6 +149,11 @@ export const readEntity = (v: ViewCursor, world: World) => {
 
   const entity = world.getNetworkObject(userId, netId)
 
+  if (!entity) {
+    scrollViewCursor(v, EntityDataByteLength)
+    return
+  }
+
   // don't apply input state if we have authority
   const weHaveAuthority = hasComponent(entity, NetworkObjectAuthorityTag)
   if (weHaveAuthority) {


### PR DESCRIPTION
## Summary

Fixes a crash where a pose packet can come after a user entity has been destroyed.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
