### PR TITLE
Moved feathers-swagger to server-core package.json

### DIFF
--- a/packages/gameserver/package.json
+++ b/packages/gameserver/package.json
@@ -54,7 +54,6 @@
     "compression": "1.7.4",
     "cors": "2.8.5",
     "feathers-logger": "0.3.2",
-    "feathers-swagger": "1.2.1",
     "feathers-sync": "2.4.0",
     "helmet": "5.0.2",
     "mediasoup": "3.9.6",

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -66,6 +66,7 @@
     "feathers-hooks-common": "^5.0.3",
     "feathers-mailer": "^3.0.1",
     "feathers-sequelize": "6.3.2",
+    "feathers-swagger": "1.2.1",
     "feathers-sync": "2.4.0",
     "fs-blob-store": "6.0.0",
     "internal-ip": "^6.1.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -55,7 +55,6 @@
     "compression": "1.7.4",
     "cors": "2.8.5",
     "feathers-logger": "0.3.2",
-    "feathers-swagger": "1.2.1",
     "feathers-sync": "2.4.0",
     "helmet": "5.0.2",
     "mysql2": "2.3.3",


### PR DESCRIPTION
## Summary

server-core is the only package that uses feathers-swagger, and most other packages include server-core
anyway.

## Checklist
- [ ] Pre-push checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Unit & Integration tests passing via `npm run test:packages`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers

## References

_References to pertaining issue(s)_

## QA Steps

1. `git checkout pr_branch_name`
2. `npm install`
3. `npm run dev-reinit`
4. `npm run dev`

List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos.

## Reviewers

_Reviewers for this PR_
