### PR TITLE
Update 01-installation.md

### DIFF
--- a/tutorial/01-installation.md
+++ b/tutorial/01-installation.md
@@ -44,6 +44,8 @@ you start your machine anew)
 
 ## Build the image
 
+Create an empty folder at the root called `project-package-jsons` and the run the following command to build:
+
 ``` bash
 DOCKER_BUILDKIT=1 docker build -t xrengine --build-arg MYSQL_USER=server --build-arg MYSQL_PASSWORD=password --build-arg MYSQL_HOST=127.0.0.1 --build-arg MYSQL_DATABASE=xrengine --build-arg MYSQL_PORT=3304 --build-arg VITE_SERVER_HOST=localhost --build-arg VITE_SERVER_PORT=3030 --build-arg VITE_GAMESERVER_HOST=localhost --build-arg VITE_GAMESERVER_PORT=3031 --build-arg VITE_LOCAL_BUILD=true --build-arg CACHE_DATE="$(date)" --network="host" .
 


### PR DESCRIPTION
## Summary

_A summary of changes being made in this PR_

Just a small change to the installation instructions. Building the image fails on a new pull of the repo since you cant commit an empty folder.  So an empty folder for `project-package-jsons` needs to be created for the image build to succeed.  There might be a better way to fix this, like a default file in that folder.  However I wanted to raise this as a flag as I walk through installing the engine.