### PR TITLE
Fixed some issues encountered when testing on minikube.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,7 @@
 FROM node:16-buster-slim
 
 RUN apt-get update
-RUN apt-get install build-essential -y
-RUN apt install -y meson
-RUN apt install -y python3-testresources
-RUN apt-get install -y python3-venv
-RUN apt-get install python3-pip -y
+RUN apt-get install -y build-essential meson python3-testresources python3-venv python3-pip git
 # Create app directory
 WORKDIR /app
 
@@ -26,6 +22,7 @@ COPY packages/matchmaking/package.json ./packages/matchmaking/
 COPY packages/server/package.json ./packages/server/
 COPY packages/server-core/package.json ./packages/server-core/
 COPY packages/projects/package.json ./packages/projects/
+COPY project-package-jsons ./
 
 #RUN  npm ci --verbose  # we should make lockfile or shrinkwrap then use npm ci for predicatble builds
 RUN npm install --production=false --loglevel notice --legacy-peer-deps
@@ -39,11 +36,17 @@ ARG MYSQL_PORT
 ARG MYSQL_USER
 ARG MYSQL_PASSWORD
 ARG MYSQL_DATABASE
+ARG VITE_CLIENT_HOST
+ARG VITE_SERVER_HOST
+ARG VITE_GAMESERVER_HOST
 ENV MYSQL_HOST=$MYSQL_HOST
 ENV MYSQL_PORT=$MYSQL_PORT
 ENV MYSQL_USER=$MYSQL_USER
 ENV MYSQL_PASSWORD=$MYSQL_PASSWORD
 ENV MYSQL_DATABASE=$MYSQL_DATABASE
+ENV VITE_CLIENT_HOST=$VITE_CLIENT_HOST
+ENV VITE_SERVER_HOST=$VITE_SERVER_HOST
+ENV VITE_GAMESERVER_HOST=$VITE_GAMESERVER_HOST
 
 RUN npm run build-client
 

