### PR TITLE
Fixed fetching of current closest users and their media.

### DIFF
--- a/packages/client-core/src/components/PartyVideoWindows/index.tsx
+++ b/packages/client-core/src/components/PartyVideoWindows/index.tsx
@@ -13,18 +13,11 @@ const PartyVideoWindows = (): JSX.Element => {
   const nearbyLayerUsers = useState(accessMediaStreamState().nearbyLayerUsers)
   const selfUserId = useState(accessAuthState().user.id)
   const userState = useUserState()
-  const [displayedUsers, setDisplayedUsers] = React.useState([] as Array<User>)
   const channelConnectionState = useMediaInstanceConnectionState()
-
-  useEffect(() => {
-    if (channelConnectionState.channelType.value === 'channel') {
-      setDisplayedUsers(userState.channelLayerUsers.value.filter((user) => user.id !== selfUserId.value))
-    } else {
-      setDisplayedUsers(
-        userState.layerUsers.value.filter((user) => !!nearbyLayerUsers.value.find((u) => u.id === user.id))
-      )
-    }
-  }, [nearbyLayerUsers.value.length])
+  const displayedUsers =
+    channelConnectionState.channelType.value === 'channel'
+      ? userState.channelLayerUsers.value.filter((user) => user.id !== selfUserId.value)
+      : userState.layerUsers.value.filter((user) => !!nearbyLayerUsers.value.find((u) => u.id === user.id))
 
   return (
     <>

--- a/packages/engine/src/initializeEngine.ts
+++ b/packages/engine/src/initializeEngine.ts
@@ -151,10 +151,6 @@ export const initializeMediaServerSystems = async () => {
     {
       type: SystemUpdateType.FIXED_LATE,
       systemModulePromise: import('./ecs/functions/ActionCleanupSystem')
-    },
-    {
-      type: SystemUpdateType.PRE_RENDER,
-      systemModulePromise: import('./networking/systems/MediaStreamSystem')
     }
   )
 
@@ -355,8 +351,15 @@ export const initializeSceneSystems = async () => {
   await initSystems(world, systemsToLoad)
 }
 
-export const initializeRealtimeSystems = async (pose = true) => {
+export const initializeRealtimeSystems = async (media = true, pose = true) => {
   const systemsToLoad: SystemModuleType<any>[] = []
+
+  if (media) {
+    systemsToLoad.push({
+      type: SystemUpdateType.PRE_RENDER,
+      systemModulePromise: import('./networking/systems/MediaStreamSystem')
+    })
+  }
 
   if (pose) {
     systemsToLoad.push(

--- a/packages/engine/src/networking/systems/MediaStreamSystem.ts
+++ b/packages/engine/src/networking/systems/MediaStreamSystem.ts
@@ -11,6 +11,7 @@ import { getNearbyUsers, NearbyUser } from '../functions/getNearbyUsers'
 /** System class for media streaming. */
 export class MediaStreams {
   static EVENTS = {
+    TRIGGER_REQUEST_CURRENT_PRODUCERS: 'NETWORK_TRANSPORT_EVENT_REQUEST_CURRENT_PRODUCERS',
     TRIGGER_UPDATE_CONSUMERS: 'NETWORK_TRANSPORT_EVENT_UPDATE_CONSUMERS',
     CLOSE_CONSUMER: 'NETWORK_TRANSPORT_EVENT_CLOSE_CONSUMER',
     UPDATE_NEARBY_LAYER_USERS: 'NETWORK_TRANSPORT_EVENT_UPDATE_NEARBY_LAYER_USERS'
@@ -314,7 +315,7 @@ export const updateNearbyAvatars = () => {
 }
 
 // every 5 seconds
-const NEARYBY_AVATAR_UPDATE_PERIOD = 60 * 5
+const NEARBY_AVATAR_UPDATE_PERIOD = 60 * 5
 
 export default async function MediaStreamSystem() {
   let nearbyAvatarTick = 0
@@ -342,7 +343,7 @@ export default async function MediaStreamSystem() {
 
     if (isClient) {
       nearbyAvatarTick++
-      if (nearbyAvatarTick > NEARYBY_AVATAR_UPDATE_PERIOD) {
+      if (nearbyAvatarTick > NEARBY_AVATAR_UPDATE_PERIOD) {
         nearbyAvatarTick = 0
         updateNearbyAvatars()
       }

--- a/packages/gameserver/src/channels.ts
+++ b/packages/gameserver/src/channels.ts
@@ -73,7 +73,7 @@ const loadScene = async (app: Application, scene: string) => {
     createEngine()
     initializeNode()
     await initializeCoreSystems()
-    await initializeRealtimeSystems()
+    await initializeRealtimeSystems(false, true)
     await initializeSceneSystems()
     await initializeProjectSystems(projects, systems)
 
@@ -233,6 +233,7 @@ const loadEngine = async (app: Application, sceneId: string) => {
     world.hostId = userId
     initializeNode()
     await initializeMediaServerSystems()
+    await initializeRealtimeSystems(true, false)
     const projects = (await app.service('project').find(null!)).data.map((project) => project.name)
     await initializeProjectSystems(projects, [])
 


### PR DESCRIPTION
## Summary

MediaStreamService had been disabled on the client. Re-enabled it, and made pause/resume
producer/consumer functions push their actions to mediasoupOperationQueue.

Complete split of world and media servers had resulted in WebRTCRequestCurrentProducers message
being sent to world server, which has no knowledge of producers. Added a new MediaStreamSystem
message `TRIGGER_REQUEST_CURRENT_PRODUCERS`; the world server now gets the closest users and
sends them with that message, with the media server setup adding a listener to take that list
and call RequestCurrentProducers from the media server.

With new hookstate implementation, updated PartyVideoWindows to properly use nearbyLayerUsers
to populate PartyParticipantWindows.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
