### PR TITLE
Fixed [Admin] the pagination count of groups in admin are wrong #5574

### DIFF
--- a/packages/client-core/src/admin/common/Table.tsx
+++ b/packages/client-core/src/admin/common/Table.tsx
@@ -144,10 +144,10 @@ const TableComponent = (props: Props) => {
           />
           <TableBody>
             {stableSort(rows, getComparator(order, orderBy))
-              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+              //.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
               .map((row, index) => {
                 return (
-                  <TableRow hover role="checkbox" tabIndex={-1} key={row.name}>
+                  <TableRow hover role="checkbox" tabIndex={-1} key={`${index}${row.name}`}>
                     {column.map((column, index) => {
                       const value = row[column.id]
                       return (

--- a/packages/client-core/src/admin/services/GroupService.ts
+++ b/packages/client-core/src/admin/services/GroupService.ts
@@ -61,11 +61,7 @@ export const useGroupState = () => useState(state) as any as typeof state
 
 //Service
 export const GroupService = {
-  getGroupService: async (
-    incDec?: 'increment' | 'decrement',
-    search: string | null = null,
-    skip = accessGroupState().skip.value
-  ) => {
+  getGroupService: async (incDec?: 'increment' | 'decrement', search: string | null = null, skip = 0) => {
     const dispatch = useDispatch()
     {
       const limit = accessGroupState().limit.value

--- a/packages/client-core/src/admin/services/UserService.ts
+++ b/packages/client-core/src/admin/services/UserService.ts
@@ -81,11 +81,7 @@ export const useUserState = () => useState(state) as any as typeof state
 
 //Service
 export const UserService = {
-  fetchUsersAsAdmin: async (
-    incDec?: 'increment' | 'decrement',
-    value: string | null = null,
-    skip = accessUserState().skip.value
-  ) => {
+  fetchUsersAsAdmin: async (incDec?: 'increment' | 'decrement', value: string | null = null, skip = 0) => {
     const dispatch = useDispatch()
     {
       const userState = accessUserState()

--- a/packages/server-core/src/social/group/group.class.ts
+++ b/packages/server-core/src/social/group/group.class.ts
@@ -71,7 +71,8 @@ export class Group<T = GroupDataType> extends Service<T> {
       limit: limit,
       order: [['name', 'ASC']],
       include: include,
-      where: q
+      where: q,
+      distinct: true
     })
 
     await Promise.all(


### PR DESCRIPTION
## Summary

Fixed  pagination count of groups in admin

## Checklist
- [x] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
