### PR TITLE
Resize Avatar in Avatar Load Pipeline

### DIFF
--- a/packages/engine/src/avatar/functions/avatarFunctions.ts
+++ b/packages/engine/src/avatar/functions/avatarFunctions.ts
@@ -47,6 +47,7 @@ import { AvatarPendingComponent } from '../components/AvatarPendingComponent'
 import { bonesData2 } from '../DefaultSkeletonBones'
 import { DissolveEffect } from '../DissolveEffect'
 import { SkeletonUtils } from '../SkeletonUtils'
+import { resizeAvatar } from './resizeAvatar'
 
 const vec3 = new Vector3()
 
@@ -194,9 +195,11 @@ export const setupAvatarHeight = (entity: Entity, boneStructure: BoneStructure) 
   const eyeTarget = boneStructure.LeftEye ?? boneStructure.Head ?? boneStructure.Neck
   boneStructure.Neck.updateMatrixWorld(true)
   boneStructure.Root.updateMatrixWorld(true)
-  const avatar = getComponent(entity, AvatarComponent)
-  avatar.avatarHeight = eyeTarget.getWorldPosition(vec3).y - boneStructure.Root.getWorldPosition(vec3).y
-  avatar.avatarHalfHeight = avatar.avatarHeight / 2
+
+  const eyeHeight = eyeTarget.getWorldPosition(vec3).y
+  const rootHeight = boneStructure.Root.getWorldPosition(vec3).y
+
+  resizeAvatar(entity, eyeHeight - rootHeight)
 }
 
 export const loadGrowingEffectObject = (entity: Entity, originalMatList: Array<MaterialMap>) => {

--- a/packages/engine/src/avatar/functions/resizeAvatar.ts
+++ b/packages/engine/src/avatar/functions/resizeAvatar.ts
@@ -1,0 +1,23 @@
+import { Entity } from '../../ecs/classes/Entity'
+import { getComponent } from '../../ecs/functions/ComponentFunctions'
+import { ColliderComponent } from '../../physics/components/ColliderComponent'
+import { RaycastComponent } from '../../physics/components/RaycastComponent'
+import { AvatarComponent } from '../components/AvatarComponent'
+import { AvatarControllerComponent } from '../components/AvatarControllerComponent'
+
+export const resizeAvatar = (entity: Entity, height: number) => {
+  const avatar = getComponent(entity, AvatarComponent)
+
+  avatar.avatarHeight = height
+  avatar.avatarHalfHeight = avatar.avatarHeight / 2
+
+  getComponent(entity, AvatarControllerComponent).controller.resize(avatar.avatarHeight - 0.5)
+  const shape = getComponent(entity, ColliderComponent).body.getShapes() as PhysX.PxShape
+  const geometry = new PhysX.PxCapsuleGeometry(0, 0)
+  shape.getCapsuleGeometry(geometry)
+  geometry.setHalfHeight(avatar.avatarHalfHeight - 0.25)
+  shape.setGeometry(geometry)
+
+  const raycast = getComponent(entity, RaycastComponent)
+  raycast.maxDistance = avatar.avatarHalfHeight + 0.05 // add small offset so raycaster hits properly
+}


### PR DESCRIPTION
## Summary

resizes the avatar controller, collider and raycaster to properly align model with capsule and ground. 

future work is improving the calculation for sizing these things based on distance between bottom of feet and hips, and hips and top of head, rather than just eyes to root

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

closes #5579

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
