### PR TITLE
app property with same Application type is already in parent CustomOA…

### DIFF
--- a/packages/server-core/src/user/strategies/discord.ts
+++ b/packages/server-core/src/user/strategies/discord.ts
@@ -5,8 +5,7 @@ import { Application } from '../../../declarations'
 import { AuthenticationRequest } from '@feathersjs/authentication'
 
 export class DiscordStrategy extends CustomOAuthStrategy {
-  app: Application
-  constructor(app) {
+  constructor(app: Application) {
     super()
     this.app = app
   }

--- a/packages/server-core/src/user/strategies/facebook.ts
+++ b/packages/server-core/src/user/strategies/facebook.ts
@@ -4,8 +4,7 @@ import config from '../../appconfig'
 import { Application } from '../../../declarations'
 
 export class FacebookStrategy extends CustomOAuthStrategy {
-  app: Application
-  constructor(app) {
+  constructor(app: Application) {
     super()
     this.app = app
   }

--- a/packages/server-core/src/user/strategies/github.ts
+++ b/packages/server-core/src/user/strategies/github.ts
@@ -4,8 +4,7 @@ import config from '../../appconfig'
 import { Application } from '../../../declarations'
 
 export class GithubStrategy extends CustomOAuthStrategy {
-  app: Application
-  constructor(app) {
+  constructor(app: Application) {
     super()
     this.app = app
   }

--- a/packages/server-core/src/user/strategies/google.ts
+++ b/packages/server-core/src/user/strategies/google.ts
@@ -4,8 +4,7 @@ import config from '../../appconfig'
 import { Application } from '../../../declarations'
 
 export class Googlestrategy extends CustomOAuthStrategy {
-  app: Application
-  constructor(app) {
+  constructor(app: Application) {
     super()
     this.app = app
   }

--- a/packages/server-core/src/user/strategies/linkedin.ts
+++ b/packages/server-core/src/user/strategies/linkedin.ts
@@ -4,8 +4,7 @@ import config from '../../appconfig'
 import { Application } from '../../../declarations'
 
 export class LinkedInStrategy extends CustomOAuthStrategy {
-  app: Application
-  constructor(app) {
+  constructor(app: Application) {
     super()
     this.app = app
   }

--- a/packages/server-core/src/user/strategies/twitter.ts
+++ b/packages/server-core/src/user/strategies/twitter.ts
@@ -4,8 +4,7 @@ import config from '../../appconfig'
 import { Application } from '../../../declarations'
 
 export class TwitterStrategy extends CustomOAuthStrategy {
-  app: Application
-  constructor(app) {
+  constructor(app: Application) {
     super()
     this.app = app
   }


### PR DESCRIPTION
## Summary

app property with same Application type is already in parent CustomOAuthStrategy.

fix for error TS2612: Property 'app' will overwrite the base property in 'CustomOAuthStrategy'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
