### PR TITLE
Fixed issues with OAuth by moving app.set('host') and ('port')

### DIFF
--- a/packages/server-core/src/createApp.ts
+++ b/packages/server-core/src/createApp.ts
@@ -120,6 +120,11 @@ export const createFeathersExpressApp = (configurationPipe = serverPipe): Applic
   const app = express(feathers()) as Application
   app.set('nextReadyEmitter', new EventEmitter())
 
+  // Feathers authentication-oauth will only append the port in production, but then it will also
+  // hard-code http as the protocol, so manually mashing host + port together if in local.
+  app.set('host', config.server.local ? config.server.hostname + ':' + config.server.port : config.server.hostname)
+  app.set('port', config.server.port)
+
   app.set('paginate', config.server.paginate)
   app.set('authentication', config.authentication)
 

--- a/packages/server/src/start.ts
+++ b/packages/server/src/start.ts
@@ -19,11 +19,6 @@ export const start = async (): Promise<void> => {
   const app = createFeathersExpressApp()
   serverPipe(app)
 
-  // Feathers authentication-oauth will only append the port in production, but then it will also
-  // hard-code http as the protocol, so manually mashing host + port together if in local.
-  app.set('host', config.server.local ? config.server.hostname + ':' + config.server.port : config.server.hostname)
-  app.set('port', config.server.port)
-
   app.use(favicon(path.join(config.server.publicDir, 'favicon.ico')))
   app.configure(channels)
 


### PR DESCRIPTION
## Summary

app.host and app.port need to be configured before authentication is configured, since it sets
the OAuth callback URLs from these values on setup.

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Unit & Integration tests passing via `npm run test:packages`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
