### PR TITLE
Fix webrtc transport connection issues

### DIFF
--- a/packages/engine/src/networking/classes/Network.ts
+++ b/packages/engine/src/networking/classes/Network.ts
@@ -23,8 +23,8 @@ export class Network {
   static instance: Network = new Network()
   /** Object holding transport details over network. */
   transportHandler: NetworkTransportHandler<NetworkTransport, NetworkTransport>
-  /** Object holding transport details over network. */
-  // transport: NetworkTransport
+  /** Transport connection promises */
+  transportsConnectPending = [] as Promise<any>[]
   /** Network transports. */
   transports = [] as any[]
   /** List of data producer nodes. */

--- a/packages/engine/tests/networking/TestNetwork.ts
+++ b/packages/engine/tests/networking/TestNetwork.ts
@@ -3,6 +3,7 @@ import { Network } from '../../src/networking/classes/Network'
 import { DummyTransportHandler } from '../util/setupEngine'
 
 export class TestNetwork implements Network {
+  transportsConnectPending: Promise<any>[]
   transports: any[]
   dataProducers: Map<string, any>
   dataConsumers: Map<string, any>


### PR DESCRIPTION
In some cases, the client webrtc transport tries to connect to the gameserver more than once, which causes the connection to fail. Tracking the connection state in the server fixes the problem.

Added a `transportsConnectPending` array to Network.instance, which keeps track of pending connections. 

## References

closes #_insert number here_


## Checklist
- [ ] CI/CD checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Typescript passing via `npm run check-errors`
  - [ ] Unit & Integration tests passing via `npm run test`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
