### PR TITLE
Netcode Fix Fixed Tick Bug & No-change Desync

### DIFF
--- a/packages/engine/src/networking/serialization/DataReader.test.ts
+++ b/packages/engine/src/networking/serialization/DataReader.test.ts
@@ -41,6 +41,7 @@ import { Vector3SoA, Vector4SoA } from './Utils'
 import { createViewCursor, readFloat32, readUint8, readUint32, sliceViewCursor, writeProp } from './ViewCursor'
 
 describe('DataReader', () => {
+  // todo: should be beforeEach?
   before(() => {
     Engine.currentWorld = createWorld()
   })
@@ -356,7 +357,7 @@ describe('DataReader', () => {
       parameters: {}
     })
 
-    writeEntity(view, userIndex, networkId, entity)
+    writeEntity(view, networkId, entity)
 
     transform.position.x = 0
     transform.position.y = 0
@@ -368,7 +369,7 @@ describe('DataReader', () => {
 
     view.cursor = 0
 
-    readEntity(view, Engine.currentWorld)
+    readEntity(view, Engine.currentWorld, userId)
 
     strictEqual(TransformComponent.position.x[entity], x)
     strictEqual(TransformComponent.position.y[entity], y)
@@ -383,14 +384,14 @@ describe('DataReader', () => {
 
     view.cursor = 0
 
-    writeEntity(view, userIndex, networkId, entity)
+    writeEntity(view, networkId, entity)
 
     transform.position.x = x
     transform.rotation.z = z
 
     view.cursor = 0
 
-    readEntity(view, Engine.currentWorld)
+    readEntity(view, Engine.currentWorld, userId)
 
     strictEqual(TransformComponent.position.x[entity], 0)
     strictEqual(TransformComponent.position.y[entity], y)
@@ -432,7 +433,7 @@ describe('DataReader', () => {
 
     addComponent(entity, NetworkObjectAuthorityTag, {})
 
-    writeEntity(view, userIndex, networkId, entity)
+    writeEntity(view, networkId, entity)
 
     view.cursor = 0
 
@@ -441,7 +442,7 @@ describe('DataReader', () => {
     transform.rotation.set(0, 0, 0, 0)
 
     // read entity will populate data stored in 'view'
-    readEntity(view, Engine.currentWorld)
+    readEntity(view, Engine.currentWorld, userId)
 
     // should no repopulate as we own this entity
     strictEqual(TransformComponent.position.x[entity], 0)
@@ -453,7 +454,7 @@ describe('DataReader', () => {
     strictEqual(TransformComponent.rotation.w[entity], 0)
 
     // should update the view cursor accordingly
-    strictEqual(view.cursor, 40)
+    strictEqual(view.cursor, 36)
   })
 
   it('should not readEntity if entity is undefined', () => {
@@ -478,7 +479,7 @@ describe('DataReader', () => {
       scale: new Vector3(1, 1, 1)
     })
 
-    writeEntity(view, userIndex, networkId, entity)
+    writeEntity(view, networkId, entity)
 
     view.cursor = 0
 
@@ -487,7 +488,7 @@ describe('DataReader', () => {
     transform.rotation.set(0, 0, 0, 0)
 
     // read entity will populate data stored in 'view'
-    readEntity(view, Engine.currentWorld)
+    readEntity(view, Engine.currentWorld, userId)
 
     // should no repopulate as entity is not listed in network entities
     strictEqual(TransformComponent.position.x[entity], 0)
@@ -499,7 +500,7 @@ describe('DataReader', () => {
     strictEqual(TransformComponent.rotation.w[entity], 0)
 
     // should update the view cursor accordingly
-    strictEqual(view.cursor, 40)
+    strictEqual(view.cursor, 36)
   })
 
   it('should readEntities', () => {
@@ -508,6 +509,7 @@ describe('DataReader', () => {
     Engine.currentWorld.userIndexToUserId = new Map()
     Engine.currentWorld.userIdToUserIndex = new Map()
 
+    const userId = 'userId' as UserId
     const n = 50
     const entities: Entity[] = Array(n)
       .fill(0)
@@ -517,7 +519,6 @@ describe('DataReader', () => {
 
     entities.forEach((entity) => {
       const networkId = entity as unknown as NetworkId
-      const userId = entity as unknown as UserId
       const userIndex = entity
       addComponent(entity, TransformComponent, {
         position: createVector3Proxy(TransformComponent.position, entity).set(x, y, z),
@@ -552,7 +553,7 @@ describe('DataReader', () => {
     const packet = sliceViewCursor(writeView)
 
     const readView = createViewCursor(packet)
-    readEntities(readView, Engine.currentWorld, packet.byteLength)
+    readEntities(readView, Engine.currentWorld, packet.byteLength, userId)
 
     for (let i = 0; i < entities.length; i++) {
       const entity = entities[i]
@@ -573,6 +574,12 @@ describe('DataReader', () => {
     Engine.currentWorld.userIndexToUserId = new Map()
     Engine.currentWorld.userIdToUserIndex = new Map()
 
+    Engine.userId = 'userId' as UserId
+    const userId = Engine.userId
+    const userIndex = 0
+    Engine.currentWorld.userIndexToUserId.set(userIndex, userId)
+    Engine.currentWorld.userIdToUserIndex.set(userId, userIndex)
+
     const n = 10
     const entities: Entity[] = Array(n)
       .fill(0)
@@ -582,8 +589,6 @@ describe('DataReader', () => {
 
     entities.forEach((entity) => {
       const networkId = entity as unknown as NetworkId
-      const userId = entity as unknown as UserId
-      const userIndex = entity
       addComponent(entity, TransformComponent, {
         position: createVector3Proxy(TransformComponent.position, entity).set(x, y, z),
         rotation: createQuaternionProxy(TransformComponent.rotation, entity).set(x, y, z, w),
@@ -596,23 +601,19 @@ describe('DataReader', () => {
         prefab: '',
         parameters: {}
       })
-      Engine.currentWorld.userIndexToUserId.set(userIndex, userId)
-      Engine.currentWorld.userIdToUserIndex.set(userId, userIndex)
     })
 
     const packet = write(Engine.currentWorld, entities)
 
     const readView = createViewCursor(packet)
 
-    const tick = readUint32(readView)
+    const _tick = readUint32(readView)
+    const _userIndex = readUint32(readView)
 
     const count = readUint32(readView)
     strictEqual(count, entities.length)
 
     for (let i = 0; i < count; i++) {
-      // read userIndex
-      strictEqual(readUint32(readView), entities[i])
-
       // read networkId
       strictEqual(readUint32(readView), entities[i])
 
@@ -669,11 +670,12 @@ describe('DataReader', () => {
     }
   })
 
-  it('should createDataReader and return empty packet if no changes were made', () => {
+  it('should createDataReader and return empty packet if no changes were made on a fixedTick not divisible by 60', () => {
     const write = createDataWriter()
 
     Engine.currentWorld.userIndexToUserId = new Map()
     Engine.currentWorld.userIdToUserIndex = new Map()
+    Engine.currentWorld.fixedTick = 1
 
     const n = 10
     const entities: Entity[] = Array(n)
@@ -713,11 +715,51 @@ describe('DataReader', () => {
     })
   })
 
+  it('should createDataReader and return populated packet if no changes were made but on a fixedTick divisible by 60', () => {
+    const write = createDataWriter()
+
+    Engine.currentWorld.userIndexToUserId = new Map()
+    Engine.currentWorld.userIdToUserIndex = new Map()
+    Engine.currentWorld.fixedTick = 60
+
+    const n = 10
+    const entities: Entity[] = Array(n)
+      .fill(0)
+      .map(() => createEntity())
+
+    const [x, y, z, w] = [0, 0, 0, 0]
+
+    entities.forEach((entity) => {
+      const networkId = entity as unknown as NetworkId
+      const userId = entity as unknown as UserId
+      const userIndex = entity
+      addComponent(entity, TransformComponent, {
+        position: createVector3Proxy(TransformComponent.position, entity).set(x, y, z),
+        rotation: createQuaternionProxy(TransformComponent.rotation, entity).set(x, y, z, w),
+        scale: new Vector3(1, 1, 1)
+      })
+      addComponent(entity, NetworkObjectComponent, {
+        networkId,
+        ownerId: userId,
+        ownerIndex: userIndex,
+        prefab: '',
+        parameters: {}
+      })
+      Engine.currentWorld.userIndexToUserId.set(userIndex, userId)
+      Engine.currentWorld.userIdToUserIndex.set(userId, userIndex)
+    })
+
+    const packet = write(Engine.currentWorld, entities)
+
+    strictEqual(packet.byteLength, 372)
+  })
+
   it('should createDataReader and detect changes', () => {
     const write = createDataWriter()
 
     Engine.currentWorld.userIndexToUserId = new Map()
     Engine.currentWorld.userIdToUserIndex = new Map()
+    Engine.currentWorld.fixedTick = 1
 
     const n = 10
     const entities: Entity[] = Array(n)
@@ -768,15 +810,13 @@ describe('DataReader', () => {
 
     readView = createViewCursor(packet)
 
-    const tick = readUint32(readView)
+    const _tick = readUint32(readView)
+    const _userIndex = readUint32(readView)
 
     const count = readUint32(readView)
     strictEqual(count, 1) // only one entity changed
 
     for (let i = 0; i < count; i++) {
-      // read userIndex
-      strictEqual(readUint32(readView), entities[i])
-
       // read networkId
       strictEqual(readUint32(readView), entities[i])
 

--- a/packages/engine/src/networking/serialization/DataReader.ts
+++ b/packages/engine/src/networking/serialization/DataReader.ts
@@ -169,7 +169,9 @@ export const readEntities = (v: ViewCursor, world: World, byteLength: number) =>
 }
 
 export const readMetadata = (v: ViewCursor, world: World) => {
-  world.fixedTick = readUint32(v)
+  const fixedTick = readUint32(v)
+  const fromHost = readUint32(v) === world.userIdToUserIndex.get(world.hostId)!
+  if (fromHost && !world.isHosting) world.fixedTick = fixedTick
   // const time = readUint32(v)
 }
 

--- a/packages/engine/src/networking/serialization/DataReader.ts
+++ b/packages/engine/src/networking/serialization/DataReader.ts
@@ -1,6 +1,7 @@
 import { TypedArray } from 'bitecs'
 
 import { NetworkId } from '@xrengine/common/src/interfaces/NetworkId'
+import { UserId } from '@xrengine/common/src/interfaces/UserId'
 
 import { Entity } from '../../ecs/classes/Entity'
 import { World } from '../../ecs/classes/World'
@@ -141,13 +142,11 @@ export const readXRInputs = (v: ViewCursor, entity: Entity, shouldWrite = true) 
   if (checkBitflag(changeMask, 1 << b++)) readXRControllerGripRightRotation(v, entity, shouldWrite)
 }
 
-export const readEntity = (v: ViewCursor, world: World) => {
-  const userIndex = readUint32(v)
-  const userId = world.userIndexToUserId.get(userIndex)!
+export const readEntity = (v: ViewCursor, world: World, fromUserId: UserId) => {
   const netId = readUint32(v) as NetworkId
   const changeMask = readUint8(v)
 
-  const entity = world.getNetworkObject(userId, netId)
+  const entity = world.getNetworkObject(fromUserId, netId)
   const shouldWrite = entity && !hasComponent(entity, NetworkObjectAuthorityTag)
 
   let b = 0
@@ -159,26 +158,27 @@ export const readEntity = (v: ViewCursor, world: World) => {
   network.lastTick = world.fixedTick
 }
 
-export const readEntities = (v: ViewCursor, world: World, byteLength: number) => {
+export const readEntities = (v: ViewCursor, world: World, byteLength: number, fromUserId: UserId) => {
   while (v.cursor < byteLength) {
     const count = readUint32(v)
     for (let i = 0; i < count; i++) {
-      readEntity(v, world)
+      readEntity(v, world, fromUserId)
     }
   }
 }
 
 export const readMetadata = (v: ViewCursor, world: World) => {
+  const userIndex = readUint32(v)
   const fixedTick = readUint32(v)
-  const fromHost = readUint32(v) === world.userIdToUserIndex.get(world.hostId)!
-  if (fromHost && !world.isHosting) world.fixedTick = fixedTick
-  // const time = readUint32(v)
+  if (userIndex === world.userIdToUserIndex.get(world.hostId)! && !world.isHosting) world.fixedTick = fixedTick
+  return userIndex
 }
 
 export const createDataReader = () => {
   return (world: World, packet: ArrayBuffer) => {
     const view = createViewCursor(packet)
-    readMetadata(view, world)
-    readEntities(view, world, packet.byteLength)
+    const userIndex = readMetadata(view, world)
+    const fromUserId = world.userIndexToUserId.get(userIndex)
+    if (fromUserId) readEntities(view, world, packet.byteLength, fromUserId)
   }
 }

--- a/packages/engine/src/networking/serialization/DataWriter.test.ts
+++ b/packages/engine/src/networking/serialization/DataWriter.test.ts
@@ -10,7 +10,7 @@ import { Entity } from '../../ecs/classes/Entity'
 import { createWorld } from '../../ecs/classes/World'
 import { addComponent } from '../../ecs/functions/ComponentFunctions'
 import { createEntity } from '../../ecs/functions/EntityFunctions'
-import { TransformComponent, Vector3Schema } from '../../transform/components/TransformComponent'
+import { TransformComponent } from '../../transform/components/TransformComponent'
 import { NetworkObjectComponent } from '../components/NetworkObjectComponent'
 import {
   createDataWriter,
@@ -22,7 +22,6 @@ import {
   writeTransform,
   writeVector3
 } from './DataWriter'
-import { Vector3SoA } from './Utils'
 import { createViewCursor, readFloat32, readUint8, readUint32, sliceViewCursor } from './ViewCursor'
 
 describe('DataWriter', () => {
@@ -33,6 +32,7 @@ describe('DataWriter', () => {
   it('should writeComponent', () => {
     const writeView = createViewCursor()
     const entity = 1234 as Entity
+    Engine.currentWorld.fixedTick = 1
 
     const [x, y, z] = [1.5, 2.5, 3.5]
     TransformComponent.position.x[entity] = x
@@ -206,17 +206,14 @@ describe('DataWriter', () => {
 
     NetworkObjectComponent.networkId[entity] = networkId
 
-    writeEntity(writeView, userIndex, networkId, entity)
+    writeEntity(writeView, networkId, entity)
 
     const readView = createViewCursor(writeView.buffer)
 
     strictEqual(
       writeView.cursor,
-      2 * Uint32Array.BYTES_PER_ELEMENT + 4 * Uint8Array.BYTES_PER_ELEMENT + 7 * Float32Array.BYTES_PER_ELEMENT
+      1 * Uint32Array.BYTES_PER_ELEMENT + 4 * Uint8Array.BYTES_PER_ELEMENT + 7 * Float32Array.BYTES_PER_ELEMENT
     )
-
-    // read userIndex
-    strictEqual(readUint32(readView), userIndex)
 
     // read networkId
     strictEqual(readUint32(readView), networkId)
@@ -279,7 +276,7 @@ describe('DataWriter', () => {
 
     const expectedBytes =
       1 * Uint32Array.BYTES_PER_ELEMENT +
-      n * (2 * Uint32Array.BYTES_PER_ELEMENT + 4 * Uint8Array.BYTES_PER_ELEMENT + 7 * Float32Array.BYTES_PER_ELEMENT)
+      n * (1 * Uint32Array.BYTES_PER_ELEMENT + 4 * Uint8Array.BYTES_PER_ELEMENT + 7 * Float32Array.BYTES_PER_ELEMENT)
 
     strictEqual(writeView.cursor, 0)
     strictEqual(packet.byteLength, expectedBytes)
@@ -290,9 +287,6 @@ describe('DataWriter', () => {
     strictEqual(count, entities.length)
 
     for (let i = 0; i < count; i++) {
-      // read userIndex
-      strictEqual(readUint32(readView), entities[i])
-
       // read networkId
       strictEqual(readUint32(readView), entities[i])
 
@@ -355,22 +349,20 @@ describe('DataWriter', () => {
     const packet = write(world, entities)
 
     const expectedBytes =
-      2 * Uint32Array.BYTES_PER_ELEMENT +
-      n * (2 * Uint32Array.BYTES_PER_ELEMENT + 4 * Uint8Array.BYTES_PER_ELEMENT + 7 * Float32Array.BYTES_PER_ELEMENT)
+      3 * Uint32Array.BYTES_PER_ELEMENT +
+      n * (1 * Uint32Array.BYTES_PER_ELEMENT + 4 * Uint8Array.BYTES_PER_ELEMENT + 7 * Float32Array.BYTES_PER_ELEMENT)
 
     strictEqual(packet.byteLength, expectedBytes)
 
     const readView = createViewCursor(packet)
 
     const tick = readUint32(readView)
+    const userIndex = readUint32(readView)
 
     const count = readUint32(readView)
     strictEqual(count, entities.length)
 
     for (let i = 0; i < count; i++) {
-      // read userIndex
-      strictEqual(readUint32(readView), entities[i])
-
       // read networkId
       strictEqual(readUint32(readView), entities[i])
 

--- a/packages/engine/src/networking/serialization/DataWriter.ts
+++ b/packages/engine/src/networking/serialization/DataWriter.ts
@@ -1,5 +1,6 @@
 import { NetworkId } from '@xrengine/common/src/interfaces/NetworkId'
 
+import { Engine } from '../../ecs/classes/Engine'
 import { Entity } from '../../ecs/classes/Entity'
 import { World } from '../../ecs/classes/World'
 import { hasComponent } from '../../ecs/functions/ComponentFunctions'
@@ -199,6 +200,7 @@ export const writeEntities = (v: ViewCursor, entities: Entity[]) => {
 }
 
 export const writeMetadata = (v: ViewCursor, world: World) => {
+  writeUint32(v, world.userIdToUserIndex.get(Engine.userId)!)
   writeUint32(v, world.fixedTick)
   // writeUint32(v, Date.now())
 }

--- a/packages/engine/src/networking/serialization/DataWriter.ts
+++ b/packages/engine/src/networking/serialization/DataWriter.ts
@@ -164,10 +164,9 @@ export const writeXRInputs = (v: ViewCursor, entity: Entity) => {
   return (changeMask > 0 && writeChangeMask(changeMask)) || rewind()
 }
 
-export const writeEntity = (v: ViewCursor, userIndex: number, networkId: NetworkId, entity: Entity) => {
+export const writeEntity = (v: ViewCursor, networkId: NetworkId, entity: Entity) => {
   const rewind = rewindViewCursor(v)
 
-  const writeUserIndex = spaceUint32(v)
   const writeNetworkId = spaceUint32(v)
 
   const writeChangeMask = spaceUint8(v)
@@ -178,10 +177,7 @@ export const writeEntity = (v: ViewCursor, userIndex: number, networkId: Network
   changeMask |= writeVelocity(v, entity) ? 1 << b++ : b++ && 0
   changeMask |= writeXRInputs(v, entity) ? 1 << b++ : b++ && 0
 
-  return (
-    (changeMask > 0 && writeUserIndex(userIndex) && writeNetworkId(networkId) && writeChangeMask(changeMask)) ||
-    rewind()
-  )
+  return (changeMask > 0 && writeNetworkId(networkId) && writeChangeMask(changeMask)) || rewind()
 }
 
 export const writeEntities = (v: ViewCursor, entities: Entity[]) => {
@@ -190,9 +186,8 @@ export const writeEntities = (v: ViewCursor, entities: Entity[]) => {
   let count = 0
   for (let i = 0, l = entities.length; i < l; i++) {
     const entity = entities[i]
-    const userIndex = NetworkObjectComponent.ownerIndex[entity]
     const networkId = NetworkObjectComponent.networkId[entity] as NetworkId
-    count += writeEntity(v, userIndex, networkId, entity) ? 1 : 0
+    count += writeEntity(v, networkId, entity) ? 1 : 0
   }
 
   if (count > 0) writeCount(count)
@@ -202,7 +197,6 @@ export const writeEntities = (v: ViewCursor, entities: Entity[]) => {
 export const writeMetadata = (v: ViewCursor, world: World) => {
   writeUint32(v, world.userIdToUserIndex.get(Engine.userId)!)
   writeUint32(v, world.fixedTick)
-  // writeUint32(v, Date.now())
 }
 
 export const createDataWriter = (size: number = 100000) => {

--- a/packages/engine/src/networking/serialization/ViewCursor.ts
+++ b/packages/engine/src/networking/serialization/ViewCursor.ts
@@ -1,6 +1,7 @@
 import { TypedArray } from 'bitecs'
 
 import { Entity } from '../../ecs/classes/Entity'
+import { useWorld } from '../../ecs/functions/SystemHooks'
 import { NetworkObjectComponent } from '../components/NetworkObjectComponent'
 
 export type ViewCursor = DataView & { cursor: number; shadowMap: Map<TypedArray, TypedArray> }
@@ -48,7 +49,8 @@ export const writePropIfChanged = (v: ViewCursor, prop: TypedArray, entity: Enti
 
   const shadow = shadowMap.get(prop)! || (shadowMap.set(prop, prop.slice().fill(0)) && shadowMap.get(prop))!
 
-  const changed = shadow[entity] !== prop[entity]
+  // TODO: we should be handling the fixedDelta check more explicitly, passing down through all the functions
+  const changed = shadow[entity] !== prop[entity] || useWorld().fixedTick % 60 === 0
 
   shadow[entity] = prop[entity]
 


### PR DESCRIPTION
## Summary

A quick fix to periodically send the whole networked pose state regardless of if it's changed or not.

Also now sends the originating userIndex across the network so we can decipher if a packet is coming from the host or not.  Previously this was sent per-entity being serialized, which was expensive and unnecessary. 
This fixes the issue of clients reading their own fixedTick and getting desynced from the server.
This is currently still insecure as it needs curation on the server side between receiving and sending client data to other clients.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
