### PR TITLE
Fix physics debug renderer not updating

### DIFF
--- a/packages/editor/src/components/properties/Util.ts
+++ b/packages/editor/src/components/properties/Util.ts
@@ -14,12 +14,13 @@ export type EditorComponentType = React.FC<EditorPropType> & {
 
 export const updateProperty = <C extends ComponentConstructor<any, any>, K extends keyof ComponentType<C>>(
   component: C,
-  propName: K
+  propName: K,
+  ...args: any
 ) => {
   return (value: ComponentType<C>[K]) => {
     CommandManager.instance.setPropertyOnSelectionEntities({
       component,
-      properties: { [propName]: value } as ComponentType<C>
+      properties: { [propName]: value, ...args } as ComponentType<C>
     })
   }
 }

--- a/packages/editor/src/components/toolbar/tools/HelperToggleTool.tsx
+++ b/packages/editor/src/components/toolbar/tools/HelperToggleTool.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useState } from 'react'
 
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
+import { accessEngineState, EngineActions, useEngineState } from '@xrengine/engine/src/ecs/classes/EngineService'
+import { dispatchLocal } from '@xrengine/engine/src/networking/functions/dispatchFrom'
 import { ObjectLayers } from '@xrengine/engine/src/scene/constants/ObjectLayers'
 
 import SelectAllIcon from '@mui/icons-material/SelectAll'
@@ -12,10 +14,11 @@ import * as styles from '../styles.module.scss'
 export const HelperToggleTool = () => {
   const [, updateState] = useState<any>()
   const forceUpdate = useCallback(() => updateState({}), [])
+  const engineState = useEngineState()
 
   const togglePhysicsDebug = () => {
-    Engine.camera.layers.toggle(ObjectLayers.PhysicsHelper)
     forceUpdate()
+    dispatchLocal(EngineActions.setPhysicsDebug(!accessEngineState().isPhysicsDebug.value) as any)
   }
   const toggleNodeHelpers = () => {
     Engine.camera.layers.toggle(ObjectLayers.NodeHelper)
@@ -28,11 +31,7 @@ export const HelperToggleTool = () => {
         <InfoTooltip title="Toggle Physics Helpers">
           <button
             onClick={togglePhysicsDebug}
-            className={
-              styles.toolButton +
-              ' ' +
-              (Engine.camera.layers.isEnabled(ObjectLayers.PhysicsHelper) ? styles.selected : '')
-            }
+            className={styles.toolButton + ' ' + (engineState.isPhysicsDebug.value ? styles.selected : '')}
           >
             <SquareFootIcon fontSize="small" />
           </button>

--- a/packages/engine/src/debug/systems/DebugHelpersSystem.ts
+++ b/packages/engine/src/debug/systems/DebugHelpersSystem.ts
@@ -28,6 +28,7 @@ import { createGraphHelper } from '../../navigation/GraphHelper'
 import { createConvexRegionHelper } from '../../navigation/NavMeshHelper'
 import { isStaticBody } from '../../physics/classes/Physics'
 import { ColliderComponent } from '../../physics/components/ColliderComponent'
+import { ObstaclesComponent } from '../../physics/components/ObstaclesComponent'
 import { VelocityComponent } from '../../physics/components/VelocityComponent'
 import { Object3DComponent } from '../../scene/components/Object3DComponent'
 import { TransformComponent } from '../../transform/components/TransformComponent'
@@ -94,6 +95,7 @@ export default async function DebugHelpersSystem(world: World) {
   }
   Engine.currentWorld.receptors.push(receptor)
 
+  const obstacleQuery = defineQuery([ObstaclesComponent])
   const avatarDebugQuery = defineQuery([AvatarComponent])
   const ikDebugQuery = defineQuery([IKObj])
   const boundingBoxQuery = defineQuery([BoundingBoxComponent])
@@ -345,6 +347,21 @@ export default async function DebugHelpersSystem(world: World) {
     }
     // ===== Autopilot Helper ===== //
     // TODO add createPathHelper for navpathQuery
+
+    // TODO: move this to an editor action receptor after commands have been updated to FLUX pattern
+    if (Engine.isEditor) {
+      for (const entity of obstacleQuery()) {
+        const obstaclesComponent = getComponent(entity, ObstaclesComponent)
+        if (obstaclesComponent) {
+          for (const obstacle of obstaclesComponent.obstacles) {
+            const mesh = (obstacle as any)._mesh
+            mesh.updateMatrixWorld(true, true)
+            obstacle.setPosition(mesh.getWorldPosition(new Vector3()))
+            obstacle.setRotation(mesh.getWorldQuaternion(new Quaternion()))
+          }
+        }
+      }
+    }
 
     physicsDebugRenderer(world, physicsDebugEnabled)
   }

--- a/packages/engine/src/debug/systems/DebugHelpersSystem.ts
+++ b/packages/engine/src/debug/systems/DebugHelpersSystem.ts
@@ -258,6 +258,21 @@ export default async function DebugHelpersSystem(world: World) {
         velocityArrowHelper.setDirection(vel.normalize())
         velocityArrowHelper.position.copy(transform.position)
       }
+
+      if (Engine.isEditor) {
+        collider.body.setGlobalPose(
+          {
+            translation: { x: transform.position.x, y: transform.position.y, z: transform.position.z },
+            rotation: {
+              x: transform.rotation.x,
+              y: transform.rotation.y,
+              z: transform.rotation.z,
+              w: transform.rotation.w
+            }
+          },
+          true
+        )
+      }
     }
 
     // ===== INTERACTABLES ===== //

--- a/packages/engine/src/debug/systems/DebugRenderer.ts
+++ b/packages/engine/src/debug/systems/DebugRenderer.ts
@@ -90,12 +90,13 @@ export const DebugRenderer = () => {
         geom = new BoxBufferGeometry(halfExtents.x * 2, halfExtents.y * 2, halfExtents.z * 2)
       }
       const mesh = new Mesh(geom, _materials[5])
-      mesh.position.copy(obstacle.getPosition() as Vector3)
-      mesh.quaternion.copy(obstacle.getRotation() as Quaternion)
       setObjectLayers(mesh, ObjectLayers.PhysicsHelper)
       Engine.scene.add(mesh)
       _obstacles.set(id, mesh)
     }
