### PR TITLE
Fixed seeding of routes.

### DIFF
--- a/packages/server-core/src/route/route/route.class.ts
+++ b/packages/server-core/src/route/route/route.class.ts
@@ -18,7 +18,9 @@ export class Route<T = ActiveRoutesDataType> extends Service<T> {
 
   // @ts-ignore
   async find(params?: Params): Promise<T[], Paginated<T>> {
-    const routes = await super.find({ paginate: false })
+    if (!params) params = {}
+    params.paginate = false
+    const routes = await super.find(params)
     return {
       total: (routes as any).length,
       data: routes


### PR DESCRIPTION
## Summary

route.class.ts:find() was not using params, so seeder's check if seed existed was
just searching for all routes and getting a mistaken 'match' after the first seed.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
