### PR TITLE
Fixed a bug with seeding values.

### DIFF
--- a/packages/server-core/src/sequelize.ts
+++ b/packages/server-core/src/sequelize.ts
@@ -93,22 +93,20 @@ export default (app: Application): void => {
                 if (templates)
                   for (let template of templates) {
                     let isSeeded
-                    if (template.id) {
-                      try {
-                        await service.get(template.id)
-                        isSeeded = true
-                      } catch (err) {
-                        await service.find()
-                        isSeeded = false
-                      }
-                    } else if (settingsServiceNames.indexOf(config.path) > 0) {
-                      console.log('settings template', template)
+                    if (settingsServiceNames.indexOf(config.path) > -1) {
                       const result = await service.find()
                       isSeeded = result.total > 0
                     } else {
                       const searchTemplate = {}
-                      for (let key of Object.keys(template))
-                        if (typeof template[key] !== 'object') searchTemplate[key] = template[key]
+
+                      const sequelizeModel = service.Model
+                      const uniqueField = Object.values(sequelizeModel.rawAttributes).find(
+                        (value: any) => value.unique
+                      ) as any
+                      if (uniqueField) searchTemplate[uniqueField.fieldName] = template[uniqueField.fieldName]
+                      else
+                        for (let key of Object.keys(template))
+                          if (typeof template[key] !== 'object') searchTemplate[key] = template[key]
                       const result = await service.find({
                         query: searchTemplate
                       })


### PR DESCRIPTION
## Summary

Seeding didn't take into account uniqueness. e.g., if a location seed shared a name with
a location that existed under a different ID, the seed ID lookup would show no matches and
try to insert a new location, and would fail on the uniqueness constraint.

ID lookup has been removed for seeding. Now, if it's not a settings service, it tries to find
a unique field on the model and just find a match on that. If there's no unique field, then it
does what it was doing before, and just searches on all the field values specified in the seed.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
