### PR TITLE
Fixed A/V button overlap on mobile.

### DIFF
--- a/packages/client-core/src/components/Layout/Layout.module.scss
+++ b/packages/client-core/src/components/Layout/Layout.module.scss
@@ -57,7 +57,7 @@ body {
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 11;
+    z-index: 9;
     max-height: calc(100vh - 120px);
     overflow-y: auto;
     min-width: 90px;
@@ -77,7 +77,7 @@ body {
         flex-direction: row;
         overflow-x: auto;
         max-width: 100vw;
-        padding: 20px;
+        padding: 60px 20px 20px 20px;
         margin: 0;
         &::after { display: inline-block; }
     }


### PR DESCRIPTION
## Summary

On mobile, PartyParticipantWindows covered up the audio/video buttons. Increased the top padding and made
the z-index of that container less than the z-index of the A/V controls.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
