### PR TITLE
Fixed bug in producer creation/resumption.

### DIFF
--- a/packages/gameserver/src/WebRTCFunctions.ts
+++ b/packages/gameserver/src/WebRTCFunctions.ts
@@ -720,7 +720,8 @@ export async function handleWebRtcResumeProducer(socket, data, callback): Promis
       const hostClient = Array.from(world.clients.entries()).find(([, client]) => {
         return client.media && client.media![producer.appData.mediaTag]?.producerId === producerId
       })!
-      hostClient[1].socket!.emit(MessageTypes.WebRTCResumeProducer.toString(), producer.id)
+      if (hostClient && hostClient[1])
+        hostClient[1].socket!.emit(MessageTypes.WebRTCResumeProducer.toString(), producer.id)
     }
   }
   callback({ resumed: true })
@@ -747,7 +748,8 @@ export async function handleWebRtcPauseProducer(socket, data, callback): Promise
         const hostClient = Array.from(world.clients.entries()).find(([, client]) => {
           return client.media && client.media![producer.appData.mediaTag]?.producerId === producerId
         })!
-        hostClient[1].socket!.emit(MessageTypes.WebRTCPauseProducer.toString(), producer.id, true)
+        if (hostClient && hostClient[1])
+          hostClient[1].socket!.emit(MessageTypes.WebRTCPauseProducer.toString(), producer.id, true)
       }
     }
   }


### PR DESCRIPTION
## Summary

Client-side loop to wait for audio/video producers to start was trying to create
producers on every iteration. This resulted multiple producers being made on the
backend, with the last one being set as the client's producers. When the client
sent signals to resume producers, they had the ID of the first one to be created,
leading to the gameserver not being able to find a matching producer and crashing.

Loop now only creates producer on first iteration. gameserver now has a check that
a hostClient was found before trying to send a message over it.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