--- a/packages/client-core/src/admin/services/Setting/AuthSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/AuthSettingService.ts
@@ -42,25 +42,21 @@ export const useAdminAuthSettingState = () => useState(state) as any as typeof s
 export const AuthSettingService = {
   fetchAuthSetting: async () => {
     const dispatch = useDispatch()
-    {
-      try {
-        await waitForClientAuthenticated()
-        const authSetting = await client.service('authentication-setting').find()
-        dispatch(AuthSettingAction.authSettingRetrieved(authSetting))
-      } catch (err) {
-        AlertService.dispatchAlertError(err)
-      }
+    try {
+      await waitForClientAuthenticated()
+      const authSetting = await client.service('authentication-setting').find()
+      dispatch(AuthSettingAction.authSettingRetrieved(authSetting))
+    } catch (err) {
+      AlertService.dispatchAlertError(err)
     }
   },
   patchAuthSetting: async (data: any, id: string) => {
     const dispatch = useDispatch()
-    {
-      try {
-        await client.service('authentication-setting').patch(id, data)
-        dispatch(AuthSettingAction.authSettingPatched())
-      } catch (err) {
-        AlertService.dispatchAlertError(err)
-      }
+    try {
+      await client.service('authentication-setting').patch(id, data)
+      dispatch(AuthSettingAction.authSettingPatched())
+    } catch (err) {
+      AlertService.dispatchAlertError(err)
     }
   }
 }

--- a/packages/server-core/src/setting/authentication-setting/authentication.class.ts
+++ b/packages/server-core/src/setting/authentication-setting/authentication.class.ts
@@ -44,7 +44,7 @@ export class Authentication extends Service {
         bearerToken: bearerToken,
         callback: callback,
         oauth: {
-          oauth
+          ...oauth
         }
       }
       if (oauth.defaults) returned.oauth.defaults = JSON.parse(oauth.defaults)

--- a/packages/server-core/src/social/invite/invite.test.ts
+++ b/packages/server-core/src/social/invite/invite.test.ts
@@ -7,8 +7,6 @@ let user: any = null
 
 describe('invite service', () => {
   before(async () => {
-    await app.setup()
-
     await app.service('invite').hooks({
       before: {
         find: []

--- a/packages/server-core/src/user/identity-provider/identity-provider.test.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.test.ts
@@ -5,9 +5,7 @@ import app from '../../../../server/src/app'
 let providers: any = []
 
 describe('identity-provider service', () => {
-  before(async () => {
-    await app.setup()
-  })
+  before(async () => {})
 
   it('registered the service', async () => {
     const service = await app.service('identity-provider')

--- a/packages/server-core/src/user/user/user.test.ts
+++ b/packages/server-core/src/user/user/user.test.ts
@@ -5,9 +5,7 @@ import app from '../../../../server/src/app'
 let users: any = []
 
 describe('user service', () => {
-  before(async () => {
-    await app.setup()
-  })
+  before(async () => {})
 
   it('registered the service', async () => {
     const service = await app.service('user')

--- a/packages/server-core/tests/services/matchmaking/match-instance.test.ts
+++ b/packages/server-core/tests/services/matchmaking/match-instance.test.ts
@@ -42,7 +42,6 @@ describe('matchmaking match-instance service', () => {
 
   before(async () => {
     scope = nock(FRONTEND_SERVICE_URL)
-    await app.setup()
 
     const ticketsService = app.service('match-ticket')
 

--- a/scripts/build_minikube.sh
+++ b/scripts/build_minikube.sh
@@ -37,8 +37,41 @@ else
   MYSQL_DATABASE=$MYSQL_DATABASE
 fi
 
+if [ -z "$VITE_CLIENT_HOST" ]
+then
+  VITE_CLIENT_HOST=local.theoverlay.io
+else
+  VITE_CLIENT_HOST=$VITE_CLIENT_HOST
+fi
+
+if [ -z "$VITE_SERVER_HOST" ]
+then
+  VITE_SERVER_HOST=api-local.theoverlay.io
+else
+  VITE_SERVER_HOST=$VITE_SERVER_HOST
+fi
+
+if [ -z "$VITE_GAMESERVER_HOST" ]
+then
+  VITE_GAMESERVER_HOST=gameserver-local.theoverlay.io
+else
+  VITE_GAMESERVER_HOST=$VITE_GAMESERVER_HOST
+fi
+
 docker start xrengine_minikube_db
 eval $(minikube docker-env)
-DOCKER_BUILDKIT=1 docker build -t xrengine --build-arg MYSQL_HOST=$MYSQL_HOST --build-arg MYSQL_PORT=$MYSQL_PORT --build-arg MYSQL_PASSWORD=$MYSQL_PASSWORD --build-arg MYSQL_USER=$MYSQL_USER --build-arg MYSQL_DATABASE=$MYSQL_DATABASE .
+
+mkdir -p ./project-package-jsons/projects/default-project
+cp packages/projects/default-project/package.json ./project-package-jsons/projects/default-project
+find packages/projects/projects/ -name package.json -exec bash -c 'mkdir -p ./project-package-jsons/$(dirname $1) && cp $1 ./project-package-jsons/$(dirname $1)' - '{}' \;
+DOCKER_BUILDKIT=1 docker build -t xrengine \
+  --build-arg MYSQL_HOST=$MYSQL_HOST \
+  --build-arg MYSQL_PORT=$MYSQL_PORT \
+  --build-arg MYSQL_PASSWORD=$MYSQL_PASSWORD \
+  --build-arg MYSQL_USER=$MYSQL_USER \
+  --build-arg MYSQL_DATABASE=$MYSQL_DATABASE \
+  --build-arg VITE_CLIENT_HOST=$VITE_CLIENT_HOST \
+  --build-arg VITE_SERVER_HOST=$VITE_SERVER_HOST \
+  --build-arg VITE_GAMESERVER_HOST=$VITE_GAMESERVER_HOST .
 
 DOCKER_BUILDKIT=1 docker build -t xrengine-testbot -f ./dockerfiles/testbot/Dockerfile-testbot .

--- a/tutorial/09-minikube.md
+++ b/tutorial/09-minikube.md
@@ -107,18 +107,6 @@ and `helm install local-redis redis/redis` to install redis.
 You can run `kubectl get pods -A` to list all of the pods running in minikube. After a minute or so,
 all of these pods should be in the Running state.
 
-## Build .env.production file locally
-vite, the package that is used to build the front-end client, can only pass environment variables in the form
-`VITE_*` to the files it builds, and in a production build, these variables must be passed into the build process.
-In an actual deployment, the builder service will generate the file `.env.production` from the environment variables
-that are set on its context. When building for minikube, the builder service is not run, so you need to build
-`.env.production` manually.
-
-In a separate terminal tab, go to `packages/client` and run 
-`VITE_SERVER_HOST=api-local.theoverlay.io VITE_GAMESERVER_HOST=gameserver-local.theoverlay.io npm run buildenv`.
-This will write those two environment variables to `.env.production` at the repo root. If you need to set other
-variables, just define them alongside the existing variables when calling `npm run buildenv`.
-
 ## Run build_minikube.sh
 When minikube is running, run the following command from the root of the XREngine repo:
 `./scripts/build_minikube.sh`
@@ -127,10 +115,14 @@ This points Docker *in the current terminal* to minikube's Docker environment. A
 will be locally accessible to minikube; if the first main command in the script were not run, Docker would build to your
 machine's Docker environment, and minikube would not have access to it.
 
-The script also builds the full-repo Docker image using several of build arguments. Vite, which builds
+The script also builds the full-repo Docker image using several build arguments. Vite, which builds
 the client files, uses some information from the MariaDB database created for minikube deployments
 to fill in some variables, and needs database credentials. The script will supply default values
-for all of the MYSQL_* variables if they are not provided to the script.
+for all of the MYSQL_* variables if they are not provided to the script, as well as VITE_CLIENT_HOST,
+VITE_SERVER_HOST, and VITE_GAMESERVER_HOST. The latter three will make your minikube deployment
+accessible on `(local/api-local/gameserver-local).theoverlay.io`; if you want to run it on a different
+domain, then you'll have to set those three environment variables to what you want them to be (and also
+change the hostfile records you made pointing those subdomains to minikube's IP)
 
 This will build an image of the entire XREngine repo into a single Docker file. When deployed for
 different services, it will only run the parts needed for that service. This may take up to 15 minutes,


### PR DESCRIPTION
## Summary

Authentication.class.ts:find() was mistakenly not unpacking the oauth field.

build-minikube.sh now has default values for VITE_(CLIENT/SERVER/GAMESERVER)_HOST,
installs project package.json's.

Root Dockerfile uses VITE_(CLIENT/SERVER/GAMESERVER)_HOST values when building, installs git.

Removed app.setup() from recent tests because that was double-registering services, which was leading
to errors due to user aliases being used twice.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
