### PR TITLE
Added script to check db exists only

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "make-user-admin": "ts-node scripts/make-user-admin.js",
     "install-projects": "ts-node scripts/install-projects.js",
     "check-db-exists": "cross-env ts-node --transpile-only scripts/check-db-exists.ts",
+    "check-db-exists-only": "cross-env ts-node --transpile-only scripts/check-db-exists-only.ts",
     "init-db-production": "cross-env APP_ENV=production FORCE_DB_REFRESH=true EXIT_ON_DB_INIT=true ts-node --transpile-only packages/server/src/index.ts",
     "prepare-database": "cross-env APP_ENV=production PREPARE_DATABASE=true EXIT_ON_DB_INIT=true ts-node --transpile-only packages/server/src/index.ts",
     "clean-node-modules": "npx rimraf node_modules && npx rimraf package-lock.json && npx lerna exec npx rimraf node_modules && npx lerna exec npx rimraf package-lock.json",

--- a/scripts/check-db-exists-only.ts
+++ b/scripts/check-db-exists-only.ts
@@ -1,0 +1,37 @@
+import cli from 'cli'
+import { Sequelize } from 'sequelize'
+
+const db = {
+  username: process.env.MYSQL_USER ?? 'server',
+  password: process.env.MYSQL_PASSWORD ?? 'password',
+  database: process.env.MYSQL_DATABASE ?? 'xrengine',
+  host: process.env.MYSQL_HOST ?? '127.0.0.1',
+  port: process.env.MYSQL_PORT ?? 3306,
+  dialect: 'mysql'
+} as any
+
+db.url = process.env.MYSQL_URL ?? `mysql://${db.username}:${db.password}@${db.host}:${db.port}/${db.database}`
+
+cli.enable('status')
+
+const sequelize = new Sequelize({
+  ...db,
+  logging: false,
+  define: {
+    freezeTableName: true
+  }
+})
+
+cli.main(async () => {
+  await sequelize.sync()
+
+  const [results] = await sequelize.query("SHOW TABLES LIKE 'user';")
+
+  if (results.length === 0) {
+    console.log('database not found')
+  } else {
+    console.log('database found')
+  }
+
+  process.exit(0)
+})


### PR DESCRIPTION
## Summary

This script was required for https://github.com/XRFoundation/XREngine-Control-Center to check whether the minikube database is populated with data or not. Incase it is not then appropriate value of FORCE_DB_REFRESH are passed in helm.

There is a previous script named `check-db-exists` but that script also populates the database which was not required.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
