### PR TITLE
Fixed bug in make-user-admin.js (and other similar scripts).

### DIFF
--- a/packages/server/scripts/make-user-location-admin.js
+++ b/packages/server/scripts/make-user-location-admin.js
@@ -1,9 +1,13 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const dotenv = require('dotenv');
+const dotenv = require('dotenv-flow');
 const cli = require('cli');
+import appRootPath from 'app-root-path'
 const Sequelize = require('sequelize');
 
-dotenv.config();
+dotenv.config({
+    path: appRootPath.path,
+    silent: true
+})
 const db = {
     username: process.env.MYSQL_USER ?? 'server',
     password: process.env.MYSQL_PASSWORD ?? 'password',


### PR DESCRIPTION
## Summary

Some of the make-user-admin scripts were using dotenv instead of dotenv-flow, and were
ignoring .env.local files. In cases like WSL where the DB address is not 127.0.0.1, the
script was not using the configured address from the proper .env file.

Made make-user-admin.js check for existing scopes so that they are not duplicated, and
print a different message if the user does not exist.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
