### PR TITLE
Improved transport reconnection logic.

### DIFF
--- a/packages/engine/src/networking/functions/NetworkActionReceptors.ts
+++ b/packages/engine/src/networking/functions/NetworkActionReceptors.ts
@@ -52,6 +52,7 @@ const removeClientNetworkActionReceptor = (world: World, userId: UserId, allowRe
   world.userIdToUserIndex.delete(userId)
   world.userIndexToUserId.delete(userIndex)
   world.clients.delete(userId)
+  world.namedEntities.delete(userId)
 }
 
 const spawnObjectNetworkActionReceptor = (world: World, action: ReturnType<typeof NetworkWorldAction.spawnObject>) => {

--- a/packages/gameserver/package.json
+++ b/packages/gameserver/package.json
@@ -33,8 +33,8 @@
   "scripts": {
     "check-errors": "tsc --noemit",
     "start": "cross-env APP_ENV=production ts-node --transpile-only src/index.ts",
-    "dev": "ts-node-dev --inspect=2995 --respawn --transpile-only src/index.ts",
-    "dev-channel": "cross-env GAMESERVER_PORT=3032 ts-node-dev --inspect=2996 --respawn --transpile-only src/index.ts",
+    "dev": "APP_ENV=development ts-node-dev --inspect=2995 --respawn --transpile-only src/index.ts",
+    "dev-channel": "APP_ENV=development cross-env GAMESERVER_PORT=3032 ts-node-dev --inspect=2996 --respawn --transpile-only src/index.ts",
     "dev-nossl": "cross-env NOSSL=true ts-node-dev --respawn --transpile-only src/index.ts",
     "test": "exit 0",
     "validate": "npm run build && npm run test"

--- a/packages/gameserver/src/WebRTCFunctions.ts
+++ b/packages/gameserver/src/WebRTCFunctions.ts
@@ -114,7 +114,11 @@ export const sendCurrentProducers = async (
         )
       )
         Object.entries(client.media).map(([subName, subValue]) => {
-          if ((subValue as any).channelType === channelType && (subValue as any).channelId === channelId)
+          if (
+            (subValue as any).channelType === channelType &&
+            (subValue as any).channelId === channelId &&
+            !(subValue as any).paused
+          )
             selfClient.socket!.emit(
               MessageTypes.WebRTCCreateProducer.toString(),
               client.userId,


### PR DESCRIPTION
## Summary

Made a lot of event listeners use named functions so that they can be removed on disconnect.

Added *_RECONNECTED message after re-creation of transports.

Saving current displayed gameserver warnings in local state, only clearing if update matches
the currently displayed error, e.g. CHANNEL_RECONNECTED should not clear warning if it's
displaying INSTANCE_DISCONNECTED.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
