### PR TITLE
GLTF ECS Matrix Auto Update Bug Fixes

### DIFF
--- a/packages/engine/src/scene/functions/SceneLoading.ts
+++ b/packages/engine/src/scene/functions/SceneLoading.ts
@@ -106,8 +106,6 @@ export const loadSceneFromJSON = async (sceneData: SceneJson, world = useWorld()
 
   if (!accessEngineState().isTeleporting.value) Engine.camera?.layers.enable(ObjectLayers.Scene)
 
-  // Configure CSM
-  updateRenderSetting(world.entityTree.rootNode.entity)
   dispatchLocal(EngineActions.sceneLoaded()).delay(2)
 }
 

--- a/packages/engine/src/scene/functions/loadGLTFModel.ts
+++ b/packages/engine/src/scene/functions/loadGLTFModel.ts
@@ -3,6 +3,7 @@ import { NavMesh, Polygon } from 'yuka'
 
 import { AnimationComponent } from '../../avatar/components/AnimationComponent'
 import { parseGeometry } from '../../common/functions/parseGeometry'
+import { createQuaternionProxy, createVector3Proxy } from '../../common/proxies/three'
 import { DebugNavMeshComponent } from '../../debug/DebugNavMeshComponent'
 import { Engine } from '../../ecs/classes/Engine'
 import { EngineEvents } from '../../ecs/classes/EngineEvents'
@@ -96,11 +97,14 @@ export const parseObjectComponentsFromGLTF = (entity: Entity, object3d?: Object3
 
     // apply root mesh's world transform to this mesh locally
     applyTransformToMeshWorld(entity, mesh)
-    addComponent(e, TransformComponent, {
-      position: mesh.getWorldPosition(new Vector3()),
-      rotation: mesh.getWorldQuaternion(new Quaternion()),
-      scale: mesh.getWorldScale(new Vector3())
-    })
+
+    const position = createVector3Proxy(TransformComponent.position, e)
+    const rotation = createQuaternionProxy(TransformComponent.rotation, e)
+    const scale = createVector3Proxy(TransformComponent.scale, e)
+    const transform = addComponent(e, TransformComponent, { position, rotation, scale })
+    mesh.getWorldPosition(transform.position)
+    mesh.getWorldQuaternion(transform.rotation)
+    mesh.getWorldScale(transform.scale)
 
     mesh.removeFromParent()
     addComponent(e, Object3DComponent, { value: mesh })
@@ -178,6 +182,9 @@ export const overrideTexture = (entity: Entity, object3d?: Object3D, world = use
 }
 
 export const parseGLTFModel = (entity: Entity, props: ModelComponentType, obj3d: Object3D) => {
+  // always parse components first
+  parseObjectComponentsFromGLTF(entity, obj3d)
+
   setObjectLayers(obj3d, ObjectLayers.Scene)
 
   // DIRTY HACK TO LOAD NAVMESH
@@ -216,16 +223,19 @@ export const parseGLTFModel = (entity: Entity, props: ModelComponentType, obj3d:
         })
       ).cache()
     }
-  } else {
-    if (props.matrixAutoUpdate === false) {
-      obj3d.traverse((child) => {
-        child.updateMatrixWorld(true)
-        child.matrixAutoUpdate = false
-      })
-    }
   }
 
-  parseObjectComponentsFromGLTF(entity, obj3d)
+  // ignore disabling matrix auto update in the editor as we need to be able move things around with the transform tools
+  if (!Engine.isEditor && props.matrixAutoUpdate === false) {
+    const transform = getComponent(entity, TransformComponent)
+    obj3d.position.copy(transform.position)
+    obj3d.quaternion.copy(transform.rotation)
+    obj3d.scale.copy(transform.scale)
+    obj3d.updateMatrixWorld(true)
+    obj3d.traverse((child) => {
+      child.matrixAutoUpdate = false
+    })
+  }
 
   const modelComponent = getComponent(entity, ModelComponent)
   if (modelComponent) modelComponent.parsed = true

--- a/packages/server-core/src/setting/project-setting/project-setting.class.ts
+++ b/packages/server-core/src/setting/project-setting/project-setting.class.ts
@@ -22,7 +22,7 @@ export class ProjectSetting implements ServiceMethods<Data> {
   }
 
   async patch(id: Id, params?: Params): Promise<any> {
-    const result = await this.app.service('project').updateSettings(id, params)
+    const result = await this.app.service('project').updateSettings(id, params as any)
 
     return result
   }


### PR DESCRIPTION
## Summary

- now parses gltf ecs data before applying matrix auto update, avoiding issues with physics objects being offset
- gltf ecs entities use bitecs transform store
- remove redundant second call to setup render settings

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
