### PR TITLE
Remove ownerIndex from NetworkObjectComponent

### DIFF
--- a/packages/engine/src/avatar/functions/avatarFunctions.test.ts
+++ b/packages/engine/src/avatar/functions/avatarFunctions.test.ts
@@ -58,7 +58,7 @@ describe('avatarFunctions Integration', async () => {
           const networkObject = addComponent(entity, NetworkObjectComponent, {
             // remote owner
             ownerId: Engine.userId,
-            ownerIndex: 0,
+            lastTick: 0,
             networkId: i as NetworkId,
             prefab: '',
             parameters: {}

--- a/packages/engine/src/avatar/functions/createAvatar.test.ts
+++ b/packages/engine/src/avatar/functions/createAvatar.test.ts
@@ -49,7 +49,7 @@ describe('createAvatar', () => {
     const networkObject = addComponent(entity, NetworkObjectComponent, {
       // remote owner
       ownerId: Engine.userId,
-      ownerIndex: 0,
+      lastTick: 0,
       networkId: 0 as NetworkId,
       prefab: '',
       parameters: {}

--- a/packages/engine/src/interaction/functions/equippableFunctions.test.ts
+++ b/packages/engine/src/interaction/functions/equippableFunctions.test.ts
@@ -31,7 +31,7 @@ describe('equippableFunctions', () => {
 
     const networkObject = addComponent(entity2, NetworkObjectComponent, {
       ownerId: 'server' as UserId,
-      ownerIndex: 0,
+      lastTick: 0,
       networkId: 0 as NetworkId,
       prefab: '',
       parameters: {}
@@ -47,7 +47,7 @@ describe('equippableFunctions', () => {
     const entity2: Entity = createEntity()
     const networkObject = addComponent(entity2, NetworkObjectComponent, {
       ownerId: 'server' as UserId,
-      ownerIndex: 0,
+      lastTick: 0,
       networkId: 0 as NetworkId,
       prefab: '',
       parameters: {}

--- a/packages/engine/src/interaction/systems/EquippableSystem.test.ts
+++ b/packages/engine/src/interaction/systems/EquippableSystem.test.ts
@@ -48,7 +48,7 @@ describe.skip('EquippableSystem Integration Tests', () => {
 
     const networkObject = addComponent(player, NetworkObjectComponent, {
       ownerId: Engine.userId,
-      ownerIndex: 0,
+      lastTick: 0,
       networkId: 0 as NetworkId,
       prefab: '',
       parameters: {}

--- a/packages/engine/src/networking/components/NetworkObjectComponent.ts
+++ b/packages/engine/src/networking/components/NetworkObjectComponent.ts
@@ -8,8 +8,6 @@ import { createMappedComponent } from '../../ecs/functions/ComponentFunctions'
 export type NetworkObjectComponentType = {
   /** The user who owns this object. */
   ownerId: UserId
-  /** Index of the owner's UserId. */
-  ownerIndex: number
   /** The network id for this object (this id is only unique per owner) */
   networkId: NetworkId
   /** All network objects need to be a registered prefab. */
@@ -21,7 +19,6 @@ export type NetworkObjectComponentType = {
 }
 
 const SCHEMA = {
-  ownerIndex: Types.ui32,
   networkId: Types.ui32
 }
 

--- a/packages/engine/src/networking/functions/NetworkActionReceptors.ts
+++ b/packages/engine/src/networking/functions/NetworkActionReceptors.ts
@@ -94,7 +94,6 @@ const spawnObjectNetworkActionReceptor = (world: World, action: ReturnType<typeo
 
   addComponent(entity, NetworkObjectComponent, {
     ownerId: action.$from,
-    ownerIndex: action.ownerIndex,
     networkId: action.networkId,
     prefab: action.prefab,
     parameters: action.parameters,

--- a/packages/engine/src/networking/serialization/DataReader.test.ts
+++ b/packages/engine/src/networking/serialization/DataReader.test.ts
@@ -352,7 +352,7 @@ describe('DataReader', () => {
     addComponent(entity, NetworkObjectComponent, {
       networkId,
       ownerId: userId,
-      ownerIndex: userIndex,
+      lastTick: 0,
       prefab: '',
       parameters: {}
     })
@@ -426,7 +426,7 @@ describe('DataReader', () => {
     addComponent(entity, NetworkObjectComponent, {
       networkId,
       ownerId: userId,
-      ownerIndex: userIndex,
+      lastTick: 0,
       prefab: '',
       parameters: {}
     })
@@ -528,7 +528,7 @@ describe('DataReader', () => {
       addComponent(entity, NetworkObjectComponent, {
         networkId,
         ownerId: userId,
-        ownerIndex: userIndex,
+        lastTick: 0,
         prefab: '',
         parameters: {}
       })
@@ -597,7 +597,7 @@ describe('DataReader', () => {
       addComponent(entity, NetworkObjectComponent, {
         networkId,
         ownerId: userId,
-        ownerIndex: userIndex,
+        lastTick: 0,
         prefab: '',
         parameters: {}
       })
@@ -696,7 +696,7 @@ describe('DataReader', () => {
       addComponent(entity, NetworkObjectComponent, {
         networkId,
         ownerId: userId,
-        ownerIndex: userIndex,
+        lastTick: 0,
         prefab: '',
         parameters: {}
       })
@@ -741,7 +741,7 @@ describe('DataReader', () => {
       addComponent(entity, NetworkObjectComponent, {
         networkId,
         ownerId: userId,
-        ownerIndex: userIndex,
+        lastTick: 0,
         prefab: '',
         parameters: {}
       })
@@ -780,7 +780,7 @@ describe('DataReader', () => {
       addComponent(entity, NetworkObjectComponent, {
         networkId,
         ownerId: userId,
-        ownerIndex: userIndex,
+        lastTick: 0,
         prefab: '',
         parameters: {}
       })

--- a/packages/engine/src/networking/serialization/DataWriter.test.ts
+++ b/packages/engine/src/networking/serialization/DataWriter.test.ts
@@ -199,7 +199,7 @@ describe('DataWriter', () => {
     addComponent(entity, NetworkObjectComponent, {
       networkId,
       ownerId: userId,
-      ownerIndex: userIndex,
+      lastTick: 0,
       prefab: '',
       parameters: {}
     })
@@ -265,7 +265,7 @@ describe('DataWriter', () => {
       addComponent(entity, NetworkObjectComponent, {
         networkId,
         ownerId: userId,
-        ownerIndex: userIndex,
+        lastTick: 0,
         prefab: '',
         parameters: {}
       })
@@ -340,7 +340,7 @@ describe('DataWriter', () => {
       addComponent(entity, NetworkObjectComponent, {
         networkId,
         ownerId: userId,
-        ownerIndex: userIndex,
+        lastTick: 0,
         prefab: '',
         parameters: {}
       })

--- a/packages/engine/tests/equippables/equippables.test.ts
+++ b/packages/engine/tests/equippables/equippables.test.ts
@@ -73,7 +73,7 @@ describe('Equippables Integration Tests', () => {
     // initially the object is owned by server
     const networkObject = addComponent(equippableEntity, NetworkObjectComponent, {
       ownerId: world.hostId,
-      ownerIndex: hostIndex,
+      lastTick: 0,
       networkId: 0 as NetworkId,
       prefab: '',
       parameters: {}

--- a/packages/gameserver/src/NetworkFunctions.ts
+++ b/packages/gameserver/src/NetworkFunctions.ts
@@ -328,7 +328,7 @@ export const handleJoinWorld = async (
   for (const action of world.cachedActions as Set<ReturnType<typeof NetworkWorldAction.spawnAvatar>>) {
     // we may have a need to remove the check for the prefab type to enable this to work for networked objects too
     if (action.type === 'network.SPAWN_OBJECT' && action.prefab === 'avatar') {
-      const ownerId = world.userIndexToUserId.get(action.ownerIndex)
+      const ownerId = action.$from
       if (ownerId) {
         const entity = world.getNetworkObject(ownerId, action.networkId)
         if (typeof entity !== 'undefined') {


### PR DESCRIPTION
## Summary

Slightly reduces complexity of netcode by reducing sources of truth for the `userIndex` of an object's owner, forcing the userIndex to be foudn via the ownerId on NetworkObjectComponent

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
