### PR TITLE
Move all renderer associated objects from Engine to EngineRenderer

### DIFF
--- a/packages/client-core/src/components/InstanceChat/index.tsx
+++ b/packages/client-core/src/components/InstanceChat/index.tsx
@@ -212,12 +212,12 @@ const InstanceChat = (props: Props): any => {
                     activeChannel.messages?.length
                   )
                   .map((message) => {
-                    if (!Engine.isBot && isCommand(message.text)) return undefined
+                    if (isCommand(message.text)) return undefined
                     const system = getChatMessageSystem(message.text)
                     let chatMessage = message.text
 
                     if (system !== 'none') {
-                      if (Engine.isBot || system === 'jl_system') {
+                      if (system === 'jl_system') {
                         chatMessage = removeMessageSystem(message.text)
                       } else {
                         return undefined

--- a/packages/client-core/src/components/World/LocationLoadHelper.tsx
+++ b/packages/client-core/src/components/World/LocationLoadHelper.tsx
@@ -121,7 +121,6 @@ export const initClient = async (sceneData: SceneData) => {
         MediaStreamService.triggerUpdateNearbyLayerUsers()
       })
   })
-  Engine.isReady = true
 }
 
 export const loadLocation = (sceneData: SceneJson) => {

--- a/packages/client-core/src/social/services/ChatService.ts
+++ b/packages/client-core/src/social/services/ChatService.ts
@@ -378,15 +378,15 @@ if (globalThis.process.env['VITE_OFFLINE_MODE'] !== 'true') {
           const system = getChatMessageSystem(message.text)
           if (system !== 'none') {
             message.text = removeMessageSystem(message.text)
-            if (!Engine.isBot && !hasSubscribedToChatSystem(selfUser.id, system)) return
+            if (!hasSubscribedToChatSystem(selfUser.id, system)) return
           }
         }
       } else {
         const system = getChatMessageSystem(message.text)
         if (system !== 'none') {
           message.text = removeMessageSystem(message.text)
-          if (!Engine.isBot && !hasSubscribedToChatSystem(selfUser.id, system)) return
-        } else if (isCommand(message.text) && !Engine.isBot) return
+          if (!hasSubscribedToChatSystem(selfUser.id, system)) return
+        } else if (isCommand(message.text)) return
       }
     }
 