+    const mesh = _obstacles.get(id)
+    mesh.position.copy(obstacle.getPosition() as Vector3)
+    mesh.quaternion.copy(obstacle.getRotation() as Quaternion)
   }
 
   function _updateController(body: PhysX.PxRigidActor) {

--- a/packages/engine/src/physics/classes/Physics.ts
+++ b/packages/engine/src/physics/classes/Physics.ts
@@ -477,6 +477,7 @@ export class Physics {
     const handle = this.obstacleContext.addObstacle(obstacle)
     ;(obstacle as any)._handle = handle
     this.obstacles.set(id, obstacle)
+    return obstacle
   }
 
   removeObstacle(obstacle: PhysX.PxObstacle) {

--- a/packages/engine/src/physics/components/ObstaclesComponent.ts
+++ b/packages/engine/src/physics/components/ObstaclesComponent.ts
@@ -1,0 +1,7 @@
+import { createMappedComponent } from '../../ecs/functions/ComponentFunctions'
+
+export type ObstaclesComponentType = {
+  obstacles: Array<PhysX.PxBoxObstacle | PhysX.PxCapsuleObstacle>
+}
+
+export const ObstaclesComponent = createMappedComponent<ObstaclesComponentType>('ObstaclesComponent')

--- a/packages/engine/src/physics/functions/createCollider.ts
+++ b/packages/engine/src/physics/functions/createCollider.ts
@@ -2,13 +2,14 @@ import { Mesh, Object3D, Quaternion, Vector3 } from 'three'
 
 import { mergeBufferGeometries } from '../../common/classes/BufferGeometryUtils'
 import { Entity } from '../../ecs/classes/Entity'
-import { addComponent, getComponent } from '../../ecs/functions/ComponentFunctions'
+import { addComponent, getComponent, hasComponent } from '../../ecs/functions/ComponentFunctions'
 import { useWorld } from '../../ecs/functions/SystemHooks'
 import { Object3DComponent } from '../../scene/components/Object3DComponent'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { getGeometryType } from '../classes/Physics'
 import { ColliderComponent } from '../components/ColliderComponent'
 import { CollisionComponent } from '../components/CollisionComponent'
+import { ObstaclesComponent } from '../components/ObstaclesComponent'
 import { CollisionGroups, DefaultCollisionMask } from '../enums/CollisionGroups'
 import { BodyType, ColliderTypes, ObstacleConfig } from '../types/PhysicsTypes'
 import { getTransform } from './parseModelColliders'
@@ -244,7 +245,13 @@ export const createObstacleFromMesh = (entity: Entity, mesh: Mesh) => {
     halfHeight: scale.y,
     halfExtents: scale
   }
-  useWorld().physics.createObstacle(position, quaternion, config)
+  const obstacle = useWorld().physics.createObstacle(position, quaternion, config)
+  ;(obstacle as any)._mesh = mesh
+  if (!hasComponent(entity, ObstaclesComponent)) {
+    addComponent(entity, ObstaclesComponent, { obstacles: [] })
+  }
+  const obstaclesComponent = getComponent(entity, ObstaclesComponent)
+  obstaclesComponent.obstacles.push(obstacle)
 }
 
 const EPSILON = 1e-6
@@ -267,14 +274,14 @@ export const getAllShapesFromObject3D = (entity: Entity, asset: Object3D, data: 
 
     if (mesh.userData.type === 'obstacle') {
       createObstacleFromMesh(entity, mesh)
-      mesh.removeFromParent()
+      mesh.visible = false
       return
     }
 
     const shape = createShape(entity, mesh, mesh.userData as any)
     if (!shape) return
     shapes.push(shape)
-    mesh.removeFromParent()
+    mesh.visible = false
   })
 
   return shapes.filter((val) => {

--- a/packages/engine/src/physics/systems/PhysicsSystem.ts
+++ b/packages/engine/src/physics/systems/PhysicsSystem.ts
@@ -174,10 +174,6 @@ export default async function PhysicsSystem(world: World) {
       processBoundingBox(entity, true)
     }
 
-    for (const entity of boxQuery()) {
-      processBoundingBox(entity)
-    }
-
     for (const entity of colliderQuery.exit()) {
       const colliderComponent = getComponent(entity, ColliderComponent, true)
       if (colliderComponent?.body) {
@@ -185,9 +181,9 @@ export default async function PhysicsSystem(world: World) {
       }
     }
 
-    simulationPipeline(world)
-
     if (Engine.isEditor) return
+
+    simulationPipeline(world)
 
     // step physics world
     for (let i = 0; i < world.physics.substeps; i++) {

--- a/packages/engine/src/scene/functions/loadGLTFModel.ts
+++ b/packages/engine/src/scene/functions/loadGLTFModel.ts
@@ -96,7 +96,7 @@ export const parseObjectComponentsFromGLTF = (entity: Entity, object3d?: Object3
 
     // apply root mesh's world transform to this mesh locally
     applyTransformToMeshWorld(entity, mesh)
-    const transformComponent = addComponent(e, TransformComponent, {
+    addComponent(e, TransformComponent, {
       position: mesh.getWorldPosition(new Vector3()),
       rotation: mesh.getWorldQuaternion(new Quaternion()),
       scale: mesh.getWorldScale(new Vector3())

--- a/packages/engine/src/scene/functions/loadGLTFModel.ts
+++ b/packages/engine/src/scene/functions/loadGLTFModel.ts
@@ -15,6 +15,7 @@ import { dispatchFrom } from '../../networking/functions/dispatchFrom'
 import { receiveActionOnce } from '../../networking/functions/matchActionOnce'
 import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
 import { applyTransformToMeshWorld } from '../../physics/functions/parseModelColliders'
+import { TransformChildComponent } from '../../transform/components/TransformChildComponent'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { ModelComponent, ModelComponentType } from '../components/ModelComponent'
 import { NameComponent } from '../components/NameComponent'
@@ -91,7 +92,7 @@ export const parseObjectComponentsFromGLTF = (entity: Entity, object3d?: Object3
 
     // apply root mesh's world transform to this mesh locally
     applyTransformToMeshWorld(entity, mesh)
-    addComponent(e, TransformComponent, {
+    const transformComponent = addComponent(e, TransformComponent, {
       position: mesh.getWorldPosition(new Vector3()),
       rotation: mesh.getWorldQuaternion(new Quaternion()),
       scale: mesh.getWorldScale(new Vector3())
@@ -99,6 +100,13 @@ export const parseObjectComponentsFromGLTF = (entity: Entity, object3d?: Object3
 
     mesh.removeFromParent()
     addComponent(e, Object3DComponent, { value: mesh })
+    addComponent(e, TransformChildComponent, {
+      parent: entity,
+      offsetPosition: new Vector3().copy(transformComponent.position).sub(obj3d.getWorldPosition(new Vector3())),
+      offsetQuaternion: new Quaternion()
+        .copy(transformComponent.rotation)
+        .multiply(obj3d.getWorldQuaternion(new Quaternion()).invert())
+    })
 
     createObjectEntityFromGLTF(e, mesh)
   }


### PR DESCRIPTION
## Summary

Due to all our scenes loading colliders as separate entities, the model no longer informs the transform of the static colliders. To remedy this, a TransformChildComponent can be used to keep the new entities up to date.

Position and rotation manipulations are working, but scale is a lot harder, as that requires changes to how we think about the physics implementation. This likely needs a big rewrite, and the use case is small (since objects with colliders will rarely be scaled at all) and can be fixed by reloading the scene in the editor.

Some other optimizations with physics has also been done.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

https://github.com/XRFoundation/XREngine/issues/4935

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