--- a/packages/client-core/src/systems/XRUILoadingSystem.tsx
+++ b/packages/client-core/src/systems/XRUILoadingSystem.tsx
@@ -49,7 +49,7 @@ export default async function XRUILoadingSystem(world: World) {
 
   return () => {
     // add a slow rotation to animate on desktop, otherwise just keep it static for VR
-    // if (!Engine.xrSession && !Engine.hasJoinedWorld) {
+    // if (!EngineRenderer.instance.xrSession && !accessEngineState().joinedWorld.value) {
     //   Engine.camera.rotateY(world.delta * 0.35)
     // } else {
     //   // todo: figure out how to make this work properly for VR

--- a/packages/client-core/tsconfig.json
+++ b/packages/client-core/tsconfig.json
@@ -6,7 +6,6 @@
       "dom",
       "dom.iterable"
     ],
-    "baseUrl": ".",
     "paths": {
       "@mui/styled-engine": ["./node_modules/@mui/styled-engine-sc"]
     },

--- a/packages/editor/src/components/properties/DirectionalLightNodeEditor.tsx
+++ b/packages/editor/src/components/properties/DirectionalLightNodeEditor.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { getComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
+import { EngineRenderer } from '@xrengine/engine/src/renderer/WebGLRendererSystem'
 import { DirectionalLightComponent } from '@xrengine/engine/src/scene/components/DirectionalLightComponent'
 import { Object3DComponent } from '@xrengine/engine/src/scene/components/Object3DComponent'
 
@@ -29,34 +30,37 @@ export const DirectionalLightNodeEditor: EditorComponentType = (props) => {
   const lightComponent = getComponent(props.node.entity, DirectionalLightComponent)
 
   useEffect(() => {
-    if (!Engine.isCSMEnabled || props.node.entity !== Engine.activeCSMLightEntity) return
+    if (!EngineRenderer.instance.isCSMEnabled || props.node.entity !== EngineRenderer.instance.activeCSMLightEntity)
+      return
 
-    if (selectionState.propertyName.value === 'rotation' && Engine.csm) {
-      getComponent(props.node.entity, Object3DComponent)?.value.getWorldDirection(Engine.csm.lightDirection)
+    if (selectionState.propertyName.value === 'rotation' && EngineRenderer.instance.csm) {
+      getComponent(props.node.entity, Object3DComponent)?.value.getWorldDirection(
+        EngineRenderer.instance.csm.lightDirection
+      )
     }
 
     if (selectionState.propertyName.value === 'color') {
-      Engine.csm.updateProperty('color', lightComponent.color)
+      EngineRenderer.instance.csm.updateProperty('color', lightComponent.color)
     }
 
     if (selectionState.propertyName.value === 'intensity') {
-      Engine.csm.updateProperty('intensity', lightComponent.intensity)
+      EngineRenderer.instance.csm.updateProperty('intensity', lightComponent.intensity)
     }
 
     if (selectionState.propertyName.value === 'shadowBias') {
-      Engine.csm.updateProperty('shadow.bias', lightComponent.shadowBias)
+      EngineRenderer.instance.csm.updateProperty('shadow.bias', lightComponent.shadowBias)
     }
 
     if (selectionState.propertyName.value === 'shadowRadius') {
-      Engine.csm.updateProperty('shadow.radius', lightComponent.shadowRadius)
+      EngineRenderer.instance.csm.updateProperty('shadow.radius', lightComponent.shadowRadius)
     }
 
     if (selectionState.propertyName.value === 'shadowMapResolution') {
-      Engine.csm.updateProperty('shadow.mapSize', lightComponent.shadowMapResolution)
+      EngineRenderer.instance.csm.updateProperty('shadow.mapSize', lightComponent.shadowMapResolution)
     }
 
     if (selectionState.propertyName.value === 'cameraFar') {
-      Engine.csm.updateProperty('shadow.camera.far', lightComponent.cameraFar)
+      EngineRenderer.instance.csm.updateProperty('shadow.camera.far', lightComponent.cameraFar)
     }
   }, [selectionState.objectChangeCounter.value])
 
@@ -80,7 +84,7 @@ export const DirectionalLightNodeEditor: EditorComponentType = (props) => {
         onChange={updateProperty(DirectionalLightComponent, 'intensity')}
         unit="cd"
       />
-      {Engine.isCSMEnabled && (
+      {EngineRenderer.instance.isCSMEnabled && (
         <InputGroup name="Use in CSM" label={t('editor:properties.directionalLight.lbl-useInCSM')}>
           <BooleanInput
             value={lightComponent.useInCSM}

--- a/packages/editor/src/components/properties/LightShadowProperties.tsx
+++ b/packages/editor/src/components/properties/LightShadowProperties.tsx
@@ -5,6 +5,7 @@ import { Vector2 } from 'three'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { EntityTreeNode } from '@xrengine/engine/src/ecs/classes/EntityTree'
 import { ComponentConstructor, getComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
+import { EngineRenderer } from '@xrengine/engine/src/renderer/WebGLRendererSystem'
 import { DirectionalLightComponent } from '@xrengine/engine/src/scene/components/DirectionalLightComponent'
 
 import { setPropertyOnSelectionEntities } from '../../classes/History'
@@ -66,7 +67,7 @@ export const LightShadowProperties = (props: LightShadowPropertiesProps) => {
   }
 
   const lightComponent = getComponent(props.node.entity, props.comp)
-  const csmEnabled = Engine.isCSMEnabled && props.comp === DirectionalLightComponent
+  const csmEnabled = EngineRenderer.instance.isCSMEnabled && props.comp === DirectionalLightComponent
 
   return (
     <Fragment>

--- a/packages/editor/src/controls/InputEvents.ts
+++ b/packages/editor/src/controls/InputEvents.ts
@@ -1,5 +1,5 @@
-import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { getComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
+import { EngineRenderer } from '@xrengine/engine/src/renderer/WebGLRendererSystem'
 
 import { InputComponent, InputComponentType } from '../classes/InputComponent'
 import isInputSelected from '../functions/isInputSelected'
@@ -19,7 +19,7 @@ const InputData: InputDataType = {
 let inputComponent: InputComponentType
 
 export function initInputEvents() {
-  const canvas = Engine.renderer.domElement
+  const canvas = EngineRenderer.instance.renderer.domElement
   InputData.boundingClientRect = canvas.getBoundingClientRect()
   window.addEventListener('keydown', onKeyDown)
   window.addEventListener('keyup', onKeyUp)
@@ -116,7 +116,10 @@ function onWindowMouseDown(event: MouseEvent): void {
 }
 
 function onWindowMouseUp(event: MouseEvent): void {
-  if (event.target !== Engine.renderer.domElement && InputData.mouseDownTarget === Engine.renderer.domElement) {
+  if (
+    event.target !== EngineRenderer.instance.renderer.domElement &&
+    InputData.mouseDownTarget === EngineRenderer.instance.renderer.domElement
+  ) {
     onMouseUp(event)
   }
 
@@ -187,9 +190,9 @@ function onMouseMove(event: MouseEvent): void {
     if (actionName === 'movementX' || actionName === 'movementY') {
       inputComponent.actionState[key] += event[actionName]
     } else if (actionName === 'normalizedMovementX') {
-      inputComponent.actionState[key] += -event.movementX / Engine.renderer.domElement.clientWidth
+      inputComponent.actionState[key] += -event.movementX / EngineRenderer.instance.renderer.domElement.clientWidth
     } else if (actionName === 'normalizedMovementY') {
-      inputComponent.actionState[key] += -event.movementY / Engine.renderer.domElement.clientHeight
+      inputComponent.actionState[key] += -event.movementY / EngineRenderer.instance.renderer.domElement.clientHeight
     } else if (actionName === 'position') {
       handlePosition(inputComponent.actionState, key, event)
     } else {
@@ -261,7 +264,7 @@ function onContextMenu(event: Event): void {
 }
 
 function onResize(): void {
-  InputData.boundingClientRect = Engine.renderer.domElement.getBoundingClientRect()
+  InputData.boundingClientRect = EngineRenderer.instance.renderer.domElement.getBoundingClientRect()
 }
 
 function onWindowBlur(): void {
@@ -277,7 +280,7 @@ function onWindowBlur(): void {
 }
 
 export function removeInputEvents(): void {
-  const canvas = Engine.renderer.domElement
+  const canvas = EngineRenderer.instance.renderer.domElement
   window.removeEventListener('keydown', onKeyDown)
   window.removeEventListener('keyup', onKeyUp)
   canvas.removeEventListener('wheel', onWheel)

--- a/packages/editor/src/controls/PlayModeControls.ts
+++ b/packages/editor/src/controls/PlayModeControls.ts
@@ -1,5 +1,6 @@
 import { store, useDispatch } from '@xrengine/client-core/src/store'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
+import { EngineRenderer } from '@xrengine/engine/src/renderer/WebGLRendererSystem'
 import { ObjectLayers } from '@xrengine/engine/src/scene/constants/ObjectLayers'
 
 import { executeCommandWithHistory } from '../classes/History'
@@ -12,7 +13,7 @@ export function enterPlayMode(): void {
   executeCommandWithHistory(EditorCommands.REPLACE_SELECTION, [])
   Engine.camera.layers.set(ObjectLayers.Scene)
 
-  Engine.renderer.domElement.addEventListener('click', onClickCanvas)
+  EngineRenderer.instance.renderer.domElement.addEventListener('click', onClickCanvas)
   document.addEventListener('pointerlockchange', onPointerLockChange)
   store.dispatch(EditorHelperAction.changedPlayMode(true))
 }
@@ -26,7 +27,7 @@ export function leavePlayMode(): void {
   dispatch(EditorHelperAction.changedFlyMode(false))
   removeInputActionMapping(ActionSets.FLY)
 
-  Engine.renderer.domElement.removeEventListener('click', onClickCanvas)
+  EngineRenderer.instance.renderer.domElement.removeEventListener('click', onClickCanvas)
   document.removeEventListener('pointerlockchange', onPointerLockChange)
   document.exitPointerLock()
 
@@ -34,13 +35,13 @@ export function leavePlayMode(): void {
 }
 
 function onClickCanvas(): void {
-  Engine.renderer.domElement.requestPointerLock()
+  EngineRenderer.instance.renderer.domElement.requestPointerLock()
 }
 
 function onPointerLockChange(): void {
   const dispatch = useDispatch()
 
-  if (document.pointerLockElement === Engine.renderer.domElement) {
+  if (document.pointerLockElement === EngineRenderer.instance.renderer.domElement) {
     dispatch(EditorHelperAction.changedFlyMode(true))
     addInputActionMapping(ActionSets.FLY, FlyMapping)
 
@@ -54,6 +55,6 @@ function onPointerLockChange(): void {
 }
 
 export function disposePlayModeControls(): void {
-  Engine.renderer.domElement.removeEventListener('click', onClickCanvas)
+  EngineRenderer.instance.renderer.domElement.removeEventListener('click', onClickCanvas)
   document.removeEventListener('pointerlockchange', onPointerLockChange)
 }

--- a/packages/editor/src/controls/input-mappings.ts
+++ b/packages/editor/src/controls/input-mappings.ts
@@ -1,4 +1,4 @@
-import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
+import { EngineRenderer } from '@xrengine/engine/src/renderer/WebGLRendererSystem'
 
 import { getInput } from '../functions/parseInputActionMapping'
 
@@ -200,7 +200,7 @@ export const EditorMapping: InputActionMapping = {
       left: { key: EditorActionSet.selectStart, defaultValue: 0 },
       position: { key: EditorActionSet.selectStartPosition, defaultValue: 0 },
       right: {
-        callback: (_event) => Engine.renderer.domElement.requestPointerLock(),
+        callback: (_event) => EngineRenderer.instance.renderer.domElement.requestPointerLock(),
         key: EditorActionSet.enableFlyMode,
         defaultValue: 0
       }
@@ -210,7 +210,7 @@ export const EditorMapping: InputActionMapping = {
       position: { key: EditorActionSet.selectEndPosition, defaultValue: 0 },
       right: {
         callback: (_event) => {
-          if (document.pointerLockElement === Engine.renderer.domElement) {
+          if (document.pointerLockElement === EngineRenderer.instance.renderer.domElement) {
             document.exitPointerLock()
           }
         },

--- a/packages/editor/src/functions/sceneRenderFunctions.ts
+++ b/packages/editor/src/functions/sceneRenderFunctions.ts
@@ -220,8 +220,8 @@ export async function exportScene(options = {} as DefaultExportOptionsType) {
 }*/
 
 export function disposeScene() {
-  Engine.activeCSMLightEntity = null
-  Engine.directionalLightEntities = []
+  EngineRenderer.instance.activeCSMLightEntity = null
+  EngineRenderer.instance.directionalLightEntities = []
   if (Engine.activeCameraEntity) removeEntity(Engine.activeCameraEntity, true)
   if (SceneState.gizmoEntity) removeEntity(SceneState.gizmoEntity, true)
   if (SceneState.editorEntity) removeEntity(SceneState.editorEntity, true)

--- a/packages/editor/src/functions/screenSpaceFunctions.ts
+++ b/packages/editor/src/functions/screenSpaceFunctions.ts
@@ -1,7 +1,7 @@
 import { Intersection, Object3D, Raycaster, Vector2, Vector3 } from 'three'
 
-import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { useWorld } from '@xrengine/engine/src/ecs/functions/SystemHooks'
+import { EngineRenderer } from '@xrengine/engine/src/renderer/WebGLRendererSystem'
 import { SnapMode } from '@xrengine/engine/src/scene/constants/transformConstants'
 
 import { executeCommand } from '../classes/History'
@@ -68,7 +68,7 @@ export const getSpawnPositionAtCenter = (() => {
  * @returns
  */
 export function getCursorSpawnPosition(mousePos: Vector2, target = new Vector3()): Vector3 {
-  const rect = Engine.renderer.domElement.getBoundingClientRect()
+  const rect = EngineRenderer.instance.renderer.domElement.getBoundingClientRect()
   const position = new Vector2()
   position.x = ((mousePos.x - rect.left) / rect.width) * 2 - 1
   position.y = ((mousePos.y - rect.top) / rect.height) * -2 + 1

--- a/packages/editor/src/functions/takeScreenshot.ts
+++ b/packages/editor/src/functions/takeScreenshot.ts
@@ -22,7 +22,7 @@ import { getCanvasBlob } from './thumbnails'
 export async function takeScreenshot(width: number, height: number): Promise<Blob | null> {
   EngineRenderer.instance.disableUpdate = true
   const size = new Vector2()
-  Engine.renderer.getSize(size)
+  EngineRenderer.instance.renderer.getSize(size)
 
   let scenePreviewCamera: PerspectiveCamera = null!
   const query = defineQuery([ScenePreviewCameraTagComponent])
@@ -44,12 +44,12 @@ export async function takeScreenshot(width: number, height: number): Promise<Blo
   scenePreviewCamera.updateProjectionMatrix()
   scenePreviewCamera.layers.disableAll()
   scenePreviewCamera.layers.set(ObjectLayers.Scene)
-  Engine.renderer.setSize(width, height, false)
-  Engine.renderer.render(Engine.scene, scenePreviewCamera)
-  const blob = await getCanvasBlob(Engine.renderer.domElement)
+  EngineRenderer.instance.renderer.setSize(width, height, false)
+  EngineRenderer.instance.renderer.render(Engine.scene, scenePreviewCamera)
+  const blob = await getCanvasBlob(EngineRenderer.instance.renderer.domElement)
   scenePreviewCamera.aspect = prevAspect
   scenePreviewCamera.updateProjectionMatrix()
-  Engine.renderer.setSize(size.x, size.y, false)
+  EngineRenderer.instance.renderer.setSize(size.x, size.y, false)
   EngineRenderer.instance.disableUpdate = false
   return blob
 }

--- a/packages/editor/src/functions/updateOutlinePassSelection.ts
+++ b/packages/editor/src/functions/updateOutlinePassSelection.ts
@@ -1,12 +1,12 @@
-import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { getComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
+import { EngineRenderer } from '@xrengine/engine/src/renderer/WebGLRendererSystem'
 import { Object3DComponent } from '@xrengine/engine/src/scene/components/Object3DComponent'
 import { Effects } from '@xrengine/engine/src/scene/constants/PostProcessing'
 
 import { accessSelectionState } from '../services/SelectionServices'
 
 export const updateOutlinePassSelection = (): void => {
-  if (!Engine.effectComposer || !Engine.effectComposer[Effects.OutlineEffect]) return
+  if (!EngineRenderer.instance.effectComposer || !EngineRenderer.instance.effectComposer[Effects.OutlineEffect]) return
 
   const meshes = [] as any[]
   const parentEntities = accessSelectionState().selectedParentEntities.value
@@ -23,5 +23,5 @@ export const updateOutlinePassSelection = (): void => {
     })
   }
 
-  Engine.effectComposer[Effects.OutlineEffect].selection.set(meshes)
+  EngineRenderer.instance.effectComposer[Effects.OutlineEffect].selection.set(meshes)
 }

--- a/packages/editor/src/functions/uploadCubemapBake.ts
+++ b/packages/editor/src/functions/uploadCubemapBake.ts
@@ -10,6 +10,7 @@ import {
   hasComponent
 } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
 import { useWorld } from '@xrengine/engine/src/ecs/functions/SystemHooks'
+import { EngineRenderer } from '@xrengine/engine/src/renderer/WebGLRendererSystem'
 import { beforeMaterialCompile } from '@xrengine/engine/src/scene/classes/BPCEMShader'
 import CubemapCapturer from '@xrengine/engine/src/scene/classes/CubemapCapturer'
 import { convertCubemapToEquiImageData } from '@xrengine/engine/src/scene/classes/ImageUtils'
@@ -84,7 +85,11 @@ export const uploadBakeToServer = async (entity: Entity) => {
     )
   })
 
-  const cubemapCapturer = new CubemapCapturer(Engine.renderer, Engine.scene, bakeComponent.options.resolution)
+  const cubemapCapturer = new CubemapCapturer(
+    EngineRenderer.instance.renderer,
+    Engine.scene,
+    bakeComponent.options.resolution
+  )
   const renderTarget = cubemapCapturer.update(position)
 
   // remove injected bpcem logic from material
@@ -99,7 +104,7 @@ export const uploadBakeToServer = async (entity: Entity) => {
   if (isSceneEntity) Engine.scene.environment = renderTarget.texture
 
   const { blob } = await convertCubemapToEquiImageData(
-    Engine.renderer,
+    EngineRenderer.instance.renderer,
     renderTarget,
     bakeComponent.options.resolution,
     bakeComponent.options.resolution,

--- a/packages/editor/src/systems/RenderSystem.ts
+++ b/packages/editor/src/systems/RenderSystem.ts
@@ -1,16 +1,16 @@
-import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { World } from '@xrengine/engine/src/ecs/classes/World'
+import { EngineRenderer } from '@xrengine/engine/src/renderer/WebGLRendererSystem'
 
 import { SceneState } from '../functions/sceneRenderFunctions'
 
 export default async function EditorInfoSystem(world: World) {
   return () => {
     if (SceneState.onUpdateStats) {
-      Engine.renderer.info.reset()
-      const renderStat = Engine.renderer.info.render as any
+      EngineRenderer.instance.renderer.info.reset()
+      const renderStat = EngineRenderer.instance.renderer.info.render as any
       renderStat.fps = 1 / world.delta
       renderStat.frameTime = world.delta * 1000
-      SceneState.onUpdateStats(Engine.renderer.info)
+      SceneState.onUpdateStats(EngineRenderer.instance.renderer.info)
     }
   }
 }

--- a/packages/engine/src/assets/functions/createGLTFLoader.ts
+++ b/packages/engine/src/assets/functions/createGLTFLoader.ts
@@ -1,7 +1,7 @@
 import { VRMLoaderPlugin } from '@pixiv/three-vrm'
 
 import { isClient } from '../../common/functions/isClient'
-import { Engine } from '../../ecs/classes/Engine'
+import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { GLTFHubsComponentsExtension } from '../classes/GLTFHubsComponentsExtension'
 import { GLTFHubsLightMapExtension } from '../classes/GLTFHubsLightMapExtension'
 import { GLTFInstancingExtension } from '../classes/GLTFInstancingExtension'
@@ -15,7 +15,7 @@ import { NodeDRACOLoader } from '../loaders/gltf/NodeDracoLoader'
 export const initializeKTX2Loader = (loader: GLTFLoader) => {
   const ktxLoader: any = new KTX2Loader()
   ktxLoader.setTranscoderPath(`/loader_decoders/basis/`)
-  ktxLoader.detectSupport(Engine.renderer)
+  ktxLoader.detectSupport(EngineRenderer.instance.renderer)
   loader.setKTX2Loader(ktxLoader)
 }
 

--- a/packages/engine/src/avatar/functions/createAvatar.test.ts
+++ b/packages/engine/src/avatar/functions/createAvatar.test.ts
@@ -42,7 +42,6 @@ describe('createAvatar', () => {
 
   it('check the create avatar function', () => {
     Engine.userId = world.hostId
-    Engine.hasJoinedWorld = true
 
     // mock entity to apply incoming unreliable updates to
     const entity = createEntity()

--- a/packages/engine/src/bot/functions/botHookFunctions.ts
+++ b/packages/engine/src/bot/functions/botHookFunctions.ts
@@ -1,6 +1,7 @@
 import { MathUtils, Quaternion, Vector3 } from 'three'
 
 import { Engine } from '../../ecs/classes/Engine'
+import { accessEngineState } from '../../ecs/classes/EngineService'
 import { getComponent } from '../../ecs/functions/ComponentFunctions'
 import { useWorld } from '../../ecs/functions/SystemHooks'
 import { TransformComponent } from '../../transform/components/TransformComponent'
@@ -45,7 +46,7 @@ export function initializeBot() {
 // === ENGINE === //
 
 export function locationLoaded() {
-  return Engine.hasJoinedWorld
+  return accessEngineState().joinedWorld.value
 }
 
 export function sceneLoaded() {

--- a/packages/engine/src/bot/functions/xrBotHookFunctions.ts
+++ b/packages/engine/src/bot/functions/xrBotHookFunctions.ts
@@ -7,6 +7,7 @@ import { Engine } from '../../ecs/classes/Engine'
 import { EngineActions } from '../../ecs/classes/EngineService'
 import { getComponent } from '../../ecs/functions/ComponentFunctions'
 import { useWorld } from '../../ecs/functions/SystemHooks'
+import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { XRInputSourceComponent } from '../../xr/components/XRInputSourceComponent'
 import { WebXREventDispatcher } from '../webxr-emulator/WebXREventDispatcher'
 
@@ -65,7 +66,7 @@ export async function xrSupported() {
 }
 
 export function xrInitialized() {
-  return Boolean(Engine.xrSession)
+  return Boolean(EngineRenderer.instance.xrSession)
 }
 
 export function startXR() {

--- a/packages/engine/src/bot/systems/BotHookSystem.ts
+++ b/packages/engine/src/bot/systems/BotHookSystem.ts
@@ -1,10 +1,11 @@
 import { Engine } from '../../ecs/classes/Engine'
 import { World } from '../../ecs/classes/World'
+import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { sendXRInputData } from '../functions/xrBotHookFunctions'
 
 export default async function BotHookSystem(world: World) {
   return () => {
-    if (Engine.isBot && Boolean(Engine.xrSession)) {
+    if (Engine.isBot && Boolean(EngineRenderer.instance.xrSession)) {
       sendXRInputData()
     }
   }

--- a/packages/engine/src/camera/systems/CameraSystem.ts
+++ b/packages/engine/src/camera/systems/CameraSystem.ts
@@ -14,6 +14,7 @@ import { Entity } from '../../ecs/classes/Entity'
 import { World } from '../../ecs/classes/World'
 import { addComponent, defineQuery, getComponent, removeComponent } from '../../ecs/functions/ComponentFunctions'
 import { createEntity } from '../../ecs/functions/EntityFunctions'
+import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { Object3DComponent } from '../../scene/components/Object3DComponent'
 import { PersistTagComponent } from '../../scene/components/PersistTagComponent'
 import { ObjectLayers } from '../../scene/constants/ObjectLayers'
@@ -289,9 +290,9 @@ export default async function CameraSystem(world: World) {
         updateCameraTargetRotation(entity, delta)
       }
 
-      if (Engine.xrManager?.isPresenting) {
+      if (EngineRenderer.instance.xrManager?.isPresenting) {
         // Current WebXRManager.updateCamera() typedef is incorrect
-        ;(Engine.xrManager as any).updateCamera(Engine.camera)
+        ;(EngineRenderer.instance.xrManager as any).updateCamera(Engine.camera)
 
         removeComponent(Engine.currentWorld.localClientEntity, XRCameraUpdatePendingTagComponent)
       } else if (followCameraEntity !== undefined) {

--- a/packages/engine/src/common/functions/Timer.ts
+++ b/packages/engine/src/common/functions/Timer.ts
@@ -1,4 +1,5 @@
 import { Engine } from '../../ecs/classes/Engine'
+import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { isClient } from './isClient'
 import { nowMilliseconds } from './nowMilliseconds'
 import { ServerLoop } from './ServerLoop'
@@ -136,7 +137,7 @@ export function Timer(update: TimerUpdateCallback) {
     elapsedTime = 0
     lastTime = startTime
     if (isClient) {
-      Engine.renderer.setAnimationLoop(onFrame)
+      EngineRenderer.instance.renderer.setAnimationLoop(onFrame)
     } else {
       const _update = () => {
         const time = nowMilliseconds()
@@ -149,7 +150,7 @@ export function Timer(update: TimerUpdateCallback) {
 
   function stop() {
     if (isClient) {
-      Engine.renderer.setAnimationLoop(null)
+      EngineRenderer.instance.renderer.setAnimationLoop(null)
     } else {
       serverLoop.stop()
     }

--- a/packages/engine/src/debug/systems/DebugRenderer.ts
+++ b/packages/engine/src/debug/systems/DebugRenderer.ts
@@ -22,6 +22,7 @@ import { World } from '../../ecs/classes/World'
 import { getGeometryType, isControllerBody, isTriggerShape } from '../../physics/classes/Physics'
 import { RaycastComponent } from '../../physics/components/RaycastComponent'
 import { BodyType } from '../../physics/types/PhysicsTypes'
+import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { ObjectLayers } from '../../scene/constants/ObjectLayers'
 import { setObjectLayers } from '../../scene/functions/setObjectLayers'
 
@@ -246,7 +247,7 @@ export const DebugRenderer = () => {
       enabled = _enabled
       setEnabled(_enabled)
       // @ts-ignore
-      const xrCameras = Engine.xrManager?.getCamera() as ArrayCamera
+      const xrCameras = EngineRenderer.instance.xrManager?.getCamera() as ArrayCamera
       if (enabled) {
         Engine.camera.layers.enable(ObjectLayers.PhysicsHelper)
         if (xrCameras) xrCameras.cameras.forEach((camera) => camera.layers.enable(ObjectLayers.PhysicsHelper))

--- a/packages/engine/src/ecs/classes/Engine.ts
+++ b/packages/engine/src/ecs/classes/Engine.ts
@@ -34,44 +34,35 @@ import { Entity } from './Entity'
  * @author Josh, Vyacheslav, Gheric and the XREngine Team
  */
 export class Engine {
-  /** The uuid of the logged-in user */
-  public static userId: UserId
+  static instance: Engine
 
-  public static store = createHyperStore({
+  /** The uuid of the logged-in user */
+  static userId: UserId
+
+  static store = createHyperStore({
     name: 'ENGINE',
     getDispatchId: () => 'engine',
     getDispatchTime: () => Engine.elapsedTime
   })
 
-  public static elapsedTime = 0
+  static elapsedTime = 0
 
-  public static engineTimer: { start: Function; stop: Function; clear: Function } = null!
+  static engineTimer: { start: Function; stop: Function; clear: Function } = null!
 
-  public static isBot = 'window' in globalThis ? isBot(window) : false
+  static isBot = false
 
-  public static isHMD = false
+  static isHMD = false
 
   /**
    * The current world
    */
-  public static currentWorld: World = null!
+  static currentWorld: World = null!
 
   /**
    * All worlds that are currently instantiated
    */
-  public static worlds: World[] = []
+  static worlds: World[] = []
 
-  /**
-   * Reference to the three.js renderer object.
-   */
-  static renderer: WebGLRenderer = null!
-  static effectComposer: EffectComposerWithSchema = null!
-  static xrManager: WebXRManager = null!
-  static xrSession: XRSession = null!
-  static csm: CSM = null!
-  static isCSMEnabled = false
-  static directionalLightEntities: Entity[] = []
-  static activeCSMLightEntity: Entity | null = null
   /**
    * Reference to the three.js scene object.
    */
@@ -103,14 +94,12 @@ export class Engine {
   static inputState = new Map<any, InputValue>()
   static prevInputState = new Map<any, InputValue>()
 
-  static isInitialized = false
-  static isReady = false
-
-  static hasJoinedWorld = false
+  static get isInitialized() {
+    return accessEngineState().isEngineInitialized.value
+  }
 
   static publicPath: string
 
-  static workers = [] as any[]
   static simpleMaterials = false
   static xrFrame: XRFrame
 

--- a/packages/engine/src/ecs/functions/EngineFunctions.ts
+++ b/packages/engine/src/ecs/functions/EngineFunctions.ts
@@ -7,6 +7,7 @@ import { AssetLoader, disposeDracoLoaderWorkers } from '../../assets/classes/Ass
 import { isClient } from '../../common/functions/isClient'
 import { configureEffectComposer } from '../../renderer/functions/configureEffectComposer'
 import disposeScene from '../../renderer/functions/disposeScene'
+import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { PersistTagComponent } from '../../scene/components/PersistTagComponent'
 import { Engine } from '../classes/Engine'
 import { EngineActions } from '../classes/EngineService'
@@ -26,10 +27,6 @@ import {
 export function reset() {
   console.log('RESETTING ENGINE')
   dispatchAction(Engine.store, EngineActions.sceneUnloaded())
-
-  // Stop all running workers
-  Engine.workers.forEach((w) => w.terminate())
-  Engine.workers.length = 0
 
   disposeDracoLoaderWorkers()
 
@@ -66,21 +63,20 @@ export function reset() {
 
   Engine.camera = null!
 
-  if (Engine.renderer) {
-    Engine.renderer.clear(true, true, true)
-    Engine.renderer.dispose()
-    Engine.renderer = null!
+  if (EngineRenderer.instance.renderer) {
+    EngineRenderer.instance.renderer.clear(true, true, true)
+    EngineRenderer.instance.renderer.dispose()
+    EngineRenderer.instance.renderer = null!
   }
 
   AssetLoader.Cache.clear()
 
-  Engine.isInitialized = false
+  dispatchAction(Engine.store, EngineActions.initializeEngine({ initialised: false }))
   Engine.inputState.clear()
   Engine.prevInputState.clear()
 }
 
 export const unloadScene = async (world: World, removePersisted = false) => {
-  await Promise.all(Engine.sceneLoadPromises)
   unloadAllEntities(world, removePersisted)
 
   dispatchAction(Engine.store, EngineActions.sceneUnloaded())

--- a/packages/engine/src/initializeEngine.ts
+++ b/packages/engine/src/initializeEngine.ts
@@ -58,11 +58,6 @@ export const initializeBrowser = () => {
 
   globalThis.botHooks = BotHookFunctions
 
-  const joinedWorld = () => {
-    Engine.hasJoinedWorld = true
-  }
-  matchActionOnce(Engine.store, EngineActions.joinedWorld.matches, joinedWorld)
-
   setupInitialClickListener()
 
   // maybe needs to be awaited?
@@ -86,17 +81,15 @@ const setupInitialClickListener = () => {
 /**
  * initializeNode
  *
- * initializes everything for the ndoe context
+ * initializes everything for the node context
  */
 export const initializeNode = () => {
-  const joinedWorld = () => {
-    Engine.hasJoinedWorld = true
-  }
-  matchActionOnce(Engine.store, EngineActions.joinedWorld.matches, joinedWorld)
+  // node currently does not need to initialize anything
 }
 
 export const createEngine = () => {
   const world = createWorld()
+  Engine.instance = new Engine()
   Engine.currentWorld = world
   Engine.scene = new Scene()
   Engine.scene.layers.set(ObjectLayers.Scene)
@@ -145,7 +138,6 @@ export const initializeMediaServerSystems = async () => {
   Engine.engineTimer = Timer(executeWorlds)
   Engine.engineTimer.start()
 
-  Engine.isInitialized = true
   dispatchAction(Engine.store, EngineActions.initializeEngine({ initialised: true }))
 }
 
@@ -214,7 +206,6 @@ export const initializeCoreSystems = async (systems: SystemModuleType<any>[] = [
   Engine.engineTimer = Timer(executeWorlds)
   Engine.engineTimer.start()
 
-  Engine.isInitialized = true
   dispatchAction(Engine.store, EngineActions.initializeEngine({ initialised: true }))
 }
 

--- a/packages/engine/src/input/systems/ClientInputSystem.ts
+++ b/packages/engine/src/input/systems/ClientInputSystem.ts
@@ -4,6 +4,7 @@ import { Engine } from '../../ecs/classes/Engine'
 import { Entity } from '../../ecs/classes/Entity'
 import { World } from '../../ecs/classes/World'
 import { defineQuery, getComponent } from '../../ecs/functions/ComponentFunctions'
+import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { InputComponent, InputComponentType } from '../components/InputComponent'
 import { LocalInputTagComponent } from '../components/LocalInputTagComponent'
 import { InputType } from '../enums/InputType'
@@ -123,7 +124,7 @@ export default async function ClientInputSystem(world: World) {
   addClientInputListeners()
 
   return () => {
-    if (!Engine.xrSession) {
+    if (!EngineRenderer.instance.xrSession) {
       handleGamepads()
     }
 

--- a/packages/engine/src/interaction/systems/EquippableSystem.test.ts
+++ b/packages/engine/src/interaction/systems/EquippableSystem.test.ts
@@ -32,7 +32,6 @@ describe.skip('EquippableSystem Integration Tests', () => {
     Network.instance = new TestNetwork()
     Engine.currentWorld = world
     Engine.userId = world.hostId
-    Engine.hasJoinedWorld = true
     await Engine.currentWorld.physics.createScene({ verbose: true })
 
     equippableSystem = await EquippableSystem(world)

--- a/packages/engine/src/renderer/EngineRendererState.ts
+++ b/packages/engine/src/renderer/EngineRendererState.ts
@@ -87,13 +87,13 @@ export const accessEngineRendererState = () => state
 
 function setQualityLevel(qualityLevel) {
   EngineRenderer.instance.scaleFactor = qualityLevel / EngineRenderer.instance.maxQualityLevel
-  Engine.renderer.setPixelRatio(window.devicePixelRatio * EngineRenderer.instance.scaleFactor)
+  EngineRenderer.instance.renderer.setPixelRatio(window.devicePixelRatio * EngineRenderer.instance.scaleFactor)
   EngineRenderer.instance.needsResize = true
 }
 
 function setUseShadows(useShadows) {
   if (state.useShadows.value === useShadows) return
-  Engine.renderer.shadowMap.enabled = useShadows
+  EngineRenderer.instance.renderer.shadowMap.enabled = useShadows
 }
 
 function setUsePostProcessing(usePostProcessing) {

--- a/packages/engine/src/renderer/HighlightSystem.ts
+++ b/packages/engine/src/renderer/HighlightSystem.ts
@@ -1,21 +1,21 @@
 import { Object3D } from 'three'
 
-import { Engine } from '../ecs/classes/Engine'
 import { defineQuery, getComponent } from '../ecs/functions/ComponentFunctions'
 import { Object3DComponent } from '../scene/components/Object3DComponent'
 import { HighlightComponent } from './components/HighlightComponent'
+import { EngineRenderer } from './WebGLRendererSystem'
 
 export default async function HighlightSystem() {
   const highlightedObjectQuery = defineQuery([Object3DComponent, HighlightComponent])
 
   const addToSelection = (obj: Object3D) => {
-    Engine.effectComposer.OutlineEffect.selection.add(obj)
+    EngineRenderer.instance.effectComposer.OutlineEffect.selection.add(obj)
   }
 
   return () => {
-    if (!Engine.effectComposer.OutlineEffect) return
+    if (!EngineRenderer.instance.effectComposer.OutlineEffect) return
 
-    Engine.effectComposer.OutlineEffect.selection.clear()
+    EngineRenderer.instance.effectComposer.OutlineEffect.selection.clear()
 
     for (const entity of highlightedObjectQuery()) {
       const highlightedObject = getComponent(entity, Object3DComponent).value

--- a/packages/engine/src/renderer/WebGLRendererSystem.ts
+++ b/packages/engine/src/renderer/WebGLRendererSystem.ts
@@ -59,7 +59,7 @@ export interface EffectComposerWithSchema extends EffectComposer {
 let lastRenderTime = 0
 
 export class EngineRenderer {
-  static instance: EngineRenderer
+  static instance = new EngineRenderer()
 
   /** Is resize needed? */
   needsResize: boolean
@@ -101,9 +101,7 @@ export class EngineRenderer {
   directionalLightEntities: Entity[] = []
   activeCSMLightEntity: Entity | null = null
 
-  /** Constructs WebGL Renderer System. */
-  constructor() {
-    EngineRenderer.instance = this
+  initialize() {
     this.onResize = this.onResize.bind(this)
 
     this.supportWebGL2 = WebGL.isWebGL2Available()
@@ -249,7 +247,7 @@ export class EngineRenderer {
 }
 
 export default async function WebGLRendererSystem(world: World) {
-  new EngineRenderer()
+  EngineRenderer.instance.initialize()
 
   matchActionOnce(Engine.store, EngineActions.joinedWorld.matches, () => {
     restoreEngineRendererData()

--- a/packages/engine/src/renderer/WebGLRendererSystem.ts
+++ b/packages/engine/src/renderer/WebGLRendererSystem.ts
@@ -12,14 +12,24 @@ import {
   SSAOEffect,
   ToneMappingEffect
 } from 'postprocessing'
-import { PerspectiveCamera, sRGBEncoding, WebGL1Renderer, WebGLRenderer, WebGLRendererParameters } from 'three'
+import {
+  PerspectiveCamera,
+  sRGBEncoding,
+  WebGL1Renderer,
+  WebGLRenderer,
+  WebGLRendererParameters,
+  WebXRManager,
+  XRSession
+} from 'three'
 
 import { addActionReceptor, dispatchAction } from '@xrengine/hyperflux'
 
+import { CSM } from '../assets/csm/CSM'
 import { ExponentialMovingAverage } from '../common/classes/ExponentialAverageCurve'
 import { nowMilliseconds } from '../common/functions/nowMilliseconds'
 import { Engine } from '../ecs/classes/Engine'
 import { accessEngineState, EngineActions } from '../ecs/classes/EngineService'
+import { Entity } from '../ecs/classes/Entity'
 import { World } from '../ecs/classes/World'
 import { matchActionOnce } from '../networking/functions/matchActionOnce'
 import { LinearTosRGBEffect } from './effects/LinearTosRGBEffect'
@@ -82,6 +92,15 @@ export class EngineRenderer {
   /** To Disable update for renderer */
   disableUpdate = false
 
+  renderer: WebGLRenderer = null!
+  effectComposer: EffectComposerWithSchema = null!
+  xrManager: WebXRManager = null!
+  xrSession: XRSession = null!
+  csm: CSM = null!
+  isCSMEnabled = false
+  directionalLightEntities: Entity[] = []
+  activeCSMLightEntity: Entity | null = null
+
   /** Constructs WebGL Renderer System. */
   constructor() {
     EngineRenderer.instance = this
@@ -125,23 +144,23 @@ export class EngineRenderer {
     }
 
     const renderer = this.supportWebGL2 ? new WebGLRenderer(options) : new WebGL1Renderer(options)
-    Engine.renderer = renderer
-    Engine.renderer.physicallyCorrectLights = true
-    Engine.renderer.outputEncoding = sRGBEncoding
+    this.renderer = renderer
+    this.renderer.physicallyCorrectLights = true
+    this.renderer.outputEncoding = sRGBEncoding
 
     // DISABLE THIS IF YOU ARE SEEING SHADER MISBEHAVING - UNCHECK THIS WHEN TESTING UPDATING THREEJS
-    Engine.renderer.debug.checkShaderErrors = false
+    this.renderer.debug.checkShaderErrors = false
 
-    Engine.xrManager = renderer.xr
+    this.xrManager = renderer.xr
     //@ts-ignore
     renderer.xr.cameraAutoUpdate = false
-    Engine.xrManager.enabled = true
+    this.xrManager.enabled = true
 
     window.addEventListener('resize', this.onResize, false)
     this.onResize()
 
-    Engine.renderer.autoClear = true
-    Engine.effectComposer = new EffectComposer(Engine.renderer) as any
+    this.renderer.autoClear = true
+    this.effectComposer = new EffectComposer(this.renderer) as any
 
     configureEffectComposer()
   }
@@ -156,19 +175,19 @@ export class EngineRenderer {
    * @param delta Time since last frame.
    */
   execute(delta: number): void {
-    if (Engine.xrManager.isPresenting) {
-      Engine.csm?.update()
-      Engine.renderer.render(Engine.scene, Engine.camera)
+    if (this.xrManager.isPresenting) {
+      this.csm?.update()
+      this.renderer.render(Engine.scene, Engine.camera)
     } else {
       const state = accessEngineRendererState()
       const engineState = accessEngineState()
       if (state.automatic.value && engineState.joinedWorld.value) this.changeQualityLevel()
       if (this.rendereringEnabled) {
         if (this.needsResize) {
-          const curPixelRatio = Engine.renderer.getPixelRatio()
+          const curPixelRatio = this.renderer.getPixelRatio()
           const scaledPixelRatio = window.devicePixelRatio * this.scaleFactor
 
-          if (curPixelRatio !== scaledPixelRatio) Engine.renderer.setPixelRatio(scaledPixelRatio)
+          if (curPixelRatio !== scaledPixelRatio) this.renderer.setPixelRatio(scaledPixelRatio)
 
           const width = window.innerWidth
           const height = window.innerHeight
@@ -179,18 +198,18 @@ export class EngineRenderer {
             cam.updateProjectionMatrix()
           }
 
-          state.qualityLevel.value > 0 && Engine.csm?.updateFrustums()
+          state.qualityLevel.value > 0 && this.csm?.updateFrustums()
           // Effect composer calls renderer.setSize internally
-          Engine.effectComposer.setSize(width, height, true)
+          this.effectComposer.setSize(width, height, true)
           this.needsResize = false
         }
 
-        state.qualityLevel.value > 0 && Engine.csm?.update()
+        state.qualityLevel.value > 0 && this.csm?.update()
         if (state.usePostProcessing.value) {
-          Engine.effectComposer.render(delta)
+          this.effectComposer.render(delta)
         } else {
-          Engine.renderer.autoClear = true
-          Engine.renderer.render(Engine.scene, Engine.camera)
+          this.renderer.autoClear = true
+          this.renderer.render(Engine.scene, Engine.camera)
         }
       }
     }

--- a/packages/engine/src/renderer/functions/changeRenderMode.ts
+++ b/packages/engine/src/renderer/functions/changeRenderMode.ts
@@ -5,6 +5,7 @@ import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 
 import { RenderModes, RenderModesType } from '../constants/RenderModes'
 import { accessEngineRendererState } from '../EngineRendererState'
+import { EngineRenderer } from '../WebGLRendererSystem'
 
 /**
  * Change render mode of the renderer
@@ -27,14 +28,14 @@ export function changeRenderMode(mode: RenderModesType): void {
       break
   }
 
-  const passes = Engine.effectComposer?.passes.filter((p) => p.name === 'RenderPass') as any
+  const passes = EngineRenderer.instance.effectComposer?.passes.filter((p) => p.name === 'RenderPass') as any
   const renderPass: RenderPass = passes ? passes[0] : undefined
 
   if (!renderPass) return
 
   switch (mode) {
     case RenderModes.UNLIT:
-      Engine.renderer.shadowMap.enabled = false
+      EngineRenderer.instance.renderer.shadowMap.enabled = false
       Engine.scene.traverse((obj: Light) => {
         if (obj.isLight && obj.visible) {
           obj.userData.editor_disabled = true
@@ -44,24 +45,24 @@ export function changeRenderMode(mode: RenderModesType): void {
       renderPass.overrideMaterial = null!
       break
     case RenderModes.LIT:
-      Engine.renderer.shadowMap.enabled = false
+      EngineRenderer.instance.renderer.shadowMap.enabled = false
       renderPass.overrideMaterial = null!
       break
     case RenderModes.SHADOW:
-      Engine.renderer.shadowMap.enabled = true
+      EngineRenderer.instance.renderer.shadowMap.enabled = true
       renderPass.overrideMaterial = null!
       break
     case RenderModes.WIREFRAME:
-      Engine.renderer.shadowMap.enabled = false
+      EngineRenderer.instance.renderer.shadowMap.enabled = false
       renderPass.overrideMaterial = new MeshBasicMaterial({
         wireframe: true
       })
       break
     case RenderModes.NORMALS:
-      Engine.renderer.shadowMap.enabled = false
+      EngineRenderer.instance.renderer.shadowMap.enabled = false
       renderPass.overrideMaterial = new MeshNormalMaterial()
       break
   }
 
-  Engine.renderer.shadowMap.needsUpdate = true
+  EngineRenderer.instance.renderer.shadowMap.needsUpdate = true
 }

--- a/packages/engine/src/renderer/functions/configureEffectComposer.ts
+++ b/packages/engine/src/renderer/functions/configureEffectComposer.ts
@@ -6,14 +6,15 @@ import { getAllComponentsOfType } from '../../ecs/functions/ComponentFunctions'
 import { PostprocessingComponent } from '../../scene/components/PostprocessingComponent'
 import { EffectMap, Effects, OutlineEffectProps } from '../../scene/constants/PostProcessing'
 import { accessEngineRendererState } from '../EngineRendererState'
+import { EngineRenderer } from '../WebGLRendererSystem'
 import { changeRenderMode } from './changeRenderMode'
 
 export const configureEffectComposer = (remove?: boolean): void => {
-  Engine.effectComposer.removeAllPasses()
+  EngineRenderer.instance.effectComposer.removeAllPasses()
 
   // we always want to have at least the render pass enabled
   const renderPass = new RenderPass(Engine.scene, Engine.camera)
-  Engine.effectComposer.addPass(renderPass)
+  EngineRenderer.instance.effectComposer.addPass(renderPass)
 
   if (remove) {
     return
@@ -54,11 +55,11 @@ export const configureEffectComposer = (remove?: boolean): void => {
         ...effect,
         normalDepthBuffer: depthDownsamplingPass.texture
       })
-      Engine.effectComposer[key] = eff
+      EngineRenderer.instance.effectComposer[key] = eff
       effects.push(eff)
     } else if (key === Effects.DepthOfFieldEffect) {
       const eff = new effectClass(Engine.camera, effect)
-      Engine.effectComposer[key] = eff
+      EngineRenderer.instance.effectComposer[key] = eff
       effects.push(eff)
     } else if (key === Effects.OutlineEffect) {
       let outlineEffect = effect as OutlineEffectProps
@@ -66,12 +67,12 @@ export const configureEffectComposer = (remove?: boolean): void => {
         outlineEffect = { ...outlineEffect, hiddenEdgeColor: 0x22090a }
       }
       const eff = new effectClass(Engine.scene, Engine.camera, outlineEffect)
-      Engine.effectComposer[key] = eff
+      EngineRenderer.instance.effectComposer[key] = eff
       effects.push(eff)
     } else {
       if (effectClass) {
         const eff = new effectClass(effect)
-        Engine.effectComposer[key] = eff
+        EngineRenderer.instance.effectComposer[key] = eff
         effects.push(eff)
       }
     }
@@ -83,8 +84,8 @@ export const configureEffectComposer = (remove?: boolean): void => {
       texture: depthDownsamplingPass.texture
     })
 
-    Engine.effectComposer.addPass(depthDownsamplingPass)
-    Engine.effectComposer.addPass(new EffectPass(Engine.camera, ...effects, textureEffect))
+    EngineRenderer.instance.effectComposer.addPass(depthDownsamplingPass)
+    EngineRenderer.instance.effectComposer.addPass(new EffectPass(Engine.camera, ...effects, textureEffect))
   }
 
   changeRenderMode(accessEngineRendererState().renderMode.value)

--- a/packages/engine/src/scene/constants/Util.ts
+++ b/packages/engine/src/scene/constants/Util.ts
@@ -1,6 +1,6 @@
 import { CubeTextureLoader, PMREMGenerator, TextureLoader } from 'three'
 
-import { Engine } from '../../ecs/classes/Engine'
+import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 
 export const negx = 'negx.jpg'
 export const negy = 'negy.jpg'
@@ -14,6 +14,6 @@ export const textureLoader = new TextureLoader()
 let pmremGenerator: PMREMGenerator
 
 export const getPmremGenerator = (): PMREMGenerator => {
-  if (!pmremGenerator) pmremGenerator = new PMREMGenerator(Engine.renderer)
+  if (!pmremGenerator) pmremGenerator = new PMREMGenerator(EngineRenderer.instance.renderer)
   return pmremGenerator
 }

--- a/packages/engine/src/scene/functions/SceneLoading.ts
+++ b/packages/engine/src/scene/functions/SceneLoading.ts
@@ -149,12 +149,13 @@ export const loadSceneFromJSON = async (sceneData: SceneJson, world = useWorld()
   }
   const promises = preCacheAssets(sceneData, onProgress)
 
-  Engine.sceneLoadPromises = promises
+  // todo: move these layer enable & disable to loading screen thing or something so they work with portals properly
+  if (!accessEngineState().isTeleporting.value) Engine.camera?.layers.disable(ObjectLayers.Scene)
+
   promises.forEach((promise) => promise.then(onComplete))
   await Promise.all(promises)
 
   const entityMap = {} as { [key: string]: EntityTreeNode }
-  Engine.sceneLoadPromises = []
 
   // reset renderer settings for if we are teleporting and the new scene does not have an override
   resetEngineRenderer(true)
@@ -177,11 +178,6 @@ export const loadSceneFromJSON = async (sceneData: SceneJson, world = useWorld()
   if (Engine.isEditor) {
     getComponent(tree.rootNode.entity, EntityNodeComponent).components.push(SCENE_COMPONENT_SCENE_TAG)
   }
-
-  // todo: move these layer enable & disable to loading screen thing or something so they work with portals properly
-  if (!accessEngineState().isTeleporting.value) Engine.camera?.layers.disable(ObjectLayers.Scene)
-
-  await Promise.all(Engine.sceneLoadPromises)
 
   if (!accessEngineState().isTeleporting.value) Engine.camera?.layers.enable(ObjectLayers.Scene)
 

--- a/packages/engine/src/scene/functions/loaders/DirectionalLightFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/DirectionalLightFunctions.test.ts
@@ -7,6 +7,7 @@ import { Engine } from '../../../ecs/classes/Engine'
 import { createWorld } from '../../../ecs/classes/World'
 import { getComponent, hasComponent } from '../../../ecs/functions/ComponentFunctions'
 import { createEntity } from '../../../ecs/functions/EntityFunctions'
+import { EngineRenderer } from '../../../renderer/WebGLRendererSystem'
 import { Object3DComponent } from '../../components/Object3DComponent'
 import { deserializeDirectionalLight } from './DirectionalLightFunctions'
 
@@ -14,14 +15,14 @@ describe('DirectionalLightFunctions', () => {
   describe('deserializeDirectionalLight', async () => {
     // reset globals
     afterEach(() => {
-      Engine.directionalLightEntities = []
+      EngineRenderer.instance.directionalLightEntities = []
     })
 
     it('with CSM', () => {
       const world = createWorld()
       Engine.currentWorld = world
-      Engine.isCSMEnabled = true
-      Engine.directionalLightEntities = []
+      EngineRenderer.instance.isCSMEnabled = true
+      EngineRenderer.instance.directionalLightEntities = []
 
       const entity = createEntity()
 
@@ -43,7 +44,7 @@ describe('DirectionalLightFunctions', () => {
 
       deserializeDirectionalLight(entity, sceneComponent)
 
-      const activeCSMLightEntity = Engine.directionalLightEntities[0]
+      const activeCSMLightEntity = EngineRenderer.instance.directionalLightEntities[0]
       const light = getComponent(activeCSMLightEntity, Object3DComponent)?.value as DirectionalLight
 
       assert(light)
@@ -60,7 +61,7 @@ describe('DirectionalLightFunctions', () => {
     it('without CSM', () => {
       const world = createWorld()
       Engine.currentWorld = world
-      Engine.isCSMEnabled = false
+      EngineRenderer.instance.isCSMEnabled = false
 
       const entity = createEntity()
 

--- a/packages/engine/src/scene/functions/loaders/EnvMapFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/EnvMapFunctions.ts
@@ -149,7 +149,7 @@ export const updateEnvMap: ComponentUpdateFunction = (entity: Entity) => {
 
             break
           case CubemapBakeTypes.Realtime:
-            // const map = new CubemapCapturer(Engine.renderer, Engine.scene, options.resolution)
+            // const map = new CubemapCapturer(EngineRenderer.instance.renderer, Engine.scene, options.resolution)
             // const EnvMap = (await map.update(options.bakePosition)).cubeRenderTarget.texture
             // Engine.scene.environment = EnvMap
             break

--- a/packages/engine/src/scene/functions/loaders/MetaDataFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/MetaDataFunctions.ts
@@ -18,9 +18,7 @@ export const deserializeMetaData: ComponentDeserializeFunction = (
   entity: Entity,
   json: ComponentJson<MetaDataComponentType>
 ) => {
-  //if (isClient && Engine.isBot) {
   addComponent(entity, MetaDataComponent, { meta_data: json.props.meta_data ?? '' })
-  //}
 
   if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_METADATA)
 

--- a/packages/engine/src/scene/functions/loaders/RenderSettingsFunction.test.ts
+++ b/packages/engine/src/scene/functions/loaders/RenderSettingsFunction.test.ts
@@ -5,13 +5,14 @@ import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
 import { Engine } from '../../../ecs/classes/Engine'
 import { createWorld } from '../../../ecs/classes/World'
 import { createEntity } from '../../../ecs/functions/EntityFunctions'
+import { EngineRenderer } from '../../../renderer/WebGLRendererSystem'
 import { deserializeRenderSetting } from './RenderSettingsFunction'
 
 describe('RenderSettingFunctions', () => {
   it('deserializeRenderSetting', () => {
     const world = createWorld()
     Engine.currentWorld = world
-    Engine.isCSMEnabled = false
+    EngineRenderer.instance.isCSMEnabled = false
 
     const entity = createEntity()
 
@@ -25,10 +26,10 @@ describe('RenderSettingFunctions', () => {
 
     deserializeRenderSetting(entity, sceneComponent)
 
-    assert.equal(Engine.isCSMEnabled, false)
+    assert.equal(EngineRenderer.instance.isCSMEnabled, false)
     // TODO: currently renderer only is created on client
 
     // TODO: unnecessary once engine global scope is refactored
-    Engine.isCSMEnabled = false
+    EngineRenderer.instance.isCSMEnabled = false
   })
 })

--- a/packages/engine/src/scene/functions/loaders/SimpleMaterialFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/SimpleMaterialFunctions.test.ts
@@ -17,6 +17,7 @@ import { createWorld, World } from '../../../ecs/classes/World'
 import { getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { addComponent } from '../../../ecs/functions/ComponentFunctions'
 import { createEntity } from '../../../ecs/functions/EntityFunctions'
+import { EngineRenderer } from '../../../renderer/WebGLRendererSystem'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
 import { SimpleMaterialTagComponent } from '../../components/SimpleMaterialTagComponent'
 import { SceneOptions } from '../../systems/SceneObjectSystem'
@@ -134,7 +135,7 @@ describe('SimpleMaterialFunctions', () => {
       const mat = new MeshStandardMaterial()
       const obj3d = new Mesh(new BoxGeometry(), new MeshPhongMaterial())
       obj3d.receiveShadow = true
-      Engine.csm = { setupMaterial() {} } as any
+      EngineRenderer.instance.csm = { setupMaterial() {} } as any
       obj3d.userData.prevMaterial = mat
 
       useStandardMaterial(obj3d)

--- a/packages/engine/src/scene/functions/loaders/SimpleMaterialFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SimpleMaterialFunctions.ts
@@ -6,6 +6,7 @@ import { ComponentDeserializeFunction, ComponentSerializeFunction } from '../../
 import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent, hasComponent } from '../../../ecs/functions/ComponentFunctions'
+import { EngineRenderer } from '../../../renderer/WebGLRendererSystem'
 import { beforeMaterialCompile } from '../../classes/BPCEMShader'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
 import { SimpleMaterialTagComponent } from '../../components/SimpleMaterialTagComponent'
@@ -65,5 +66,5 @@ export const useStandardMaterial = (obj: Mesh<any, Material>): void => {
     obj.userData.prevMaterial = undefined
   }
 
-  if (obj.receiveShadow) Engine.csm?.setupMaterial(obj)
+  if (obj.receiveShadow) EngineRenderer.instance.csm?.setupMaterial(obj)
 }

--- a/packages/engine/src/scene/functions/loaders/SkyboxFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SkyboxFunctions.ts
@@ -18,6 +18,7 @@ import {
   getComponentCountOfType,
   hasComponent
 } from '../../../ecs/functions/ComponentFunctions'
+import { EngineRenderer } from '../../../renderer/WebGLRendererSystem'
 import { DisableTransformTagComponent } from '../../../transform/components/DisableTransformTagComponent'
 import { Sky } from '../../classes/Sky'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
@@ -126,7 +127,7 @@ export const updateSkybox: ComponentUpdateFunction = (entity: Entity) => {
 
       setSkyDirection(component.sky.sunPosition)
       Engine.scene.background = getPmremGenerator().fromCubemap(
-        component.sky.generateSkyboxTextureCube(Engine.renderer)
+        component.sky.generateSkyboxTextureCube(EngineRenderer.instance.renderer)
       ).texture
 
       break
@@ -157,7 +158,7 @@ export const serializeSkybox: ComponentSerializeFunction = (entity) => {
 }
 
 const setSkyDirection = (direction: Vector3): void => {
-  Engine.csm?.lightDirection.copy(direction).multiplyScalar(-1)
+  EngineRenderer.instance.csm?.lightDirection.copy(direction).multiplyScalar(-1)
 }
 
 export const shouldDeserializeSkybox: ComponentShouldDeserializeFunction = () => {

--- a/packages/engine/src/scene/functions/loaders/VolumetricFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/VolumetricFunctions.ts
@@ -17,6 +17,7 @@ import { isClient } from '../../../common/functions/isClient'
 import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent, removeComponent } from '../../../ecs/functions/ComponentFunctions'
+import { EngineRenderer } from '../../../renderer/WebGLRendererSystem'
 import UpdateableObject3D from '../../classes/UpdateableObject3D'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
 import { Object3DComponent } from '../../components/Object3DComponent'
@@ -88,7 +89,7 @@ export const updateVolumetric: ComponentUpdateFunction = (entity: Entity, proper
 
       obj3d.userData.player = new DracosisPlayer({
         scene: obj3d,
-        renderer: Engine.renderer,
+        renderer: EngineRenderer.instance.renderer,
         paths,
         isLoadingEffect: isClient,
         isVideoTexture: false,

--- a/packages/engine/src/scene/functions/teleportToScene.ts
+++ b/packages/engine/src/scene/functions/teleportToScene.ts
@@ -14,7 +14,6 @@ import { HyperspaceTagComponent } from '../components/HyperspaceTagComponent'
 export const teleportToScene = async () => {
   const world = useWorld()
   console.log('teleportToScene', world.activePortal)
-  Engine.hasJoinedWorld = false
 
   // trigger hyperspace effect by simply adding tag component to the world's entity
   addComponent(world.worldEntity, HyperspaceTagComponent, {})

--- a/packages/engine/src/xr/functions/WebXRFunctions.ts
+++ b/packages/engine/src/xr/functions/WebXRFunctions.ts
@@ -15,6 +15,7 @@ import { Entity } from '../../ecs/classes/Entity'
 import { addComponent, getComponent, hasComponent, removeComponent } from '../../ecs/functions/ComponentFunctions'
 import { AvatarControllerType } from '../../input/enums/InputEnums'
 import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
+import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { XRInputSourceComponent, XRInputSourceComponentType } from '../../xr/components/XRInputSourceComponent'
 import { XRHandsInputComponent } from '../components/XRHandsInputComponent'
@@ -35,7 +36,7 @@ const assignControllerAndGrip = (xrManager, controller, grip, i): void => {
  */
 
 export const mapXRControllers = (xrInput: XRInputSourceComponentType): void => {
-  const xrm = Engine.xrManager
+  const xrm = EngineRenderer.instance.xrManager
   const session = xrm.getSession()
 
   for (let i = 0; i < 2; i++) {
@@ -163,10 +164,10 @@ export const bindXRControllers = () => {
     mapXRControllers(xrInputSourceComponent)
     // Proxify only after input handedness is determined
     proxifyXRInputs(world.localClientEntity, xrInputSourceComponent)
-    Engine.xrSession.removeEventListener('inputsourceschange', inputSourceChanged)
+    EngineRenderer.instance.xrSession.removeEventListener('inputsourceschange', inputSourceChanged)
   }
 
-  Engine.xrSession.addEventListener('inputsourceschange', inputSourceChanged)
+  EngineRenderer.instance.xrSession.addEventListener('inputsourceschange', inputSourceChanged)
 }
 
 /**
@@ -179,7 +180,7 @@ export const bindXRControllers = () => {
 export const bindXRHandEvents = () => {
   const world = Engine.currentWorld
 
-  const hands = [Engine.xrManager.getHand(0), Engine.xrManager.getHand(1)]
+  const hands = [EngineRenderer.instance.xrManager.getHand(0), EngineRenderer.instance.xrManager.getHand(1)]
   let eventSent = false
 
   // TODO: we should unify the logic here and in AvatarSystem xrHandsConnected receptor
@@ -221,8 +222,8 @@ export const startWebXR = async (): Promise<void> => {
   setupXRInputSourceComponent(world.localClientEntity)
 
   // Default mapping
-  assignControllerAndGrip(Engine.xrManager, controllerLeft, controllerGripLeft, 0)
-  assignControllerAndGrip(Engine.xrManager, controllerRight, controllerGripRight, 1)
+  assignControllerAndGrip(EngineRenderer.instance.xrManager, controllerLeft, controllerGripLeft, 0)
+  assignControllerAndGrip(EngineRenderer.instance.xrManager, controllerRight, controllerGripRight, 1)
 
   dispatchAction(world.store, NetworkWorldAction.setXRMode({ enabled: true }))
 
@@ -236,9 +237,9 @@ export const startWebXR = async (): Promise<void> => {
  */
 
 export const endXR = (): void => {
-  // Engine.xrSession?.end()
-  Engine.xrSession = null!
-  Engine.xrManager.setSession(null!)
+  // EngineRenderer.instance.xrSession?.end()
+  EngineRenderer.instance.xrSession = null!
+  EngineRenderer.instance.xrManager.setSession(null!)
   Engine.scene.add(Engine.camera)
 
   const world = Engine.currentWorld

--- a/packages/engine/src/xr/functions/addControllerModels.ts
+++ b/packages/engine/src/xr/functions/addControllerModels.ts
@@ -17,6 +17,7 @@ import { Entity } from '../../ecs/classes/Entity'
 import { getComponent } from '../../ecs/functions/ComponentFunctions'
 import { AvatarControllerType } from '../../input/enums/InputEnums'
 import { isEntityLocalClient } from '../../networking/functions/isEntityLocalClient'
+import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { XRInputSourceComponent } from '../../xr/components/XRInputSourceComponent'
 import { XRHandMeshModel } from '../classes/XRHandMeshModel'
 import { initializeXRControllerAnimations } from './controllerAnimation'
@@ -74,7 +75,7 @@ export const initializeXRInputs = (entity: Entity) => {
         }
       })
 
-      const session = Engine.xrManager.getSession()
+      const session = EngineRenderer.instance.xrManager.getSession()
 
       if (session) {
         const inputSource = session.inputSources[i]

--- a/packages/engine/src/xr/systems/XRSystem.ts
+++ b/packages/engine/src/xr/systems/XRSystem.ts
@@ -14,6 +14,7 @@ import { LocalInputTagComponent } from '../../input/components/LocalInputTagComp
 import { InputType } from '../../input/enums/InputType'
 import { gamepadMapping } from '../../input/functions/GamepadInput'
 import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
+import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { ObjectLayers } from '../../scene/constants/ObjectLayers'
 import { XRInputSourceComponent } from '../components/XRInputSourceComponent'
 import { cleanXRInputs } from '../functions/addControllerModels'
@@ -25,12 +26,12 @@ const startXRSession = async () => {
   try {
     const session = await (navigator as any).xr.requestSession('immersive-vr', sessionInit)
 
-    Engine.xrSession = session
-    Engine.xrManager.setSession(session)
-    Engine.xrManager.setFoveation(1)
+    EngineRenderer.instance.xrSession = session
+    EngineRenderer.instance.xrManager.setSession(session)
+    EngineRenderer.instance.xrManager.setFoveation(1)
     dispatchAction(Engine.store, EngineActions.xrSession())
 
-    Engine.xrManager.addEventListener('sessionend', async () => {
+    EngineRenderer.instance.xrManager.addEventListener('sessionend', async () => {
       dispatchAction(Engine.store, EngineActions.xrEnd())
     })
 
@@ -67,7 +68,7 @@ export default async function XRSystem(world: World) {
       case NetworkWorldAction.setXRMode.type:
         // Current WebXRManager.getCamera() typedef is incorrect
         // @ts-ignore
-        const cameras = Engine.xrManager.getCamera() as ArrayCamera
+        const cameras = EngineRenderer.instance.xrManager.getCamera() as ArrayCamera
         cameras.layers.enableAll()
         cameras.cameras.forEach((camera) => {
           camera.layers.disableAll()
@@ -81,7 +82,7 @@ export default async function XRSystem(world: World) {
   addActionReceptor(Engine.store, (a: EngineActionType) => {
     matches(a)
       .when(EngineActions.xrStart.matches, (action) => {
-        if (accessEngineState().joinedWorld.value && !Engine.xrSession) startXRSession()
+        if (accessEngineState().joinedWorld.value && !EngineRenderer.instance.xrSession) startXRSession()
       })
       .when(EngineActions.xrEnd.matches, (action) => {
         for (const entity of xrControllerQuery()) {
@@ -92,7 +93,7 @@ export default async function XRSystem(world: World) {
   })
 
   return () => {
-    if (Engine.xrManager?.isPresenting) {
+    if (EngineRenderer.instance.xrManager?.isPresenting) {
       const session = Engine.xrFrame.session
       for (const source of session.inputSources) {
         if (source.gamepad) {

--- a/packages/engine/src/xrui/systems/XRUISystem.ts
+++ b/packages/engine/src/xrui/systems/XRUISystem.ts
@@ -12,14 +12,15 @@ import { InputComponent } from '../../input/components/InputComponent'
 import { LocalInputTagComponent } from '../../input/components/LocalInputTagComponent'
 import { BaseInput } from '../../input/enums/BaseInput'
 import { NetworkObjectComponent } from '../../networking/components/NetworkObjectComponent'
+import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { Object3DComponent } from '../../scene/components/Object3DComponent'
 import { XRInputSourceComponent, XRInputSourceComponentType } from '../../xr/components/XRInputSourceComponent'
 import { XRUIManager } from '../classes/XRUIManager'
 import { XRUIComponent } from '../components/XRUIComponent'
 
 export default async function XRUISystem(world: World) {
-  const renderer = Engine.renderer
-  if (!renderer) throw new Error('Engine.renderer must exist before initializing XRUISystem')
+  const renderer = EngineRenderer.instance.renderer
+  if (!renderer) throw new Error('EngineRenderer.instance.renderer must exist before initializing XRUISystem')
 
   const hitColor = new Color(0x00e6e6)
   const normalColor = new Color(0xffffff)
@@ -132,7 +133,7 @@ export default async function XRUISystem(world: World) {
 
   return () => {
     if (!addedEventListeners) {
-      const canvas = Engine.renderer.getContext().canvas
+      const canvas = EngineRenderer.instance.renderer.getContext().canvas
       canvas.addEventListener('click', redirectDOMEvent)
       canvas.addEventListener('contextmenu', redirectDOMEvent)
       canvas.addEventListener('dblclick', redirectDOMEvent)
@@ -173,7 +174,7 @@ export default async function XRUISystem(world: World) {
     }
 
     // xrui.layoutSystem.viewFrustum.setFromPerspectiveProjectionMatrix(Engine.camera.projectionMatrix)
-    // Engine.renderer.getSize(xrui.layoutSystem.viewResolution)
+    // EngineRenderer.instance.renderer.getSize(xrui.layoutSystem.viewResolution)
     // xrui.layoutSystem.update(world.delta, world.elapsedTime)
   }
 }

--- a/packages/engine/tsconfig.json
+++ b/packages/engine/tsconfig.json
@@ -6,7 +6,6 @@
       "dom",
       "dom.iterable"
     ],
-    "baseUrl": ".",
     "allowJs": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/hyperflux/tsconfig.json
+++ b/packages/hyperflux/tsconfig.json
@@ -6,7 +6,6 @@
       "dom",
       "dom.iterable"
     ],
-    "baseUrl": ".",
     "paths": {
       "@mui/styled-engine": ["./node_modules/@mui/styled-engine-sc"]
     },


### PR DESCRIPTION
## Summary

- fixes a problem with ts config making imports annoying
- moves all renderer associated objects from Engine to EngineRenderer
- clean up a few unnecessary objects on Engine object

## References

part of https://github.com/XRFoundation/XREngine/issues/5834

## Checklist
- [ ] CI/CD checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Typescript passing via `npm run check-errors`
  - [ ] Unit & Integration tests passing via `npm run test`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
