### PR TITLE
Remove is editor

### DIFF
--- a/packages/client-core/i18n/en/common.json
+++ b/packages/client-core/i18n/en/common.json
@@ -34,6 +34,7 @@
     "physicsDebug": "Physics Debug",
     "avatarDebug": "Avatar Debug",
     "nodeHelperDebug": "Node Helper Debug",
+    "gridDebug": "Grid Debug",
     "tick": "Tick",
     "namedEntities": "Named Entities",
     "networkObject": "Network Object",

--- a/packages/client-core/i18n/en/common.json
+++ b/packages/client-core/i18n/en/common.json
@@ -33,6 +33,7 @@
     "refresh": "Refresh",
     "physicsDebug": "Physics Debug",
     "avatarDebug": "Avatar Debug",
+    "nodeHelperDebug": "Node Helper Debug",
     "tick": "Tick",
     "namedEntities": "Named Entities",
     "networkObject": "Network Object",

--- a/packages/client-core/src/components/Debug/index.tsx
+++ b/packages/client-core/src/components/Debug/index.tsx
@@ -7,8 +7,13 @@ import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { useEngineState } from '@xrengine/engine/src/ecs/classes/EngineService'
 import { getComponent, MappedComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
 import { Network } from '@xrengine/engine/src/networking/classes/Network'
-import { EngineRendererAction, useEngineRendererState } from '@xrengine/engine/src/renderer/EngineRendererState'
+import {
+  accessEngineRendererState,
+  EngineRendererAction,
+  useEngineRendererState
+} from '@xrengine/engine/src/renderer/EngineRendererState'
 import { NameComponent } from '@xrengine/engine/src/scene/components/NameComponent'
+import { ObjectLayers } from '@xrengine/engine/src/scene/constants/ObjectLayers'
 import { dispatchAction } from '@xrengine/hyperflux'
 
 export const Debug = () => {
@@ -82,6 +87,14 @@ export const Debug = () => {
     }
   }
 
+  const toggleNodeHelpers = () => {
+    Engine.camera.layers.toggle(ObjectLayers.NodeHelper)
+    dispatchAction(
+      Engine.store,
+      EngineRendererAction.changeNodeHelperVisibility(!accessEngineRendererState().nodeHelperVisibility.value)
+    )
+  }
+
   if (isShowing)
     return (
       <div
@@ -104,6 +117,9 @@ export const Debug = () => {
         </button>
         <button type="button" value="Avatar Debug" onClick={toggleAvatarDebug}>
           {t('common:debug.avatarDebug')}
+        </button>
+        <button type="button" value="Node Debug" onClick={toggleNodeHelpers}>
+          {t('common:debug.nodeHelperDebug')}
         </button>
         {Network.instance !== null && (
           <div>

--- a/packages/client-core/src/components/Debug/index.tsx
+++ b/packages/client-core/src/components/Debug/index.tsx
@@ -95,6 +95,14 @@ export const Debug = () => {
     )
   }
 
+  const toggleGridHelper = () => {
+    Engine.camera.layers.toggle(ObjectLayers.Gizmos)
+    dispatchAction(
+      Engine.store,
+      EngineRendererAction.changeGridToolVisibility(!accessEngineRendererState().gridVisibility.value)
+    )
+  }
+
   if (isShowing)
     return (
       <div
@@ -120,6 +128,9 @@ export const Debug = () => {
         </button>
         <button type="button" value="Node Debug" onClick={toggleNodeHelpers}>
           {t('common:debug.nodeHelperDebug')}
+        </button>
+        <button type="button" value="Grid Debug" onClick={toggleGridHelper}>
+          {t('common:debug.gridDebug')}
         </button>
         {Network.instance !== null && (
           <div>

--- a/packages/editor/src/commands/TagComponentCommand.ts
+++ b/packages/editor/src/commands/TagComponentCommand.ts
@@ -1,5 +1,4 @@
 import { store } from '@xrengine/client-core/src/store'
-import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { EntityTreeNode } from '@xrengine/engine/src/ecs/classes/EntityTree'
 import {
   addComponent,
@@ -109,16 +108,14 @@ export default class TagComponentCommand extends Command {
 
   addTagComponent(object: EntityTreeNode, operation: TagComponentOperationType) {
     addComponent(object.entity, operation.component, {})
-    if (Engine.isEditor) getComponent(object.entity, EntityNodeComponent)?.components.push(operation.sceneComponentName)
+    getComponent(object.entity, EntityNodeComponent)?.components.push(operation.sceneComponentName)
   }
 
   removeTagComponent(object: EntityTreeNode, operation: TagComponentOperationType) {
     removeComponent(object.entity, operation.component)
-    if (Engine.isEditor) {
-      const comps = getComponent(object.entity, EntityNodeComponent)?.components
-      const index = comps.indexOf(operation.sceneComponentName)
+    const comps = getComponent(object.entity, EntityNodeComponent)?.components
+    const index = comps.indexOf(operation.sceneComponentName)
 
-      if (index !== -1) comps.splice(index, 1)
-    }
+    if (index !== -1) comps.splice(index, 1)
   }
 }

--- a/packages/editor/src/components/toolbar/tools/GridTool.tsx
+++ b/packages/editor/src/components/toolbar/tools/GridTool.tsx
@@ -1,25 +1,26 @@
 import React, { useEffect, useState } from 'react'
 
+import { useEngineRendererState } from '@xrengine/engine/src/renderer/EngineRendererState'
+import InfiniteGridHelper from '@xrengine/engine/src/scene/classes/InfiniteGridHelper'
+
 import GridOnIcon from '@mui/icons-material/GridOn'
 
-import { SceneState } from '../../../functions/sceneRenderFunctions'
-import { useEditorHelperState } from '../../../services/EditorHelperState'
 import NumericStepperInput from '../../inputs/NumericStepperInput'
 import { InfoTooltip } from '../../layout/Tooltip'
 import * as styles from '../styles.module.scss'
 
 const GridTool = () => {
-  const editorHelperState = useEditorHelperState().value
-  const [isGridVisible, setGridVisible] = useState(editorHelperState.gridVisibility)
-  const [gridHeight, setGridHeight] = useState(editorHelperState.gridHeight)
+  const engineRendererState = useEngineRendererState().value
+  const [isGridVisible, setGridVisible] = useState(engineRendererState.gridVisibility)
+  const [gridHeight, setGridHeight] = useState(engineRendererState.gridHeight)
 
   useEffect(() => {
-    updateGridHeight(editorHelperState.gridHeight)
-  }, [editorHelperState.gridHeight])
+    updateGridHeight(engineRendererState.gridHeight)
+  }, [engineRendererState.gridHeight])
 
   useEffect(() => {
-    updateGridVisibility(editorHelperState.gridVisibility)
-  }, [editorHelperState.gridVisibility])
+    updateGridVisibility(engineRendererState.gridVisibility)
+  }, [engineRendererState.gridVisibility])
 
   const updateGridVisibility = (val) => {
     setGridVisible(val)
@@ -30,11 +31,11 @@ const GridTool = () => {
   }
 
   const onToggleGridVisible = () => {
-    SceneState.grid.toggleGridVisible()
+    InfiniteGridHelper.instance.toggleGridVisible()
   }
 
   const onChangeGridHeight = (value) => {
-    SceneState.grid.setGridHeight(value)
+    InfiniteGridHelper.instance.setGridHeight(value)
   }
 
   return (

--- a/packages/editor/src/components/toolbar/tools/HelperToggleTool.tsx
+++ b/packages/editor/src/components/toolbar/tools/HelperToggleTool.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from 'react'
 
-import { useDispatch } from '@xrengine/client-core/src/store'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import {
   accessEngineRendererState,
@@ -13,12 +12,11 @@ import { dispatchAction } from '@xrengine/hyperflux'
 import SelectAllIcon from '@mui/icons-material/SelectAll'
 import SquareFootIcon from '@mui/icons-material/SquareFoot'
 
-import { EditorHelperAction, useEditorHelperState } from '../../../services/EditorHelperState'
 import { InfoTooltip } from '../../layout/Tooltip'
 import * as styles from '../styles.module.scss'
 
 export const HelperToggleTool = () => {
-  const nodeHelperVisibility = useEditorHelperState().nodeHelperVisibility.value
+  const engineRenderState = accessEngineRendererState()
   const [, updateState] = useState<any>()
   const forceUpdate = useCallback(() => updateState({}), [])
   const engineRendererState = useEngineRendererState()
@@ -27,13 +25,16 @@ export const HelperToggleTool = () => {
     forceUpdate()
     dispatchAction(
       Engine.store,
-      EngineRendererAction.setPhysicsDebug(!accessEngineRendererState().physicsDebugEnable.value) as any
+      EngineRendererAction.setPhysicsDebug(!engineRenderState.physicsDebugEnable.value) as any
     )
   }
 
   const toggleNodeHelpers = () => {
     Engine.camera.layers.toggle(ObjectLayers.NodeHelper)
-    useDispatch()(EditorHelperAction.changeNodeHelperVisibility(!nodeHelperVisibility))
+    dispatchAction(
+      Engine.store,
+      EngineRendererAction.changeNodeHelperVisibility(!engineRenderState.nodeHelperVisibility.value)
+    )
   }
 
   return (
@@ -52,7 +53,7 @@ export const HelperToggleTool = () => {
         <InfoTooltip title="Toggle Node Helpers">
           <button
             onClick={toggleNodeHelpers}
-            className={styles.toolButton + ' ' + (nodeHelperVisibility ? styles.selected : '')}
+            className={styles.toolButton + ' ' + (engineRenderState.nodeHelperVisibility.value ? styles.selected : '')}
           >
             <SelectAllIcon fontSize="small" />
           </button>

--- a/packages/editor/src/components/toolbar/tools/TransformSnapTool.tsx
+++ b/packages/editor/src/components/toolbar/tools/TransformSnapTool.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 
 import { useDispatch } from '@xrengine/client-core/src/store'
+import InfiniteGridHelper from '@xrengine/engine/src/scene/classes/InfiniteGridHelper'
 import { SnapMode } from '@xrengine/engine/src/scene/constants/transformConstants'
 
 import AttractionsIcon from '@mui/icons-material/Attractions'
 
-import { SceneState } from '../../../functions/sceneRenderFunctions'
 import { toggleSnapMode } from '../../../functions/transformFunctions'
 import { EditorHelperAction, useEditorHelperState } from '../../../services/EditorHelperState'
 import SelectInput from '../../inputs/SelectInput'
@@ -45,7 +45,7 @@ const TransformSnapTool = () => {
   const dispatch = useDispatch()
 
   const onChangeTranslationSnap = (snapValue: number) => {
-    SceneState.grid.setSize(snapValue)
+    InfiniteGridHelper.instance.setSize(snapValue)
     dispatch(EditorHelperAction.changeTranslationSnap(snapValue))
 
     if (editorHelperState.snapMode.value !== SnapMode.Grid) {

--- a/packages/editor/src/constants/EditorHelperKeys.ts
+++ b/packages/editor/src/constants/EditorHelperKeys.ts
@@ -7,7 +7,5 @@ export const EditorHelperKeys = {
   SNAP_MODE: editorHelperDBPrefix + 'snapMode',
   TRANSLATION_SNAP: editorHelperDBPrefix + 'translationSnap',
   ROTATION_SNAP: editorHelperDBPrefix + 'rotationSnap',
-  SCALE_SNAP: editorHelperDBPrefix + 'scaleSnap',
-  GRID_VISIBLE: editorHelperDBPrefix + 'gridVisible',
-  GRID_HEIGHT: editorHelperDBPrefix + 'gridHeight'
+  SCALE_SNAP: editorHelperDBPrefix + 'scaleSnap'
 }

--- a/packages/editor/src/constants/EditorHelperKeys.ts
+++ b/packages/editor/src/constants/EditorHelperKeys.ts
@@ -9,6 +9,5 @@ export const EditorHelperKeys = {
   ROTATION_SNAP: editorHelperDBPrefix + 'rotationSnap',
   SCALE_SNAP: editorHelperDBPrefix + 'scaleSnap',
   GRID_VISIBLE: editorHelperDBPrefix + 'gridVisible',
-  GRID_HEIGHT: editorHelperDBPrefix + 'gridHeight',
-  NODE_HELPER_ENABLE: editorHelperDBPrefix + 'NodeHelperEnable'
+  GRID_HEIGHT: editorHelperDBPrefix + 'gridHeight'
 }

--- a/packages/editor/src/functions/sceneRenderFunctions.ts
+++ b/packages/editor/src/functions/sceneRenderFunctions.ts
@@ -3,7 +3,6 @@ import { Group, Object3D, Scene, Vector3, WebGLInfo } from 'three'
 import { store } from '@xrengine/client-core/src/store'
 import { SceneJson } from '@xrengine/common/src/interfaces/SceneInterface'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
-import { EngineActions } from '@xrengine/engine/src/ecs/classes/EngineService'
 import { Entity } from '@xrengine/engine/src/ecs/classes/Entity'
 import { removeEntity } from '@xrengine/engine/src/ecs/functions/EntityFunctions'
 import { emptyEntityTree } from '@xrengine/engine/src/ecs/functions/EntityTreeFunctions'
@@ -14,12 +13,12 @@ import {
 } from '@xrengine/engine/src/renderer/EngineRendererState'
 import { configureEffectComposer } from '@xrengine/engine/src/renderer/functions/configureEffectComposer'
 import { EngineRenderer } from '@xrengine/engine/src/renderer/WebGLRendererSystem'
+import InfiniteGridHelper from '@xrengine/engine/src/scene/classes/InfiniteGridHelper'
 import TransformGizmo from '@xrengine/engine/src/scene/classes/TransformGizmo'
 import { ObjectLayers } from '@xrengine/engine/src/scene/constants/ObjectLayers'
 import { loadSceneFromJSON } from '@xrengine/engine/src/scene/functions/SceneLoading'
 import { dispatchAction } from '@xrengine/hyperflux'
 
-import EditorInfiniteGridHelper from '../classes/EditorInfiniteGridHelper'
 import { ActionSets, EditorMapping } from '../controls/input-mappings'
 import { initInputEvents } from '../controls/InputEvents'
 import { restoreEditorHelperData } from '../services/EditorHelperState'
@@ -41,7 +40,6 @@ export const DefaultExportOptions: DefaultExportOptionsType = {
 
 type SceneStateType = {
   isInitialized: boolean
-  grid: EditorInfiniteGridHelper
   transformGizmo: TransformGizmo
   gizmoEntity: Entity
   editorEntity: Entity
@@ -50,7 +48,6 @@ type SceneStateType = {
 
 export const SceneState: SceneStateType = {
   isInitialized: false,
-  grid: null!,
   transformGizmo: null!,
   gizmoEntity: null!,
   editorEntity: null!
@@ -71,7 +68,6 @@ export async function initializeScene(projectFile: SceneJson): Promise<Error[] |
   Engine.camera.layers.enable(ObjectLayers.NodeHelper)
   Engine.camera.layers.enable(ObjectLayers.Gizmos)
 
-  SceneState.grid = new EditorInfiniteGridHelper()
   SceneState.transformGizmo = new TransformGizmo()
 
   SceneState.gizmoEntity = createGizmoEntity(SceneState.transformGizmo)
@@ -79,8 +75,13 @@ export async function initializeScene(projectFile: SceneJson): Promise<Error[] |
   SceneState.editorEntity = createEditorEntity()
 
   Engine.scene.add(Engine.camera)
-  Engine.scene.add(SceneState.grid)
   Engine.scene.add(SceneState.transformGizmo)
+
+  // Require when changing scene
+  if (!Engine.scene.children.includes(InfiniteGridHelper.instance)) {
+    InfiniteGridHelper.instance = new InfiniteGridHelper()
+    Engine.scene.add(InfiniteGridHelper.instance)
+  }
 
   SceneState.isInitialized = true
 
@@ -227,8 +228,6 @@ export function disposeScene() {
   if (SceneState.editorEntity) removeEntity(SceneState.editorEntity, true)
 
   if (Engine.scene) {
-    if (SceneState.grid) Engine.scene.remove(SceneState.grid)
-
     // Empty existing scene
     Engine.scene.traverse((child: any) => {
       if (child.geometry) child.geometry.dispose()

--- a/packages/editor/src/services/EditorHelperState.ts
+++ b/packages/editor/src/services/EditorHelperState.ts
@@ -30,8 +30,6 @@ type EditorHelperStateType = {
   scaleSnap: number
   gridVisibility: boolean
   gridHeight: number
-  nodeHelperVisibility: boolean
-  physicsHelperVisibility: boolean
 }
 
 const state = createState<EditorHelperStateType>({
@@ -46,9 +44,7 @@ const state = createState<EditorHelperStateType>({
   rotationSnap: 10,
   scaleSnap: 0.1,
   gridVisibility: true,
-  gridHeight: 0,
-  nodeHelperVisibility: true,
-  physicsHelperVisibility: true
+  gridHeight: 0
 })
 
 export async function restoreEditorHelperData(): Promise<void> {
@@ -91,10 +87,6 @@ export async function restoreEditorHelperData(): Promise<void> {
       ClientStorage.get(EditorHelperKeys.GRID_HEIGHT).then((v) => {
         if (typeof v !== 'undefined') s.gridHeight = v as number
         else ClientStorage.set(EditorHelperKeys.GRID_HEIGHT, state.gridHeight.value)
-      }),
-      ClientStorage.get(EditorHelperKeys.NODE_HELPER_ENABLE).then((v) => {
-        if (typeof v !== 'undefined') s.nodeHelperVisibility = v as boolean
-        else ClientStorage.set(EditorHelperKeys.NODE_HELPER_ENABLE, state.nodeHelperVisibility.value)
       })
     ])
 
@@ -108,9 +100,6 @@ function updateHelpers(): void {
   SceneState.grid.setSize(state.translationSnap.value)
   SceneState.grid.setGridHeight(state.gridHeight.value)
   SceneState.grid.visible = state.gridVisibility.value
-
-  if (state.nodeHelperVisibility.value) Engine.camera.layers.enable(ObjectLayers.NodeHelper)
-  else Engine.camera.layers.disable(ObjectLayers.NodeHelper)
 }
 
 store.receptors.push((action: EditorHelperActionType): any => {
@@ -160,10 +149,6 @@ store.receptors.push((action: EditorHelperActionType): any => {
       case 'GRID_TOOL_VISIBILITY_CHANGED':
         s.merge({ gridVisibility: action.visibility })
         ClientStorage.set(EditorHelperKeys.GRID_VISIBLE, action.visibility)
-        break
-      case 'NODE_HELPER_VISIBILITY_CHANGED':
-        s.merge({ nodeHelperVisibility: action.visibility })
-        ClientStorage.set(EditorHelperKeys.NODE_HELPER_ENABLE, action.visibility)
         break
       case 'RESTORE_STORAGE_DATA':
         s.merge(action.state)
@@ -255,12 +240,6 @@ export const EditorHelperAction = {
   changeGridToolVisibility: (visibility: boolean) => {
     return {
       type: 'GRID_TOOL_VISIBILITY_CHANGED' as const,
-      visibility
-    }
-  },
-  changeNodeHelperVisibility: (visibility: boolean) => {
-    return {
-      type: 'NODE_HELPER_VISIBILITY_CHANGED' as const,
       visibility
     }
   }

--- a/packages/editor/src/systems/EditorControlSystem.ts
+++ b/packages/editor/src/systems/EditorControlSystem.ts
@@ -17,6 +17,7 @@ import { Entity } from '@xrengine/engine/src/ecs/classes/Entity'
 import { World } from '@xrengine/engine/src/ecs/classes/World'
 import { defineQuery, getComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
 import { getEntityNodeArrayFromEntities } from '@xrengine/engine/src/ecs/functions/EntityTreeFunctions'
+import InfiniteGridHelper from '@xrengine/engine/src/scene/classes/InfiniteGridHelper'
 import TransformGizmo from '@xrengine/engine/src/scene/classes/TransformGizmo'
 import { Object3DComponent } from '@xrengine/engine/src/scene/components/Object3DComponent'
 import {
@@ -131,7 +132,7 @@ export default async function EditorControlSystem(_: World) {
     )
 
     findIntersectObjects(Engine.scene, os, raycastIgnoreLayers)
-    findIntersectObjects(SceneState.grid)
+    findIntersectObjects(InfiniteGridHelper.instance)
 
     raycasterResults.sort((a, b) => a.distance - b.distance)
     if (raycasterResults[0] && raycasterResults[0].distance < 100) target.copy(raycasterResults[0].point)
@@ -482,9 +483,9 @@ export default async function EditorControlSystem(_: World) {
       } else if (getInput(EditorActionSet.toggleTransformSpace)) {
         toggleTransformSpace()
       } else if (getInput(EditorActionSet.incrementGridHeight)) {
-        SceneState.grid.incrementGridHeight()
+        InfiniteGridHelper.instance.incrementGridHeight()
       } else if (getInput(EditorActionSet.decrementGridHeight)) {
-        SceneState.grid.decrementGridHeight()
+        InfiniteGridHelper.instance.decrementGridHeight()
       } else if (getInput(EditorActionSet.undo)) {
         undoCommand()
       } else if (getInput(EditorActionSet.redo)) {

--- a/packages/engine/src/initializeEngine.ts
+++ b/packages/engine/src/initializeEngine.ts
@@ -22,6 +22,7 @@ import { Network } from './networking/classes/Network'
 import { matchActionOnce, receiveActionOnce } from './networking/functions/matchActionOnce'
 import { NetworkActionReceptor } from './networking/functions/NetworkActionReceptor'
 import { WorldState } from './networking/interfaces/WorldState'
+import InfiniteGridHelper from './scene/classes/InfiniteGridHelper'
 import { ObjectLayers } from './scene/constants/ObjectLayers'
 import { registerPrefabs } from './scene/functions/registerPrefabs'
 import { registerDefaultSceneFunctions } from './scene/functions/registerSceneFunctions'
@@ -43,6 +44,9 @@ export const initializeBrowser = () => {
   Engine.camera.layers.enable(ObjectLayers.Scene)
   Engine.camera.layers.enable(ObjectLayers.Avatar)
   Engine.camera.layers.enable(ObjectLayers.UI)
+
+  InfiniteGridHelper.instance = new InfiniteGridHelper()
+  Engine.scene.add(InfiniteGridHelper.instance)
 
   const browser = detect()
   const os = detectOS(navigator.userAgent)

--- a/packages/engine/src/renderer/EngineRnedererConstants.ts
+++ b/packages/engine/src/renderer/EngineRnedererConstants.ts
@@ -9,5 +9,7 @@ export const RenderSettingKeys = {
   PHYSICS_DEBUG_ENABLE: RenderSettingDBPrefix + 'physicsDebugEnable',
   AVATAR_DEBUG_ENABLE: RenderSettingDBPrefix + 'avatarDebugEnable',
   RENDER_MODE: RenderSettingDBPrefix + 'renderMode',
-  NODE_HELPER_ENABLE: RenderSettingDBPrefix + 'NodeHelperEnable'
+  NODE_HELPER_ENABLE: RenderSettingDBPrefix + 'NodeHelperEnable',
+  GRID_VISIBLE: RenderSettingDBPrefix + 'gridVisible',
+  GRID_HEIGHT: RenderSettingDBPrefix + 'gridHeight'
 }

--- a/packages/engine/src/renderer/EngineRnedererConstants.ts
+++ b/packages/engine/src/renderer/EngineRnedererConstants.ts
@@ -8,5 +8,6 @@ export const RenderSettingKeys = {
   QUALITY_LEVEL: RenderSettingDBPrefix + 'qualityLevel',
   PHYSICS_DEBUG_ENABLE: RenderSettingDBPrefix + 'physicsDebugEnable',
   AVATAR_DEBUG_ENABLE: RenderSettingDBPrefix + 'avatarDebugEnable',
-  RENDER_MODE: RenderSettingDBPrefix + 'renderMode'
+  RENDER_MODE: RenderSettingDBPrefix + 'renderMode',
+  NODE_HELPER_ENABLE: RenderSettingDBPrefix + 'NodeHelperEnable'
 }

--- a/packages/engine/src/scene/classes/InfiniteGridHelper.ts
+++ b/packages/engine/src/scene/classes/InfiniteGridHelper.ts
@@ -1,11 +1,12 @@
 import { Color, DoubleSide, Mesh, Plane, PlaneBufferGeometry, ShaderMaterial, Vector3 } from 'three'
 
-import { store } from '@xrengine/client-core/src/store'
-import { ObjectLayers } from '@xrengine/engine/src/scene/constants/ObjectLayers'
-import { addIsHelperFlag } from '@xrengine/engine/src/scene/functions/addIsHelperFlag'
-import { setObjectLayers } from '@xrengine/engine/src/scene/functions/setObjectLayers'
+import { dispatchAction } from '@xrengine/hyperflux'
 
-import { EditorHelperAction } from '../services/EditorHelperState'
+import { Engine } from '../../ecs/classes/Engine'
+import { EngineRendererAction } from '../../renderer/EngineRendererState'
+import { ObjectLayers } from '../../scene/constants/ObjectLayers'
+import { addIsHelperFlag } from '../../scene/functions/addIsHelperFlag'
+import { setObjectLayers } from '../../scene/functions/setObjectLayers'
 
 /**
  * Original Author: Fyrestar
@@ -60,7 +61,8 @@ void main() {
 
 const GRID_INCREAMENT = 1.5
 
-export default class EditorInfiniteGridHelper extends Mesh {
+export default class InfiniteGridHelper extends Mesh {
+  static instance: InfiniteGridHelper
   plane: Plane
   intersectionPointWorld: Vector3
   intersection: any
@@ -98,7 +100,7 @@ export default class EditorInfiniteGridHelper extends Mesh {
     super(geometry, material)
 
     this.visible = true
-    this.name = 'EditorInfiniteGridHelper'
+    this.name = 'InfiniteGridHelper'
     setObjectLayers(this, ObjectLayers.Gizmos)
     addIsHelperFlag(this)
     this.frustumCulled = false
@@ -138,11 +140,11 @@ export default class EditorInfiniteGridHelper extends Mesh {
 
   setGridHeight(value) {
     this.position.y = value
-    store.dispatch(EditorHelperAction.changeGridToolHeight(value))
+    dispatchAction(Engine.store, EngineRendererAction.changeGridToolHeight(value))
   }
 
   toggleGridVisible() {
     this.visible = !this.visible
-    store.dispatch(EditorHelperAction.changeGridToolVisibility(this.visible))
+    dispatchAction(Engine.store, EngineRendererAction.changeGridToolVisibility(this.visible))
   }
 }

--- a/packages/engine/src/scene/functions/SceneLoading.ts
+++ b/packages/engine/src/scene/functions/SceneLoading.ts
@@ -175,9 +175,7 @@ export const loadSceneFromJSON = async (sceneData: SceneJson, world = useWorld()
 
   addComponent(tree.rootNode.entity, Object3DComponent, { value: Engine.scene })
   addComponent(tree.rootNode.entity, SceneTagComponent, {})
-  if (Engine.isEditor) {
-    getComponent(tree.rootNode.entity, EntityNodeComponent).components.push(SCENE_COMPONENT_SCENE_TAG)
-  }
+  getComponent(tree.rootNode.entity, EntityNodeComponent).components.push(SCENE_COMPONENT_SCENE_TAG)
 
   if (!accessEngineState().isTeleporting.value) Engine.camera?.layers.enable(ObjectLayers.Scene)
 
@@ -191,7 +189,7 @@ export const loadSceneFromJSON = async (sceneData: SceneJson, world = useWorld()
  */
 export const loadSceneEntity = (entityNode: EntityTreeNode, sceneEntity: EntityJson): Entity => {
   addComponent(entityNode.entity, NameComponent, { name: sceneEntity.name })
-  if (Engine.isEditor) addComponent(entityNode.entity, EntityNodeComponent, { components: [] })
+  addComponent(entityNode.entity, EntityNodeComponent, { components: [] })
 
   sceneEntity.components.forEach((component) => {
     try {

--- a/packages/engine/src/scene/functions/loaders/AmbientLightFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/AmbientLightFunctions.test.ts
@@ -64,27 +64,13 @@ describe('AmbientLightFunctions', () => {
       assert(obj3d.intensity === sceneComponentData.intensity)
     })
 
-    describe('Editor vs Location', () => {
-      it('creates Ambient light in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
 
-        deserializeAmbientLight(entity, sceneComponent)
+      deserializeAmbientLight(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_AMBIENT_LIGHT))
-      })
-
-      it('creates Ambient light in Editor', () => {
-        Engine.isEditor = true
-
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
-        deserializeAmbientLight(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_AMBIENT_LIGHT))
-        Engine.isEditor = false
-      })
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_AMBIENT_LIGHT))
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/AmbientLightFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/AmbientLightFunctions.ts
@@ -8,7 +8,6 @@ import {
   ComponentShouldDeserializeFunction,
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent, getComponentCountOfType } from '../../../ecs/functions/ComponentFunctions'
 import { DisableTransformTagComponent } from '../../../transform/components/DisableTransformTagComponent'
@@ -33,7 +32,7 @@ export const deserializeAmbientLight: ComponentDeserializeFunction = (
   addComponent(entity, DisableTransformTagComponent, {})
   addComponent(entity, AmbientLightComponent, props)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_AMBIENT_LIGHT)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_AMBIENT_LIGHT)
 
   updateAmbientLight(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/AssetComponentFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/AssetComponentFunctions.ts
@@ -7,7 +7,6 @@ import {
   ComponentDeserializeFunction,
   ComponentSerializeFunction
 } from '@xrengine/engine/src/common/constants/PrefabFunctionType'
-import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { Entity } from '@xrengine/engine/src/ecs/classes/Entity'
 import { EntityTreeNode } from '@xrengine/engine/src/ecs/classes/EntityTree'
 import {
@@ -64,7 +63,7 @@ export const deserializeAsset: ComponentDeserializeFunction = async (
   }
   const props = parseAssetProperties(json.props)
   addComponent(entity, AssetComponent, props)
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_ASSET)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_ASSET)
 }
 
 export const serializeAsset: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/AudioFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/AudioFunctions.test.ts
@@ -80,7 +80,6 @@ describe('AudioFunctions', () => {
   beforeEach(() => {
     world = createWorld()
     Engine.currentWorld = world
-    Engine.isEditor = false
     entity = createEntity()
   })
 
@@ -147,19 +146,18 @@ describe('AudioFunctions', () => {
       assert(entityNodeComponent.components.includes(SCENE_COMPONENT_AUDIO))
     })
 
-    describe('Editor Tests', () => {
+    describe('Texture mesh Tests', () => {
       it('creates texture mesh for audio', () => {
-        Engine.isEditor = true
         audioFunctions.deserializeAudio(entity, sceneComponent)
 
         const obj3d = getComponent(entity, Object3DComponent).value
 
         assert(obj3d.userData.textureMesh && obj3d.children.includes(obj3d.userData.textureMesh))
         assert(obj3d.userData.textureMesh.userData.disableOutline, 'Outline is not disabled for helper mesh')
+        assert(obj3d.userData.textureMesh.userData.isHelper, 'Outline is not disabled for helper mesh')
       })
 
       it('caches audio texture', () => {
-        Engine.isEditor = true
         const entity2 = createEntity()
 
         audioFunctions.deserializeAudio(entity, sceneComponent)

--- a/packages/engine/src/scene/functions/loaders/AudioFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/AudioFunctions.test.ts
@@ -138,25 +138,13 @@ describe('AudioFunctions', () => {
       })
     })
 
-    describe('Editor vs Location', () => {
-      it('creates Audio in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
 
-        audioFunctions.deserializeAudio(entity, sceneComponent)
+      audioFunctions.deserializeAudio(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_AUDIO))
-      })
-
-      it('creates Audio in Editor', () => {
-        Engine.isEditor = true
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
-        audioFunctions.deserializeAudio(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_AUDIO))
-      })
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_AUDIO))
     })
 
     describe('Editor Tests', () => {

--- a/packages/engine/src/scene/functions/loaders/AudioFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/AudioFunctions.ts
@@ -64,24 +64,23 @@ export const deserializeAudio: ComponentDeserializeFunction = async (
 
   getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_AUDIO)
 
-  if (Engine.isEditor) {
-    obj3d.userData.textureMesh = new Mesh(
-      new PlaneBufferGeometry(),
-      new MeshBasicMaterial({ transparent: true, side: DoubleSide })
-    )
-    obj3d.add(obj3d.userData.textureMesh)
-    obj3d.userData.textureMesh.userData.disableOutline = true
-    setObjectLayers(obj3d.userData.textureMesh, ObjectLayers.NodeHelper)
+  obj3d.userData.textureMesh = new Mesh(
+    new PlaneBufferGeometry(),
+    new MeshBasicMaterial({ transparent: true, side: DoubleSide })
+  )
+  obj3d.add(obj3d.userData.textureMesh)
+  obj3d.userData.textureMesh.userData.disableOutline = true
+  obj3d.userData.textureMesh.userData.isHelper = true
+  setObjectLayers(obj3d.userData.textureMesh, ObjectLayers.NodeHelper)
 
-    if (audioTexture) {
+  if (audioTexture) {
+    obj3d.userData.textureMesh.material.map = audioTexture
+  } else {
+    // can't use await since component should have to be deserialize for media component to work properly
+    AssetLoader.loadAsync(AUDIO_TEXTURE_PATH).then((texture) => {
+      audioTexture = texture!
       obj3d.userData.textureMesh.material.map = audioTexture
-    } else {
-      // can't use await since component should have to be deserialize for media component to work properly
-      AssetLoader.loadAsync(AUDIO_TEXTURE_PATH).then((texture) => {
-        audioTexture = texture!
-        obj3d.userData.textureMesh.material.map = audioTexture
-      })
-    }
+    })
   }
 
   updateAudio(entity, props)

--- a/packages/engine/src/scene/functions/loaders/AudioFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/AudioFunctions.ts
@@ -62,9 +62,9 @@ export const deserializeAudio: ComponentDeserializeFunction = async (
   const props = parseAudioProperties(json.props)
   addComponent(entity, AudioComponent, props)
 
-  if (Engine.isEditor) {
-    getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_AUDIO)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_AUDIO)
 
+  if (Engine.isEditor) {
     obj3d.userData.textureMesh = new Mesh(
       new PlaneBufferGeometry(),
       new MeshBasicMaterial({ transparent: true, side: DoubleSide })

--- a/packages/engine/src/scene/functions/loaders/AudioSettingFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/AudioSettingFunctions.test.ts
@@ -27,7 +27,6 @@ describe('AudioSettingFunctions', () => {
   beforeEach(() => {
     world = createWorld()
     Engine.currentWorld = world
-    Engine.isEditor = false
     entity = createEntity()
   })
 

--- a/packages/engine/src/scene/functions/loaders/AudioSettingFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/AudioSettingFunctions.test.ts
@@ -63,26 +63,13 @@ describe('AudioSettingFunctions', () => {
       assert.deepEqual(ambientLightComponent, sceneComponentData)
     })
 
-    describe('Editor vs Location', () => {
-      it('creates Audio setting component in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
 
-        deserializeAudioSetting(entity, sceneComponent)
+      deserializeAudioSetting(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_AUDIO_SETTINGS))
-      })
-
-      it('creates Audio setting component in Editor', () => {
-        Engine.isEditor = true
-
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
-        deserializeAudioSetting(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_AUDIO_SETTINGS))
-      })
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_AUDIO_SETTINGS))
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/AudioSettingFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/AudioSettingFunctions.ts
@@ -1,7 +1,6 @@
 import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
 
 import { ComponentDeserializeFunction, ComponentSerializeFunction } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import {
@@ -34,7 +33,7 @@ export const deserializeAudioSetting: ComponentDeserializeFunction = (
   const props = parseAudioSettingProperties(json.props)
 
   addComponent(entity, PositionalAudioSettingsComponent, props)
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_AUDIO_SETTINGS)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_AUDIO_SETTINGS)
 }
 
 export const serializeAudioSetting: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/BoxColliderFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/BoxColliderFunctions.test.ts
@@ -94,29 +94,9 @@ describe('BoxColliderFunctions', () => {
       assert(entityNodeComponent.components.includes(SCENE_COMPONENT_BOX_COLLIDER))
     })
 
-    describe('Editor vs Location', () => {
-      it('creates BoxCollider in Location', () => {
-        const parent = new Object3D()
-        const obj3d = new Object3D()
-        parent.add(obj3d)
-
-        addComponent(entity, Object3DComponent, { value: obj3d })
-
-        sceneComponentData.removeMesh = true
-        boxcolliderFunctions.deserializeBoxCollider(entity, sceneComponent)
-
-        assert(!getComponent(entity, Object3DComponent)?.value)
-        assert(!parent.children.includes(obj3d))
-      })
-
-      it('creates BoxCollider in Editor', () => {
-        Engine.isEditor = true
-
-        boxcolliderFunctions.deserializeBoxCollider(entity, sceneComponent)
-
-        assert(getComponent(entity, Object3DComponent)?.value)
-        Engine.isEditor = false
-      })
+    it('creates Object3d Component', () => {
+      boxcolliderFunctions.deserializeBoxCollider(entity, sceneComponent)
+      assert(getComponent(entity, Object3DComponent)?.value)
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/BoxColliderFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/BoxColliderFunctions.test.ts
@@ -85,10 +85,17 @@ describe('BoxColliderFunctions', () => {
       assert(collision && collision.collisions.length <= 0, 'CollisionComponent is not created')
     })
 
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
+
+      boxcolliderFunctions.deserializeBoxCollider(entity, sceneComponent)
+
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_BOX_COLLIDER))
+    })
+
     describe('Editor vs Location', () => {
       it('creates BoxCollider in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         const parent = new Object3D()
         const obj3d = new Object3D()
         parent.add(obj3d)
@@ -98,8 +105,6 @@ describe('BoxColliderFunctions', () => {
         sceneComponentData.removeMesh = true
         boxcolliderFunctions.deserializeBoxCollider(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_BOX_COLLIDER))
         assert(!getComponent(entity, Object3DComponent)?.value)
         assert(!parent.children.includes(obj3d))
       })
@@ -107,12 +112,7 @@ describe('BoxColliderFunctions', () => {
       it('creates BoxCollider in Editor', () => {
         Engine.isEditor = true
 
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         boxcolliderFunctions.deserializeBoxCollider(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_BOX_COLLIDER))
 
         assert(getComponent(entity, Object3DComponent)?.value)
         Engine.isEditor = false

--- a/packages/engine/src/scene/functions/loaders/BoxColliderFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/BoxColliderFunctions.ts
@@ -7,9 +7,8 @@ import {
   ComponentSerializeFunction,
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
-import { addComponent, getComponent, hasComponent, removeComponent } from '../../../ecs/functions/ComponentFunctions'
+import { addComponent, getComponent, hasComponent } from '../../../ecs/functions/ComponentFunctions'
 import { useWorld } from '../../../ecs/functions/SystemHooks'
 import { isTriggerShape, setTriggerShape } from '../../../physics/classes/Physics'
 import { ColliderComponent } from '../../../physics/components/ColliderComponent'
@@ -49,20 +48,7 @@ export const deserializeBoxCollider: ComponentDeserializeFunction = (
 
   getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_BOX_COLLIDER)
 
-  if (Engine.isEditor) {
-    if (!hasComponent(entity, Object3DComponent)) addComponent(entity, Object3DComponent, { value: new Object3D() })
-  } else {
-    if (
-      boxColliderProps.removeMesh === 'true' ||
-      (typeof boxColliderProps.removeMesh === 'boolean' && boxColliderProps.removeMesh === true)
-    ) {
-      const obj = getComponent(entity, Object3DComponent)
-      if (obj?.value) {
-        if (obj.value.parent) obj.value.removeFromParent()
-        removeComponent(entity, Object3DComponent)
-      }
-    }
-  }
+  if (!hasComponent(entity, Object3DComponent)) addComponent(entity, Object3DComponent, { value: new Object3D() })
 }
 
 export const updateBoxCollider: ComponentUpdateFunction = (entity: Entity, props: BoxColliderProps) => {

--- a/packages/engine/src/scene/functions/loaders/BoxColliderFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/BoxColliderFunctions.ts
@@ -47,9 +47,10 @@ export const deserializeBoxCollider: ComponentDeserializeFunction = (
   addComponent(entity, ColliderComponent, { body })
   addComponent(entity, CollisionComponent, { collisions: [] })
 
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_BOX_COLLIDER)
+
   if (Engine.isEditor) {
     if (!hasComponent(entity, Object3DComponent)) addComponent(entity, Object3DComponent, { value: new Object3D() })
-    getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_BOX_COLLIDER)
   } else {
     if (
       boxColliderProps.removeMesh === 'true' ||

--- a/packages/engine/src/scene/functions/loaders/CameraPropertiesFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/CameraPropertiesFunctions.test.ts
@@ -68,28 +68,13 @@ describe('CameraPropertiesFunctions', () => {
       assert.deepEqual(camerapropertiesComponent, sceneComponentData)
     })
 
-    describe('Editor vs Location', () => {
-      it('creates CameraProperties in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
 
-        camerapropertiesFunctions.deserializeCameraProperties(entity, sceneComponent)
+      camerapropertiesFunctions.deserializeCameraProperties(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_CAMERA_PROPERTIES))
-      })
-
-      it('creates CameraProperties in Editor', () => {
-        Engine.isEditor = true
-
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
-        camerapropertiesFunctions.deserializeCameraProperties(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_CAMERA_PROPERTIES))
-
-        Engine.isEditor = false
-      })
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_CAMERA_PROPERTIES))
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/CameraPropertiesFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/CameraPropertiesFunctions.ts
@@ -38,8 +38,9 @@ export const deserializeCameraProperties: ComponentDeserializeFunction = (
   const props = parseCameraPropertiesProperties(json.props)
   addComponent(entity, CameraPropertiesComponent, props)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_CAMERA_PROPERTIES)
-  else if (isClient) {
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_CAMERA_PROPERTIES)
+
+  if (isClient) {
     matchActionOnce(Engine.currentWorld.store, NetworkWorldAction.spawnAvatar.matches, (spawnAction) => {
       if (spawnAction.$from === Engine.userId) {
         setCameraProperties(useWorld().localClientEntity, json.props)

--- a/packages/engine/src/scene/functions/loaders/CloudFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/CloudFunctions.test.ts
@@ -105,25 +105,27 @@ describe('CloudFunctions', () => {
       assert(obj3d && obj3d instanceof Clouds, 'Cloud is not created')
     })
 
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
+
+      cloudFunctions.deserializeCloud(entity, sceneComponent)
+
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_CLOUD))
+    })
+
     describe('Editor vs Location', () => {
       it('creates Cloud in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         cloudFunctions.deserializeCloud(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_CLOUD))
+        const obj3d = getComponent(entity, Object3DComponent)?.value
+        assert(obj3d && !obj3d.userData.disableOutline, 'Cloud outline is disabled')
       })
 
       it('creates Cloud in Editor', () => {
         Engine.isEditor = true
 
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         cloudFunctions.deserializeCloud(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_CLOUD))
 
         const obj3d = getComponent(entity, Object3DComponent)?.value
         assert(obj3d && obj3d.userData.disableOutline, 'Cloud outline is not disabled')

--- a/packages/engine/src/scene/functions/loaders/CloudFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/CloudFunctions.test.ts
@@ -103,6 +103,7 @@ describe('CloudFunctions', () => {
 
       const obj3d = getComponent(entity, Object3DComponent)?.value
       assert(obj3d && obj3d instanceof Clouds, 'Cloud is not created')
+      assert(obj3d.userData.disableOutline, 'Cloud outline is not disabled')
     })
 
     it('will include this component into EntityNodeComponent', () => {
@@ -112,25 +113,6 @@ describe('CloudFunctions', () => {
 
       const entityNodeComponent = getComponent(entity, EntityNodeComponent)
       assert(entityNodeComponent.components.includes(SCENE_COMPONENT_CLOUD))
-    })
-
-    describe('Editor vs Location', () => {
-      it('creates Cloud in Location', () => {
-        cloudFunctions.deserializeCloud(entity, sceneComponent)
-
-        const obj3d = getComponent(entity, Object3DComponent)?.value
-        assert(obj3d && !obj3d.userData.disableOutline, 'Cloud outline is disabled')
-      })
-
-      it('creates Cloud in Editor', () => {
-        Engine.isEditor = true
-
-        cloudFunctions.deserializeCloud(entity, sceneComponent)
-
-        const obj3d = getComponent(entity, Object3DComponent)?.value
-        assert(obj3d && obj3d.userData.disableOutline, 'Cloud outline is not disabled')
-        Engine.isEditor = false
-      })
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/CloudFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/CloudFunctions.ts
@@ -43,11 +43,8 @@ export const deserializeCloud: ComponentDeserializeFunction = (
   addComponent(entity, CloudComponent, props)
   addComponent(entity, UpdatableComponent, {})
 
-  if (Engine.isEditor) {
-    getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_CLOUD)
-
-    obj3d.userData.disableOutline = true
-  }
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_CLOUD)
+  if (Engine.isEditor) obj3d.userData.disableOutline = true
 
   updateCloud(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/CloudFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/CloudFunctions.ts
@@ -37,6 +37,7 @@ export const deserializeCloud: ComponentDeserializeFunction = (
   if (!isClient) return
 
   const obj3d = new Clouds(entity)
+  obj3d.userData.disableOutline = true
   const props = parseCloudProperties(json.props)
 
   addComponent(entity, Object3DComponent, { value: obj3d })
@@ -44,7 +45,6 @@ export const deserializeCloud: ComponentDeserializeFunction = (
   addComponent(entity, UpdatableComponent, {})
 
   getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_CLOUD)
-  if (Engine.isEditor) obj3d.userData.disableOutline = true
 
   updateCloud(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/ColliderFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/ColliderFunctions.test.ts
@@ -79,28 +79,13 @@ describe('ColliderFunctions', () => {
       assert(collision && collision.collisions.length <= 0, 'CollisionComponent is not created')
     })
 
-    describe('Editor vs Location', () => {
-      it('creates Collider in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
 
-        colliderFunctions.deserializeCollider(entity, sceneComponent)
+      colliderFunctions.deserializeCollider(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_COLLIDER))
-      })
-
-      it('creates Collider in Editor', () => {
-        Engine.isEditor = true
-
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
-        colliderFunctions.deserializeCollider(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_COLLIDER))
-
-        Engine.isEditor = false
-      })
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_COLLIDER))
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/ColliderFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/ColliderFunctions.ts
@@ -1,7 +1,6 @@
 import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
 
 import { ComponentDeserializeFunction, ComponentSerializeFunction } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { ColliderComponent } from '../../../physics/components/ColliderComponent'
@@ -16,7 +15,7 @@ export const deserializeCollider: ComponentDeserializeFunction = (
   json: ComponentJson<ShapeOptions>
 ): void => {
   createColliderForObject3D(entity, json.props, false)
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_COLLIDER)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_COLLIDER)
 }
 
 export const serializeCollider: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/CubemapBakeFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/CubemapBakeFunctions.ts
@@ -53,13 +53,13 @@ export const deserializeCubemapBake: ComponentDeserializeFunction = (
 ) => {
   const obj3d = new Object3D()
   addComponent(entity, Object3DComponent, { value: obj3d })
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_CUBEMAP_BAKE)
 
   if (!Engine.isEditor) return
 
   const props = parseCubemapBakeProperties(json.props)
   addComponent(entity, CubemapBakeComponent, props)
   addComponent(entity, PreventBakeTagComponent, {})
-  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_CUBEMAP_BAKE)
 
   obj3d.userData.centerBall = new Mesh(
     new SphereGeometry(0.75),

--- a/packages/engine/src/scene/functions/loaders/DirectionalLightFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/DirectionalLightFunctions.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import { Color, DirectionalLight } from 'three'
+import { Color, DirectionalLight, Scene } from 'three'
 
 import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
 
@@ -21,6 +21,7 @@ describe('DirectionalLightFunctions', () => {
     it('with CSM', () => {
       const world = createWorld()
       Engine.currentWorld = world
+      Engine.scene = new Scene()
       EngineRenderer.instance.isCSMEnabled = true
       EngineRenderer.instance.directionalLightEntities = []
 

--- a/packages/engine/src/scene/functions/loaders/DirectionalLightFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/DirectionalLightFunctions.ts
@@ -45,17 +45,19 @@ export const deserializeDirectionalLight: ComponentDeserializeFunction = (
   light.target.name = 'light-target'
   light.add(light.target)
 
-  if (Engine.isEditor) {
-    const helper = new EditorDirectionalLightHelper()
-    helper.visible = true
-    light.add(helper)
-    light.userData.helper = helper
+  const helper = new EditorDirectionalLightHelper()
+  helper.visible = true
+  helper.userData.isHelper = true
+  light.add(helper)
+  light.userData.helper = helper
 
-    const cameraHelper = new CameraHelper(light.shadow.camera)
-    cameraHelper.visible = false
-    light.userData.cameraHelper = cameraHelper
-    setObjectLayers(cameraHelper, ObjectLayers.NodeHelper)
-  }
+  const cameraHelper = new CameraHelper(light.shadow.camera)
+  cameraHelper.visible = false
+  light.userData.cameraHelper = cameraHelper
+  cameraHelper.userData.isHelper = true
+
+  setObjectLayers(helper, ObjectLayers.NodeHelper)
+  setObjectLayers(cameraHelper, ObjectLayers.NodeHelper)
 
   EngineRenderer.instance.directionalLightEntities.push(entity)
   addComponent(entity, Object3DComponent, { value: light })
@@ -130,18 +132,16 @@ export const updateDirectionalLight: ComponentUpdateFunction = (
     }
   }
 
-  if (Engine.isEditor) {
-    light.userData.helper.update()
-    light.userData.cameraHelper.visible = component.showCameraHelper
+  light.userData.helper.update()
+  light.userData.cameraHelper.visible = component.showCameraHelper
 
-    if (component.showCameraHelper) {
-      Engine.scene.add(light.userData.cameraHelper)
-    } else {
-      Engine.scene.remove(light.userData.cameraHelper)
-    }
-
-    light.userData.cameraHelper.update()
+  if (component.showCameraHelper) {
+    Engine.scene.add(light.userData.cameraHelper)
+  } else {
+    Engine.scene.remove(light.userData.cameraHelper)
   }
+
+  light.userData.cameraHelper.update()
 }
 
 export const serializeDirectionalLight: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/DirectionalLightFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/DirectionalLightFunctions.ts
@@ -61,7 +61,7 @@ export const deserializeDirectionalLight: ComponentDeserializeFunction = (
   addComponent(entity, Object3DComponent, { value: light })
   addComponent(entity, DirectionalLightComponent, props)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_DIRECTIONAL_LIGHT)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_DIRECTIONAL_LIGHT)
 
   updateDirectionalLight(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/EnvMapFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/EnvMapFunctions.ts
@@ -64,7 +64,7 @@ export const deserializeEnvMap: ComponentDeserializeFunction = (
   const props = parseEnvMapProperties(json.props)
   addComponent(entity, EnvmapComponent, props)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_ENVMAP)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_ENVMAP)
 
   updateEnvMap(entity)
 }

--- a/packages/engine/src/scene/functions/loaders/FogFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/FogFunctions.ts
@@ -27,7 +27,7 @@ export const deserializeFog: ComponentDeserializeFunction = (entity: Entity, jso
   const props = parseFogProperties(json.props)
   addComponent(entity, FogComponent, props)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_FOG)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_FOG)
 
   updateFog(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/GroundPlaneFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/GroundPlaneFunctions.ts
@@ -55,9 +55,9 @@ export const deserializeGround: ComponentDeserializeFunction = async function (
 
   const props = parseGroundPlaneProperties(json.props)
   addComponent(entity, GroundPlaneComponent, props)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_GROUND_PLANE)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_GROUND_PLANE)
-  else createCollider(entity, groundPlane.userData.mesh)
+  if (!Engine.isEditor) createCollider(entity, groundPlane.userData.mesh)
 
   updateGroundPlane(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/GroupFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/GroupFunctions.ts
@@ -3,7 +3,6 @@ import { Object3D } from 'three'
 import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
 
 import { ComponentDeserializeFunction, ComponentSerializeFunction } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent, hasComponent } from '../../../ecs/functions/ComponentFunctions'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
@@ -16,7 +15,7 @@ export const SCENE_COMPONENT_GROUP_DEFAULT_VALUES = {}
 export const deserializeGroup: ComponentDeserializeFunction = (entity: Entity, _: ComponentJson<{}>) => {
   addComponent(entity, GroupComponent, {})
   addComponent(entity, Object3DComponent, { value: new Object3D() })
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_GROUP)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_GROUP)
 }
 
 export const serializeGroup: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/HemisphereLightFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/HemisphereLightFunctions.ts
@@ -8,7 +8,6 @@ import {
   ComponentShouldDeserializeFunction,
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent, getComponentCountOfType } from '../../../ecs/functions/ComponentFunctions'
 import { DisableTransformTagComponent } from '../../../transform/components/DisableTransformTagComponent'
@@ -34,7 +33,7 @@ export const deserializeHemisphereLight: ComponentDeserializeFunction = (
   addComponent(entity, DisableTransformTagComponent, {})
   addComponent(entity, HemisphereLightComponent, props)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_HEMISPHERE_LIGHT)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_HEMISPHERE_LIGHT)
 
   updateHemisphereLight(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/ImageFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/ImageFunctions.ts
@@ -21,7 +21,6 @@ import {
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
 import { isClient } from '../../../common/functions/isClient'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { ImageAlphaMode, ImageProjection } from '../../classes/ImageUtils'
@@ -56,7 +55,7 @@ export const deserializeImage: ComponentDeserializeFunction = (
   const props = parseImageProperties(json.props)
   addComponent(entity, ImageComponent, props)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_IMAGE)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_IMAGE)
 
   updateImage(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/InteractableFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/InteractableFunctions.ts
@@ -7,7 +7,6 @@ import {
   ComponentSerializeFunction,
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { InteractableComponent, InteractableComponentType } from '../../../interaction/components/InteractableComponent'
@@ -25,7 +24,7 @@ export const deserializeInteractable: ComponentDeserializeFunction = (
   const props = parseInteractableProperties(json.props)
   addComponent(entity, InteractableComponent, createState(props))
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_INTERACTABLE)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_INTERACTABLE)
 
   updateInteractable(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/InteriorFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/InteriorFunctions.ts
@@ -36,11 +36,8 @@ export const deserializeInterior: ComponentDeserializeFunction = (
   addComponent(entity, Object3DComponent, { value: obj3d })
   addComponent(entity, InteriorComponent, props)
 
-  if (Engine.isEditor) {
-    getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_INTERIOR)
-
-    obj3d.userData.disableOutline = true
-  }
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_INTERIOR)
+  if (Engine.isEditor) obj3d.userData.disableOutline = true
 
   updateInterior(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/InteriorFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/InteriorFunctions.ts
@@ -8,7 +8,6 @@ import {
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
 import { isClient } from '../../../common/functions/isClient'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { Interior } from '../../classes/Interior'
@@ -31,13 +30,13 @@ export const deserializeInterior: ComponentDeserializeFunction = (
   if (!isClient) return
 
   const obj3d = new Interior(entity)
+  obj3d.userData.disableOutline = true
   const props = parseInteriorProperties(json.props)
 
   addComponent(entity, Object3DComponent, { value: obj3d })
   addComponent(entity, InteriorComponent, props)
 
   getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_INTERIOR)
-  if (Engine.isEditor) obj3d.userData.disableOutline = true
 
   updateInterior(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/LoopAnimationFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/LoopAnimationFunctions.ts
@@ -48,7 +48,7 @@ export const deserializeLoopAnimation: ComponentDeserializeFunction = (
     animationSpeed: 1
   })
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_LOOP_ANIMATION)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_LOOP_ANIMATION)
 
   if (accessEngineState().sceneLoaded.value) {
     updateLoopAnimation(entity)

--- a/packages/engine/src/scene/functions/loaders/MediaFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/MediaFunctions.ts
@@ -31,7 +31,7 @@ export const deserializeMedia: ComponentDeserializeFunction = (
   addComponent(entity, Object3DComponent, { value: new UpdateableObject3D() })
   addComponent(entity, UpdatableComponent, {})
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_MEDIA)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_MEDIA)
 
   updateMedia(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/MetaDataFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/MetaDataFunctions.ts
@@ -20,7 +20,7 @@ export const deserializeMetaData: ComponentDeserializeFunction = (
 ) => {
   addComponent(entity, MetaDataComponent, { meta_data: json.props.meta_data ?? '' })
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_METADATA)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_METADATA)
 
   updateMetaData(entity)
 }

--- a/packages/engine/src/scene/functions/loaders/ModelFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/ModelFunctions.ts
@@ -7,7 +7,6 @@ import {
   ComponentSerializeFunction,
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent, hasComponent, removeComponent } from '../../../ecs/functions/ComponentFunctions'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
@@ -34,7 +33,7 @@ export const deserializeModel: ComponentDeserializeFunction = (
   const props = parseModelProperties(component.props)
   addComponent(entity, ModelComponent, props)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_MODEL)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_MODEL)
   updateModel(entity, props)
 }
 

--- a/packages/engine/src/scene/functions/loaders/OceanFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/OceanFunctions.ts
@@ -56,11 +56,9 @@ export const deserializeOcean: ComponentDeserializeFunction = (
   addComponent(entity, OceanComponent, props)
   addComponent(entity, UpdatableComponent, {})
 
-  if (Engine.isEditor) {
-    getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_OCEAN)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_OCEAN)
 
-    obj3d.userData.disableOutline = true
-  }
+  if (Engine.isEditor) obj3d.userData.disableOutline = true
 
   updateOcean(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/OceanFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/OceanFunctions.ts
@@ -8,7 +8,6 @@ import {
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
 import { isClient } from '../../../common/functions/isClient'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { Ocean } from '../../classes/Ocean'
@@ -50,6 +49,7 @@ export const deserializeOcean: ComponentDeserializeFunction = (
   if (!isClient) return
 
   const obj3d = new Ocean(entity)
+  obj3d.userData.disableOutline = true
   const props = parseOceanProperties(json.props)
 
   addComponent(entity, Object3DComponent, { value: obj3d })
@@ -57,8 +57,6 @@ export const deserializeOcean: ComponentDeserializeFunction = (
   addComponent(entity, UpdatableComponent, {})
 
   getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_OCEAN)
-
-  if (Engine.isEditor) obj3d.userData.disableOutline = true
 
   updateOcean(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/ParticleEmitterFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/ParticleEmitterFunctions.ts
@@ -9,7 +9,6 @@ import {
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
 import { isClient } from '../../../common/functions/isClient'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { ParticleEmitterComponent } from '../../../particles/components/ParticleEmitter'
@@ -58,7 +57,7 @@ export const deserializeParticleEmitter: ComponentDeserializeFunction = (
   addComponent(entity, Object3DComponent, { value: mesh })
   addComponent(entity, RenderedComponent, {})
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_PARTICLE_EMITTER)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_PARTICLE_EMITTER)
 }
 
 export const updateParticleEmitter: ComponentUpdateFunction = (entity: Entity, props: any): void => {

--- a/packages/engine/src/scene/functions/loaders/PersistFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/PersistFunctions.ts
@@ -2,7 +2,6 @@ import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
 
 import { ComponentDeserializeFunction, ComponentSerializeFunction } from '../../../common/constants/PrefabFunctionType'
 import { isClient } from '../../../common/functions/isClient'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent, hasComponent } from '../../../ecs/functions/ComponentFunctions'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
@@ -12,7 +11,7 @@ export const SCENE_COMPONENT_PERSIST = 'persist'
 
 export const deserializePersist: ComponentDeserializeFunction = (entity: Entity, _: ComponentJson<{}>) => {
   if (isClient) addComponent(entity, PersistTagComponent, {})
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_PERSIST)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_PERSIST)
 }
 
 export const serializePersist: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/PointLightFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/PointLightFunctions.ts
@@ -56,7 +56,7 @@ export const deserializePointLight: ComponentDeserializeFunction = (
   addComponent(entity, Object3DComponent, { value: light })
   addComponent(entity, PointLightComponent, props)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_POINT_LIGHT)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_POINT_LIGHT)
 
   updatePointLight(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/PointLightFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/PointLightFunctions.ts
@@ -36,22 +36,20 @@ export const deserializePointLight: ComponentDeserializeFunction = (
   const light = new PointLight()
   const props = parsePointLightProperties(json.props)
 
-  if (Engine.isEditor) {
-    const ball = new Mesh(new IcosahedronGeometry(0.15), new MeshBasicMaterial({ fog: false }))
-    const rangeBall = new Mesh(
-      new IcosahedronGeometry(0.25),
-      new MeshBasicMaterial({ fog: false, transparent: true, opacity: 0.5 })
-    )
-    light.add(ball)
-    light.add(rangeBall)
-    rangeBall.userData.isHelper = true
-    ball.userData.isHelper = true
-    light.userData.rangeBall = rangeBall
-    light.userData.ball = ball
+  const ball = new Mesh(new IcosahedronGeometry(0.15), new MeshBasicMaterial({ fog: false }))
+  const rangeBall = new Mesh(
+    new IcosahedronGeometry(0.25),
+    new MeshBasicMaterial({ fog: false, transparent: true, opacity: 0.5 })
+  )
+  light.add(ball)
+  light.add(rangeBall)
+  rangeBall.userData.isHelper = true
+  ball.userData.isHelper = true
+  light.userData.rangeBall = rangeBall
+  light.userData.ball = ball
 
-    setObjectLayers(ball, ObjectLayers.NodeHelper)
-    setObjectLayers(rangeBall, ObjectLayers.NodeHelper)
-  }
+  setObjectLayers(ball, ObjectLayers.NodeHelper)
+  setObjectLayers(rangeBall, ObjectLayers.NodeHelper)
 
   addComponent(entity, Object3DComponent, { value: light })
   addComponent(entity, PointLightComponent, props)
@@ -82,10 +80,8 @@ export const updatePointLight: ComponentUpdateFunction = (entity: Entity, proper
     light.shadow.needsUpdate = true
   }
 
-  if (Engine.isEditor) {
-    light.userData.ball.material.color = component.color
-    light.userData.rangeBall.material.color = component.color
-  }
+  light.userData.ball.material.color = component.color
+  light.userData.rangeBall.material.color = component.color
 }
 
 export const serializePointLight: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/PortalFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/PortalFunctions.ts
@@ -40,30 +40,29 @@ export const deserializePortal: ComponentDeserializeFunction = (
 
   addComponent(entity, PortalComponent, props)
 
-  if (Engine.isEditor) {
-    const spawnHelperEntity = createEntity()
-    const portalComponent = getComponent(entity, PortalComponent)
-    portalComponent.helper = spawnHelperEntity
-    addComponent(spawnHelperEntity, TransformComponent, {
-      position: new Vector3(),
-      rotation: new Quaternion(),
-      scale: new Vector3(1, 1, 1)
-    })
-    const spawnHelperMesh = new Mesh(
-      new CylinderGeometry(1, 1, 0.3, 6, 1, false, (30 * Math.PI) / 180),
-      new MeshBasicMaterial({ color: 0x2b59c3 })
-    )
-    const spawnDirection = new Mesh(
-      new ConeGeometry(0.15, 0.5, 4, 1, false, Math.PI / 4),
-      new MeshBasicMaterial({ color: 0xd36582 })
-    )
-    spawnDirection.position.set(0, 0, 1.25)
-    spawnDirection.rotateX(Math.PI / 2)
-    spawnHelperMesh.add(spawnDirection)
+  const spawnHelperEntity = createEntity()
+  const portalComponent = getComponent(entity, PortalComponent)
+  portalComponent.helper = spawnHelperEntity
+  addComponent(spawnHelperEntity, TransformComponent, {
+    position: new Vector3(),
+    rotation: new Quaternion(),
+    scale: new Vector3(1, 1, 1)
+  })
+  const spawnHelperMesh = new Mesh(
+    new CylinderGeometry(1, 1, 0.3, 6, 1, false, (30 * Math.PI) / 180),
+    new MeshBasicMaterial({ color: 0x2b59c3 })
+  )
+  const spawnDirection = new Mesh(
+    new ConeGeometry(0.15, 0.5, 4, 1, false, Math.PI / 4),
+    new MeshBasicMaterial({ color: 0xd36582 })
+  )
+  spawnDirection.position.set(0, 0, 1.25)
+  spawnDirection.rotateX(Math.PI / 2)
+  spawnHelperMesh.add(spawnDirection)
+  spawnHelperMesh.userData.isHelper = true
 
-    setObjectLayers(spawnHelperMesh, ObjectLayers.NodeHelper)
-    addComponent(spawnHelperEntity, Object3DComponent, { value: spawnHelperMesh })
-  }
+  setObjectLayers(spawnHelperMesh, ObjectLayers.NodeHelper)
+  addComponent(spawnHelperEntity, Object3DComponent, { value: spawnHelperMesh })
 
   getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_PORTAL)
 
@@ -71,23 +70,21 @@ export const deserializePortal: ComponentDeserializeFunction = (
 }
 
 export const updatePortal: ComponentUpdateFunction = (entity: Entity) => {
-  if (Engine.isEditor) {
-    const portalComponent = getComponent(entity, PortalComponent)
-    const helperTransform = getComponent(portalComponent.helper, TransformComponent)
-    if (portalComponent.spawnPosition) {
-      helperTransform.position.set(
-        portalComponent.spawnPosition.x || 0,
-        portalComponent.spawnPosition.y || 0,
-        portalComponent.spawnPosition.z || 0
-      )
-    }
-    if (portalComponent.spawnRotation) {
-      const euler = new Euler().setFromQuaternion(helperTransform.rotation)
-      euler.x = portalComponent.spawnRotation.x ?? euler.x
-      euler.y = portalComponent.spawnRotation.y ?? euler.y
-      euler.z = portalComponent.spawnRotation.z ?? euler.z
-      helperTransform.rotation.setFromEuler(euler)
-    }
+  const portalComponent = getComponent(entity, PortalComponent)
+  const helperTransform = getComponent(portalComponent.helper, TransformComponent)
+  if (portalComponent.spawnPosition) {
+    helperTransform.position.set(
+      portalComponent.spawnPosition.x || 0,
+      portalComponent.spawnPosition.y || 0,
+      portalComponent.spawnPosition.z || 0
+    )
+  }
+  if (portalComponent.spawnRotation) {
+    const euler = new Euler().setFromQuaternion(helperTransform.rotation)
+    euler.x = portalComponent.spawnRotation.x ?? euler.x
+    euler.y = portalComponent.spawnRotation.y ?? euler.y
+    euler.z = portalComponent.spawnRotation.z ?? euler.z
+    helperTransform.rotation.setFromEuler(euler)
   }
 }
 

--- a/packages/engine/src/scene/functions/loaders/PortalFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/PortalFunctions.ts
@@ -65,7 +65,7 @@ export const deserializePortal: ComponentDeserializeFunction = (
     addComponent(spawnHelperEntity, Object3DComponent, { value: spawnHelperMesh })
   }
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_PORTAL)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_PORTAL)
 
   updatePortal(entity)
 }

--- a/packages/engine/src/scene/functions/loaders/PostprocessingFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/PostprocessingFunctions.test.ts
@@ -67,28 +67,13 @@ describe('PostprocessingFunctions', () => {
       assert(getComponent(entity, IgnoreRaycastTagComponent))
     })
 
-    describe('Editor vs Location', () => {
-      it('creates Postprocessing in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
 
-        postprocessingFunctions.deserializePostprocessing(entity, sceneComponent)
+      postprocessingFunctions.deserializePostprocessing(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_POSTPROCESSING))
-      })
-
-      it('creates Postprocessing in Editor', () => {
-        Engine.isEditor = true
-
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
-        postprocessingFunctions.deserializePostprocessing(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_POSTPROCESSING))
-
-        Engine.isEditor = false
-      })
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_POSTPROCESSING))
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/PostprocessingFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/PostprocessingFunctions.ts
@@ -9,7 +9,6 @@ import {
   ComponentShouldDeserializeFunction,
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent, getComponentCountOfType } from '../../../ecs/functions/ComponentFunctions'
 import { configureEffectComposer } from '../../../renderer/functions/configureEffectComposer'
@@ -35,7 +34,7 @@ export const deserializePostprocessing: ComponentDeserializeFunction = async fun
   addComponent(entity, DisableTransformTagComponent, {})
   addComponent(entity, IgnoreRaycastTagComponent, {})
   addComponent(entity, Object3DComponent, { value: new Object3D() })
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_POSTPROCESSING)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_POSTPROCESSING)
 }
 
 export const updatePostprocessing: ComponentUpdateFunction = (_: Entity) => {

--- a/packages/engine/src/scene/functions/loaders/PreventBakeFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/PreventBakeFunctions.test.ts
@@ -1,5 +1,4 @@
 import assert from 'assert'
-import { Object3D } from 'three'
 
 import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
 
@@ -12,8 +11,6 @@ import { createEntity } from '../../../ecs/functions/EntityFunctions'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
 import { PreventBakeTagComponent } from '../../components/PreventBakeTagComponent'
 import { deserializePreventBake, SCENE_COMPONENT_PREVENT_BAKE, serializePreventBake } from './PreventBakeFunctions'
-
-class FakePreventBake extends Object3D {}
 
 describe('PreventBakeFunctions', () => {
   let world: World
@@ -42,16 +39,7 @@ describe('PreventBakeFunctions', () => {
       assert(entityNodeComponent.components.includes(SCENE_COMPONENT_PREVENT_BAKE))
     })
 
-    it('does not create PreventBake Component if not in editor', () => {
-      Engine.isEditor = false
-      deserializePreventBake(entity, sceneComponent)
-
-      const preventbakeComponent = getComponent(entity, PreventBakeTagComponent)
-      assert(!preventbakeComponent)
-    })
-
     it('creates PreventBake Component with provided component data', () => {
-      Engine.isEditor = true
       deserializePreventBake(entity, sceneComponent)
 
       const preventbakeComponent = getComponent(entity, PreventBakeTagComponent)

--- a/packages/engine/src/scene/functions/loaders/PreventBakeFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/PreventBakeFunctions.test.ts
@@ -33,29 +33,30 @@ describe('PreventBakeFunctions', () => {
   }
 
   describe('deserializePreventBake()', () => {
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
+
+      deserializePreventBake(entity, sceneComponent)
+
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_PREVENT_BAKE))
+    })
+
     it('does not create PreventBake Component if not in editor', () => {
       Engine.isEditor = false
-      addComponent(entity, EntityNodeComponent, { components: [] })
       deserializePreventBake(entity, sceneComponent)
 
       const preventbakeComponent = getComponent(entity, PreventBakeTagComponent)
       assert(!preventbakeComponent)
-
-      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-      assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_PREVENT_BAKE))
     })
 
     it('creates PreventBake Component with provided component data', () => {
       Engine.isEditor = true
-      addComponent(entity, EntityNodeComponent, { components: [] })
       deserializePreventBake(entity, sceneComponent)
 
       const preventbakeComponent = getComponent(entity, PreventBakeTagComponent)
       assert(preventbakeComponent)
       assert(Object.keys(preventbakeComponent).length === 0)
-
-      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_PREVENT_BAKE))
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/PreventBakeFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/PreventBakeFunctions.ts
@@ -1,7 +1,6 @@
 import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
 
 import { ComponentDeserializeFunction, ComponentSerializeFunction } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent, hasComponent } from '../../../ecs/functions/ComponentFunctions'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
@@ -12,8 +11,7 @@ export const SCENE_COMPONENT_PREVENT_BAKE_DEFAULT_VALUES = {}
 
 export const deserializePreventBake: ComponentDeserializeFunction = (entity: Entity, _: ComponentJson<{}>) => {
   getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_PREVENT_BAKE)
-
-  if (Engine.isEditor) addComponent(entity, PreventBakeTagComponent, {})
+  addComponent(entity, PreventBakeTagComponent, {})
 }
 
 export const serializePreventBake: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/PreventBakeFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/PreventBakeFunctions.ts
@@ -11,10 +11,9 @@ export const SCENE_COMPONENT_PREVENT_BAKE = 'prevent-bake'
 export const SCENE_COMPONENT_PREVENT_BAKE_DEFAULT_VALUES = {}
 
 export const deserializePreventBake: ComponentDeserializeFunction = (entity: Entity, _: ComponentJson<{}>) => {
-  if (Engine.isEditor) {
-    addComponent(entity, PreventBakeTagComponent, {})
-    getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_PREVENT_BAKE)
-  }
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_PREVENT_BAKE)
+
+  if (Engine.isEditor) addComponent(entity, PreventBakeTagComponent, {})
 }
 
 export const serializePreventBake: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/RenderSettingsFunction.ts
+++ b/packages/engine/src/scene/functions/loaders/RenderSettingsFunction.ts
@@ -15,7 +15,7 @@ import { Engine } from '../../../ecs/classes/Engine'
 import { accessEngineState, EngineActions } from '../../../ecs/classes/EngineService'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent, hasComponent, removeComponent } from '../../../ecs/functions/ComponentFunctions'
-import { matchActionOnce, receiveActionOnce } from '../../../networking/functions/matchActionOnce'
+import { matchActionOnce } from '../../../networking/functions/matchActionOnce'
 import { EngineRenderer } from '../../../renderer/WebGLRendererSystem'
 import { DirectionalLightComponent } from '../../../scene/components/DirectionalLightComponent'
 import { Object3DComponent } from '../../../scene/components/Object3DComponent'
@@ -40,7 +40,7 @@ export const deserializeRenderSetting: ComponentDeserializeFunction = (
   const props = parseRenderSettingsProperties(json.props)
   addComponent(entity, RenderSettingComponent, props)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_RENDERER_SETTINGS)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_RENDERER_SETTINGS)
 
   updateRenderSetting(entity)
 }

--- a/packages/engine/src/scene/functions/loaders/ScenePreviewCameraFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/ScenePreviewCameraFunctions.test.ts
@@ -63,28 +63,29 @@ describe('ScenePreviewCameraFunctions', () => {
       assert(Object.keys(scenePreviewCameraComponent).length === 0)
     })
 
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
+
+      scenePreviewCameraFunctions.deserializeScenePreviewCamera(entity, sceneComponent)
+
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SCENE_PREVIEW_CAMERA))
+    })
+
     describe('Editor vs Location', () => {
       it('creates ScenePreviewCamera in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
         Engine.activeCameraEntity = createEntity()
         Engine.camera = new PerspectiveCamera()
 
         scenePreviewCameraFunctions.deserializeScenePreviewCamera(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_SCENE_PREVIEW_CAMERA))
         assert(Engine.camera.position.equals(getComponent(entity, TransformComponent).position))
       })
 
       it('creates ScenePreviewCamera in Editor', () => {
         Engine.isEditor = true
 
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         scenePreviewCameraFunctions.deserializeScenePreviewCamera(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SCENE_PREVIEW_CAMERA))
 
         const obj3d = getComponent(entity, Object3DComponent)?.value
         assert(obj3d && obj3d instanceof PerspectiveCamera)

--- a/packages/engine/src/scene/functions/loaders/ScenePreviewCameraFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/ScenePreviewCameraFunctions.ts
@@ -32,6 +32,8 @@ export const deserializeScenePreviewCamera: ComponentDeserializeFunction = (enti
   if (!isClient) return
 
   addComponent(entity, ScenePreviewCameraTagComponent, {})
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SCENE_PREVIEW_CAMERA)
+
   if (Engine.isEditor) {
     const camera = new PerspectiveCamera(80, 16 / 9, 0.2, 8000)
     camera.userData.helper = new CameraHelper(camera)
@@ -39,7 +41,6 @@ export const deserializeScenePreviewCamera: ComponentDeserializeFunction = (enti
     setObjectLayers(camera.userData.helper, ObjectLayers.NodeHelper)
 
     addComponent(entity, Object3DComponent, { value: camera })
-    getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SCENE_PREVIEW_CAMERA)
   } else if (Engine.activeCameraEntity) {
     const transformComponent = getComponent(entity, TransformComponent)
     Engine.camera.position.copy(transformComponent.position)

--- a/packages/engine/src/scene/functions/loaders/ShadowFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/ShadowFunctions.test.ts
@@ -57,28 +57,13 @@ describe('ShadowFunctions', () => {
       )
     })
 
-    describe('Editor vs Location', () => {
-      it('creates Shadow in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
 
-        deserializeShadow(entity, sceneComponent)
+      deserializeShadow(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_SHADOW))
-      })
-
-      it('creates Shadow in Editor', () => {
-        Engine.isEditor = true
-
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
-        deserializeShadow(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SHADOW))
-
-        Engine.isEditor = false
-      })
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SHADOW))
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/ShadowFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/ShadowFunctions.ts
@@ -7,7 +7,6 @@ import {
   ComponentSerializeFunction,
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
@@ -29,7 +28,7 @@ export const deserializeShadow: ComponentDeserializeFunction = (
     receiveShadow: json.props.receive ?? SCENE_COMPONENT_SHADOW_DEFAULT_VALUES.receive
   })
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SHADOW)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SHADOW)
 
   updateShadow(entity)
 }

--- a/packages/engine/src/scene/functions/loaders/SimpleMaterialFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/SimpleMaterialFunctions.test.ts
@@ -67,28 +67,13 @@ describe('SimpleMaterialFunctions', () => {
       assert(Object.keys(simplematerialComponent).length === 0)
     })
 
-    describe('Editor vs Location', () => {
-      it('creates SimpleMaterial in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
 
-        deserializeSimpleMaterial(entity, sceneComponent)
+      deserializeSimpleMaterial(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_SIMPLE_MATERIALS))
-      })
-
-      it('creates SimpleMaterial in Editor', () => {
-        Engine.isEditor = true
-
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
-        deserializeSimpleMaterial(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SIMPLE_MATERIALS))
-
-        Engine.isEditor = false
-      })
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SIMPLE_MATERIALS))
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/SimpleMaterialFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SimpleMaterialFunctions.ts
@@ -23,7 +23,7 @@ export const deserializeSimpleMaterial: ComponentDeserializeFunction = (
   addComponent(entity, SimpleMaterialTagComponent, {})
   Engine.simpleMaterials = json.props.simpleMaterials
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SIMPLE_MATERIALS)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SIMPLE_MATERIALS)
 }
 
 export const serializeSimpleMaterial: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/SkyboxFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SkyboxFunctions.ts
@@ -68,7 +68,7 @@ export const deserializeSkybox: ComponentDeserializeFunction = (
     addComponent(entity, SkyboxComponent, props)
     addComponent(entity, DisableTransformTagComponent, {})
     addComponent(entity, IgnoreRaycastTagComponent, {})
-    if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SKYBOX)
+    getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SKYBOX)
     updateSkybox(entity)
   }
 }

--- a/packages/engine/src/scene/functions/loaders/SpawnPointFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/SpawnPointFunctions.test.ts
@@ -71,25 +71,28 @@ describe('SpawnPointFunctions', () => {
       assert(getComponent(entity, Object3DComponent)?.value === obj3d)
     })
 
+    it('will include this component into EntityNodeComponent', async () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
+
+      await spawnPointFunctions.deserializeSpawnPoint(entity, sceneComponent)
+
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SPAWN_POINT))
+    })
+
     describe('Editor vs Location', () => {
       it('creates SpawnPoint in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         deserializeSpawnPoint(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_SPAWN_POINT))
+        const obj3d = getComponent(entity, Object3DComponent)?.value
+        assert(!obj3d.children.includes(obj3d.userData.helperModel))
+        assert(!obj3d.children.includes(obj3d.userData.helperBox))
       })
 
       it('creates SpawnPoint in Editor', async () => {
         Engine.isEditor = true
 
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         await spawnPointFunctions.deserializeSpawnPoint(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SPAWN_POINT))
 
         const obj3d = getComponent(entity, Object3DComponent)?.value
         assert(obj3d.children.includes(obj3d.userData.helperModel))

--- a/packages/engine/src/scene/functions/loaders/SpawnPointFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/SpawnPointFunctions.test.ts
@@ -14,12 +14,7 @@ import { EntityNodeComponent } from '../../components/EntityNodeComponent'
 import { Object3DComponent } from '../../components/Object3DComponent'
 import { SpawnPointComponent } from '../../components/SpawnPointComponent'
 import { ObjectLayers } from '../../constants/ObjectLayers'
-import {
-  deserializeSpawnPoint,
-  prepareSpawnPointForGLTFExport,
-  SCENE_COMPONENT_SPAWN_POINT,
-  serializeSpawnPoint
-} from './SpawnPointFunctions'
+import { prepareSpawnPointForGLTFExport, SCENE_COMPONENT_SPAWN_POINT, serializeSpawnPoint } from './SpawnPointFunctions'
 
 class AssetLoader {
   static async loadAsync() {
@@ -49,7 +44,7 @@ describe('SpawnPointFunctions', () => {
 
   describe('deserializeSpawnPoint()', () => {
     it('creates SpawnPoint Component with provided component data', () => {
-      deserializeSpawnPoint(entity, sceneComponent)
+      spawnPointFunctions.deserializeSpawnPoint(entity, sceneComponent)
 
       const spawnpointComponent = getComponent(entity, SpawnPointComponent)
       assert(spawnpointComponent)
@@ -57,17 +52,21 @@ describe('SpawnPointFunctions', () => {
     })
 
     it('creates SpawnPoint Object3D if Not created', () => {
-      deserializeSpawnPoint(entity, sceneComponent)
+      spawnPointFunctions.deserializeSpawnPoint(entity, sceneComponent)
 
       const obj3d = getComponent(entity, Object3DComponent)?.value
       assert(obj3d, 'SpawnPoint is not created')
+      assert(obj3d.children.includes(obj3d.userData.helperModel))
+      assert(obj3d.children.includes(obj3d.userData.helperBox))
+      assert(obj3d.userData.helperModel.layers.isEnabled(ObjectLayers.NodeHelper))
+      assert(obj3d.userData.helperBox.layers.isEnabled(ObjectLayers.NodeHelper))
     })
 
     it('does not create SpawnPoint Object3D if already created', () => {
       const obj3d = new Object3D()
       addComponent(entity, Object3DComponent, { value: obj3d })
 
-      deserializeSpawnPoint(entity, sceneComponent)
+      spawnPointFunctions.deserializeSpawnPoint(entity, sceneComponent)
       assert(getComponent(entity, Object3DComponent)?.value === obj3d)
     })
 
@@ -79,34 +78,11 @@ describe('SpawnPointFunctions', () => {
       const entityNodeComponent = getComponent(entity, EntityNodeComponent)
       assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SPAWN_POINT))
     })
-
-    describe('Editor vs Location', () => {
-      it('creates SpawnPoint in Location', () => {
-        deserializeSpawnPoint(entity, sceneComponent)
-
-        const obj3d = getComponent(entity, Object3DComponent)?.value
-        assert(!obj3d.children.includes(obj3d.userData.helperModel))
-        assert(!obj3d.children.includes(obj3d.userData.helperBox))
-      })
-
-      it('creates SpawnPoint in Editor', async () => {
-        Engine.isEditor = true
-
-        await spawnPointFunctions.deserializeSpawnPoint(entity, sceneComponent)
-
-        const obj3d = getComponent(entity, Object3DComponent)?.value
-        assert(obj3d.children.includes(obj3d.userData.helperModel))
-        assert(obj3d.children.includes(obj3d.userData.helperBox))
-        assert(obj3d.userData.helperModel.layers.isEnabled(ObjectLayers.NodeHelper))
-        assert(obj3d.userData.helperBox.layers.isEnabled(ObjectLayers.NodeHelper))
-        Engine.isEditor = false
-      })
-    })
   })
 
   describe('serializeSpawnPoint()', () => {
     it('should properly serialize spawnpoint', () => {
-      deserializeSpawnPoint(entity, sceneComponent)
+      spawnPointFunctions.deserializeSpawnPoint(entity, sceneComponent)
       assert.deepEqual(serializeSpawnPoint(entity), sceneComponent)
     })
 

--- a/packages/engine/src/scene/functions/loaders/SpawnPointFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SpawnPointFunctions.ts
@@ -35,22 +35,21 @@ export const deserializeSpawnPoint: ComponentDeserializeFunction = async (entity
 
   getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SPAWN_POINT)
 
-  if (Engine.isEditor) {
-    if (!spawnPointHelperModel) {
-      const { scene } = await AssetLoader.loadAsync(GLTF_PATH)
-      spawnPointHelperModel = scene
-      spawnPointHelperModel.traverse((obj) => (obj.castShadow = true))
-    }
-
-    obj3d.userData.helperModel = spawnPointHelperModel.clone()
-    obj3d.add(obj3d.userData.helperModel)
-    obj3d.userData.helperBox = new BoxHelper(new Mesh(new BoxBufferGeometry(1, 0, 1).translate(0, 0, 0)), 0xffffff)
-    obj3d.userData.helperBox.userData.isHelper = true
-    obj3d.add(obj3d.userData.helperBox)
-
-    setObjectLayers(obj3d.userData.helperModel, ObjectLayers.NodeHelper)
-    setObjectLayers(obj3d.userData.helperBox, ObjectLayers.NodeHelper)
+  if (!spawnPointHelperModel) {
+    const { scene } = await AssetLoader.loadAsync(GLTF_PATH)
+    spawnPointHelperModel = scene
+    spawnPointHelperModel.traverse((obj) => (obj.castShadow = true))
   }
+
+  obj3d.userData.helperModel = spawnPointHelperModel.clone()
+  obj3d.userData.helperModel.userData.isHelper = true
+  obj3d.add(obj3d.userData.helperModel)
+  obj3d.userData.helperBox = new BoxHelper(new Mesh(new BoxBufferGeometry(1, 0, 1).translate(0, 0, 0)), 0xffffff)
+  obj3d.userData.helperBox.userData.isHelper = true
+  obj3d.add(obj3d.userData.helperBox)
+
+  setObjectLayers(obj3d.userData.helperModel, ObjectLayers.NodeHelper)
+  setObjectLayers(obj3d.userData.helperBox, ObjectLayers.NodeHelper)
 }
 
 export const serializeSpawnPoint: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/SpawnPointFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SpawnPointFunctions.ts
@@ -33,9 +33,9 @@ export const deserializeSpawnPoint: ComponentDeserializeFunction = async (entity
     addComponent(entity, Object3DComponent, { value: obj3d })
   }
 
-  if (Engine.isEditor) {
-    getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SPAWN_POINT)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SPAWN_POINT)
 
+  if (Engine.isEditor) {
     if (!spawnPointHelperModel) {
       const { scene } = await AssetLoader.loadAsync(GLTF_PATH)
       spawnPointHelperModel = scene

--- a/packages/engine/src/scene/functions/loaders/SplineFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/SplineFunctions.test.ts
@@ -12,6 +12,7 @@ import { createEntity } from '../../../ecs/functions/EntityFunctions'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
 import { Object3DComponent } from '../../components/Object3DComponent'
 import { SplineComponent } from '../../components/SplineComponent'
+import { ObjectLayers } from '../../constants/ObjectLayers'
 import { deserializeSpline, parseSplineProperties, SCENE_COMPONENT_SPLINE, serializeSpline } from './SplineFunctions'
 
 describe('SplineFunctions', () => {
@@ -48,7 +49,11 @@ describe('SplineFunctions', () => {
 
     it('creates Spline Object3D with provided component data', () => {
       deserializeSpline(entity, sceneComponent)
-      assert(getComponent(entity, Object3DComponent)?.value, 'Spline is not created')
+      const obj3d = getComponent(entity, Object3DComponent)?.value
+
+      assert(obj3d, 'Spline is not created')
+      assert(obj3d.children.length > 0 && obj3d.userData.helper && obj3d.userData.helper.userData.isHelper)
+      assert(obj3d.userData.helper.layers.isEnabled(ObjectLayers.NodeHelper))
     })
 
     it('will include this component into EntityNodeComponent', () => {
@@ -58,25 +63,6 @@ describe('SplineFunctions', () => {
 
       const entityNodeComponent = getComponent(entity, EntityNodeComponent)
       assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SPLINE))
-    })
-
-    describe('Editor vs Location', () => {
-      it('creates Spline in Location', () => {
-        deserializeSpline(entity, sceneComponent)
-
-        const obj3d = getComponent(entity, Object3DComponent)?.value
-        assert(obj3d.children.length === 0 && !obj3d.userData.helper)
-      })
-
-      it('creates Spline in Editor', () => {
-        Engine.isEditor = true
-
-        deserializeSpline(entity, sceneComponent)
-
-        const obj3d = getComponent(entity, Object3DComponent)?.value
-        assert(obj3d.children.length > 0 && obj3d.userData.helper)
-        Engine.isEditor = false
-      })
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/SplineFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/SplineFunctions.test.ts
@@ -51,25 +51,27 @@ describe('SplineFunctions', () => {
       assert(getComponent(entity, Object3DComponent)?.value, 'Spline is not created')
     })
 
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
+
+      deserializeSpline(entity, sceneComponent)
+
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SPLINE))
+    })
+
     describe('Editor vs Location', () => {
       it('creates Spline in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         deserializeSpline(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_SPLINE))
+        const obj3d = getComponent(entity, Object3DComponent)?.value
+        assert(obj3d.children.length === 0 && !obj3d.userData.helper)
       })
 
       it('creates Spline in Editor', () => {
         Engine.isEditor = true
 
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         deserializeSpline(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SPLINE))
 
         const obj3d = getComponent(entity, Object3DComponent)?.value
         assert(obj3d.children.length > 0 && obj3d.userData.helper)

--- a/packages/engine/src/scene/functions/loaders/SplineFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SplineFunctions.ts
@@ -7,13 +7,14 @@ import {
   ComponentSerializeFunction,
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import Spline from '../../classes/Spline'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
 import { Object3DComponent } from '../../components/Object3DComponent'
 import { SplineComponent, SplineComponentType } from '../../components/SplineComponent'
+import { ObjectLayers } from '../../constants/ObjectLayers'
+import { setObjectLayers } from '../setObjectLayers'
 
 export const SCENE_COMPONENT_SPLINE = 'spline'
 export const SCENE_COMPONENT_SPLINE_DEFAULT_VALUES = {
@@ -32,13 +33,14 @@ export const deserializeSpline: ComponentDeserializeFunction = (
 
   getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SPLINE)
 
-  if (Engine.isEditor) {
-    const helper = new Spline()
-    obj3d.add(helper)
-    obj3d.userData.helper = helper
+  const helper = new Spline()
+  helper.userData.isHelper = true
+  setObjectLayers(helper, ObjectLayers.NodeHelper)
 
-    helper.init(props.splinePositions)
-  }
+  obj3d.add(helper)
+  obj3d.userData.helper = helper
+
+  helper.init(props.splinePositions)
 
   updateSpline(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/SplineFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SplineFunctions.ts
@@ -30,9 +30,9 @@ export const deserializeSpline: ComponentDeserializeFunction = (
   addComponent(entity, Object3DComponent, { value: obj3d })
   addComponent(entity, SplineComponent, props)
 
-  if (Engine.isEditor) {
-    getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SPLINE)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SPLINE)
 
+  if (Engine.isEditor) {
     const helper = new Spline()
     obj3d.add(helper)
     obj3d.userData.helper = helper

--- a/packages/engine/src/scene/functions/loaders/SpotLightFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/SpotLightFunctions.test.ts
@@ -81,25 +81,28 @@ describe('SpotLightFunctions', () => {
       assert(obj3d.children.includes(obj3d.target))
     })
 
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
+
+      deserializeSpotLight(entity, sceneComponent)
+
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SPOT_LIGHT))
+    })
+
     describe('Editor vs Location', () => {
       it('creates SpotLight in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         deserializeSpotLight(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_SPOT_LIGHT))
+        const obj3d = getComponent(entity, Object3DComponent)?.value
+        assert(!obj3d.children.includes(obj3d.userData.ring))
+        assert(!obj3d.children.includes(obj3d.userData.cone))
       })
 
       it('creates SpotLight in Editor', () => {
         Engine.isEditor = true
 
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         deserializeSpotLight(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SPOT_LIGHT))
 
         const obj3d = getComponent(entity, Object3DComponent)?.value
         assert(obj3d.children.includes(obj3d.userData.ring) && obj3d.userData.ring.userData.isHelper)

--- a/packages/engine/src/scene/functions/loaders/SpotLightFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/SpotLightFunctions.test.ts
@@ -79,6 +79,11 @@ describe('SpotLightFunctions', () => {
       assert(obj3d && obj3d instanceof SpotLight, 'SpotLight is not created')
       assert(obj3d.target.position.x === 0 && obj3d.target.position.y === -1 && obj3d.target.position.z === 0)
       assert(obj3d.children.includes(obj3d.target))
+
+      assert(obj3d.children.includes(obj3d.userData.ring) && obj3d.userData.ring.userData.isHelper)
+      assert(obj3d.children.includes(obj3d.userData.cone) && obj3d.userData.cone.userData.isHelper)
+      assert(obj3d.userData.ring.layers.isEnabled(ObjectLayers.NodeHelper))
+      assert(obj3d.userData.cone.layers.isEnabled(ObjectLayers.NodeHelper))
     })
 
     it('will include this component into EntityNodeComponent', () => {
@@ -88,30 +93,6 @@ describe('SpotLightFunctions', () => {
 
       const entityNodeComponent = getComponent(entity, EntityNodeComponent)
       assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SPOT_LIGHT))
-    })
-
-    describe('Editor vs Location', () => {
-      it('creates SpotLight in Location', () => {
-        deserializeSpotLight(entity, sceneComponent)
-
-        const obj3d = getComponent(entity, Object3DComponent)?.value
-        assert(!obj3d.children.includes(obj3d.userData.ring))
-        assert(!obj3d.children.includes(obj3d.userData.cone))
-      })
-
-      it('creates SpotLight in Editor', () => {
-        Engine.isEditor = true
-
-        deserializeSpotLight(entity, sceneComponent)
-
-        const obj3d = getComponent(entity, Object3DComponent)?.value
-        assert(obj3d.children.includes(obj3d.userData.ring) && obj3d.userData.ring.userData.isHelper)
-        assert(obj3d.children.includes(obj3d.userData.cone) && obj3d.userData.cone.userData.isHelper)
-        assert(obj3d.userData.ring.layers.isEnabled(ObjectLayers.NodeHelper))
-        assert(obj3d.userData.cone.layers.isEnabled(ObjectLayers.NodeHelper))
-
-        Engine.isEditor = false
-      })
     })
   })
 
@@ -142,6 +123,8 @@ describe('SpotLightFunctions', () => {
 
         updateSpotLight(entity, { color: new Color('green') })
         assert(obj3d.color.getHex() === newColor.getHex(), 'should not update property to passed value')
+        assert(obj3d.userData.ring.material.color.getHex() === newColor.getHex())
+        assert(obj3d.userData.cone.material.color.getHex() === newColor.getHex())
       })
     })
 
@@ -333,23 +316,6 @@ describe('SpotLightFunctions', () => {
           'should not update property to passed value'
         )
       })
-    })
-
-    it('should update color of helpers in editor', () => {
-      Engine.isEditor = true
-      const entity = createEntity()
-      deserializeSpotLight(entity, sceneComponent)
-
-      const newColor = new Color('pink')
-      const component = getComponent(entity, SpotLightComponent)
-      component.color = newColor
-      updateSpotLight(entity, { color: newColor })
-
-      const obj3d = getComponent(entity, Object3DComponent)?.value
-
-      assert(obj3d.userData.ring.material.color.getHex() === newColor.getHex())
-      assert(obj3d.userData.cone.material.color.getHex() === newColor.getHex())
-      Engine.isEditor = false
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/SpotLightFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SpotLightFunctions.ts
@@ -8,7 +8,6 @@ import {
   ComponentSerializeFunction,
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
@@ -42,25 +41,23 @@ export const deserializeSpotLight: ComponentDeserializeFunction = (
   light.target.name = 'light-target'
   light.add(light.target)
 
-  if (Engine.isEditor) {
-    const ring = new Mesh(new TorusGeometry(0.1, 0.025, 8, 12), new MeshBasicMaterial({ fog: false }))
-    const cone = new Mesh(
-      new ConeGeometry(0.25, 0.5, 8, 1, true),
-      new MeshBasicMaterial({ fog: false, transparent: true, opacity: 0.5, side: DoubleSide })
-    )
-    light.add(ring)
-    light.add(cone)
-    cone.userData.isHelper = true
-    ring.userData.isHelper = true
-    light.userData.ring = ring
-    light.userData.cone = cone
+  const ring = new Mesh(new TorusGeometry(0.1, 0.025, 8, 12), new MeshBasicMaterial({ fog: false }))
+  const cone = new Mesh(
+    new ConeGeometry(0.25, 0.5, 8, 1, true),
+    new MeshBasicMaterial({ fog: false, transparent: true, opacity: 0.5, side: DoubleSide })
+  )
+  light.add(ring)
+  light.add(cone)
+  cone.userData.isHelper = true
+  ring.userData.isHelper = true
+  light.userData.ring = ring
+  light.userData.cone = cone
 
-    ring.rotateX(Math.PI / 2)
-    cone.position.setY(-0.25)
+  ring.rotateX(Math.PI / 2)
+  cone.position.setY(-0.25)
 
-    setObjectLayers(ring, ObjectLayers.NodeHelper)
-    setObjectLayers(cone, ObjectLayers.NodeHelper)
-  }
+  setObjectLayers(ring, ObjectLayers.NodeHelper)
+  setObjectLayers(cone, ObjectLayers.NodeHelper)
 
   addComponent(entity, Object3DComponent, { value: light })
   addComponent(entity, SpotLightComponent, props)
@@ -93,10 +90,8 @@ export const updateSpotLight: ComponentUpdateFunction = (entity: Entity, propert
     light.shadow.needsUpdate = true
   }
 
-  if (Engine.isEditor) {
-    light.userData.ring.material.color = component.color
-    light.userData.cone.material.color = component.color
-  }
+  light.userData.ring.material.color = component.color
+  light.userData.cone.material.color = component.color
 }
 
 export const serializeSpotLight: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/SpotLightFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SpotLightFunctions.ts
@@ -65,7 +65,7 @@ export const deserializeSpotLight: ComponentDeserializeFunction = (
   addComponent(entity, Object3DComponent, { value: light })
   addComponent(entity, SpotLightComponent, props)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SPOT_LIGHT)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SPOT_LIGHT)
 
   updateSpotLight(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/SystemFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/SystemFunctions.test.ts
@@ -57,27 +57,13 @@ describe('SystemFunctions', () => {
       assert(getComponent(entity, PreventBakeTagComponent))
     })
 
-    describe('Editor vs Location', () => {
-      it('creates System in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
 
-        deserializeSystem(entity, sceneComponent)
+      deserializeSystem(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_SYSTEM))
-      })
-
-      it('creates System in Editor', () => {
-        Engine.isEditor = true
-
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
-        deserializeSystem(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SYSTEM))
-        Engine.isEditor = false
-      })
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_SYSTEM))
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/SystemFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SystemFunctions.ts
@@ -5,7 +5,6 @@ import {
   ComponentSerializeFunction,
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { SystemUpdateType } from '../../../ecs/functions/SystemUpdateType'
@@ -30,7 +29,7 @@ export const deserializeSystem: ComponentDeserializeFunction = (
   addComponent(entity, SystemComponent, props)
   addComponent(entity, PreventBakeTagComponent, {})
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SYSTEM)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_SYSTEM)
 
   updateSystem(entity)
 }

--- a/packages/engine/src/scene/functions/loaders/TransformFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/TransformFunctions.test.ts
@@ -63,28 +63,13 @@ describe('TransformFunctions', () => {
       assert(Math.abs(transformComponent.scale.z - sceneComponentData.scale.z) < EPSILON)
     })
 
-    describe('Editor vs Location', () => {
-      it('creates Transform in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
 
-        deserializeTransform(entity, sceneComponent)
+      deserializeTransform(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_TRANSFORM))
-      })
-
-      it('creates Transform in Editor', () => {
-        Engine.isEditor = true
-
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
-        deserializeTransform(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_TRANSFORM))
-
-        Engine.isEditor = false
-      })
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_TRANSFORM))
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/TransformFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/TransformFunctions.ts
@@ -4,7 +4,6 @@ import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
 
 import { ComponentDeserializeFunction, ComponentSerializeFunction } from '../../../common/constants/PrefabFunctionType'
 import { createQuaternionProxy, createVector3Proxy } from '../../../common/proxies/three'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { TransformComponent, TransformComponentType } from '../../../transform/components/TransformComponent'
@@ -35,7 +34,7 @@ export const deserializeTransform: ComponentDeserializeFunction = (
   transform.rotation.copy(props.rotation)
   transform.scale.copy(props.scale)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_TRANSFORM)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_TRANSFORM)
 }
 
 export const serializeTransform: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/TriggerVolumeFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/TriggerVolumeFunctions.test.ts
@@ -52,26 +52,26 @@ describe('TriggerVolumeFunctions', () => {
       assert.deepEqual(triggervolumeComponent, { ...sceneComponentData, active: true })
     })
 
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
+
+      triggervolumeFunctions.deserializeTriggerVolume(entity, sceneComponent)
+
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_TRIGGER_VOLUME))
+    })
+
     describe('Editor vs Location', () => {
       it('creates TriggerVolume in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         triggervolumeFunctions.deserializeTriggerVolume(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_TRIGGER_VOLUME))
         assert(!getComponent(entity, Object3DComponent))
       })
 
       it('creates TriggerVolume in Editor', () => {
         Engine.isEditor = true
 
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         triggervolumeFunctions.deserializeTriggerVolume(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_TRIGGER_VOLUME))
 
         const obj3d = getComponent(entity, Object3DComponent)?.value as Mesh<any, MeshBasicMaterial>
         assert(obj3d && obj3d.material.visible === false, 'TriggerVolume outline is not disabled')

--- a/packages/engine/src/scene/functions/loaders/TriggerVolumeFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/TriggerVolumeFunctions.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import proxyquire from 'proxyquire'
-import { Mesh, MeshBasicMaterial, Object3D } from 'three'
+import { Mesh, MeshBasicMaterial } from 'three'
 import { Quaternion, Vector3 } from 'three'
 
 import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
@@ -17,8 +17,6 @@ import { EntityNodeComponent } from '../../components/EntityNodeComponent'
 import { Object3DComponent } from '../../components/Object3DComponent'
 import { TriggerVolumeComponent } from '../../components/TriggerVolumeComponent'
 import { SCENE_COMPONENT_TRIGGER_VOLUME } from './TriggerVolumeFunctions'
-
-class FakeTriggerVolume extends Object3D {}
 
 describe('TriggerVolumeFunctions', () => {
   let world: World
@@ -50,6 +48,10 @@ describe('TriggerVolumeFunctions', () => {
 
       const triggervolumeComponent = getComponent(entity, TriggerVolumeComponent)
       assert.deepEqual(triggervolumeComponent, { ...sceneComponentData, active: true })
+
+      const obj3d = getComponent(entity, Object3DComponent)?.value as Mesh<any, MeshBasicMaterial>
+      assert(obj3d && obj3d.material.visible === false, 'TriggerVolume outline is not disabled')
+      assert(obj3d && obj3d.userData.isHelper, 'TriggerVolume outline is not disabled')
     })
 
     it('will include this component into EntityNodeComponent', () => {
@@ -59,24 +61,6 @@ describe('TriggerVolumeFunctions', () => {
 
       const entityNodeComponent = getComponent(entity, EntityNodeComponent)
       assert(entityNodeComponent.components.includes(SCENE_COMPONENT_TRIGGER_VOLUME))
-    })
-
-    describe('Editor vs Location', () => {
-      it('creates TriggerVolume in Location', () => {
-        triggervolumeFunctions.deserializeTriggerVolume(entity, sceneComponent)
-
-        assert(!getComponent(entity, Object3DComponent))
-      })
-
-      it('creates TriggerVolume in Editor', () => {
-        Engine.isEditor = true
-
-        triggervolumeFunctions.deserializeTriggerVolume(entity, sceneComponent)
-
-        const obj3d = getComponent(entity, Object3DComponent)?.value as Mesh<any, MeshBasicMaterial>
-        assert(obj3d && obj3d.material.visible === false, 'TriggerVolume outline is not disabled')
-        Engine.isEditor = false
-      })
     })
   })
 
@@ -106,15 +90,7 @@ describe('TriggerVolumeFunctions', () => {
       })
     })
 
-    it('should not update anything', () => {
-      triggervolumeFunctions.deserializeTriggerVolume(entity, sceneComponent)
-      triggervolumeFunctions.updateTriggerVolume(entity)
-
-      assert.deepEqual(getComponent(entity, ColliderComponent).body.getGlobalPose(), transform2)
-    })
-
     it('should not update collider body', () => {
-      Engine.isEditor = true
       triggervolumeFunctions.deserializeTriggerVolume(entity, sceneComponent)
       triggervolumeFunctions.updateTriggerVolume(entity)
 
@@ -124,7 +100,6 @@ describe('TriggerVolumeFunctions', () => {
         rotation: transform1.rotation
       })
       assert(collider.body._debugNeedsUpdate)
-      Engine.isEditor = false
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/TriggerVolumeFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/TriggerVolumeFunctions.ts
@@ -7,12 +7,11 @@ import {
   ComponentSerializeFunction,
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { ColliderComponent } from '../../../physics/components/ColliderComponent'
 import { CollisionGroups } from '../../../physics/enums/CollisionGroups'
-import { createCollider, createColliderForObject3D } from '../../../physics/functions/createCollider'
+import { createCollider } from '../../../physics/functions/createCollider'
 import { TransformComponent } from '../../../transform/components/TransformComponent'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
 import { Object3DComponent } from '../../components/Object3DComponent'
@@ -30,6 +29,7 @@ export const deserializeTriggerVolume: ComponentDeserializeFunction = (
   boxMesh.userData = {
     type: 'box',
     isTrigger: true,
+    isHelper: true,
     collisionLayer: CollisionGroups.Trigger,
     collisionMask: CollisionGroups.Default
   }
@@ -45,19 +45,17 @@ export const deserializeTriggerVolume: ComponentDeserializeFunction = (
 
   getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_TRIGGER_VOLUME)
 
-  if (Engine.isEditor) addComponent(entity, Object3DComponent, { value: boxMesh }, Engine.currentWorld)
+  addComponent(entity, Object3DComponent, { value: boxMesh })
 }
 
 export const updateTriggerVolume: ComponentUpdateFunction = (entity: Entity, prop: any) => {
-  if (Engine.isEditor) {
-    const transform = getComponent(entity, TransformComponent)
-    const component = getComponent(entity, ColliderComponent)
-    const pose = component.body.getGlobalPose()
-    pose.translation = transform.position
-    pose.rotation = transform.rotation
-    component.body.setGlobalPose(pose, false)
-    component.body._debugNeedsUpdate = true
-  }
+  const transform = getComponent(entity, TransformComponent)
+  const component = getComponent(entity, ColliderComponent)
+  const pose = component.body.getGlobalPose()
+  pose.translation = transform.position
+  pose.rotation = transform.rotation
+  component.body.setGlobalPose(pose, false)
+  component.body._debugNeedsUpdate = true
 }
 
 export const serializeTriggerVolume: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/TriggerVolumeFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/TriggerVolumeFunctions.ts
@@ -42,10 +42,10 @@ export const deserializeTriggerVolume: ComponentDeserializeFunction = (
     target: json.props.target,
     active: true
   })
-  if (Engine.isEditor) {
-    addComponent(entity, Object3DComponent, { value: boxMesh }, Engine.currentWorld)
-    getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_TRIGGER_VOLUME)
-  }
+
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_TRIGGER_VOLUME)
+
+  if (Engine.isEditor) addComponent(entity, Object3DComponent, { value: boxMesh }, Engine.currentWorld)
 }
 
 export const updateTriggerVolume: ComponentUpdateFunction = (entity: Entity, prop: any) => {

--- a/packages/engine/src/scene/functions/loaders/VideoFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/VideoFunctions.test.ts
@@ -108,28 +108,13 @@ describe('VideoFunctions', () => {
       assert(obj3d.userData.videoEl)
     })
 
-    describe('Editor vs Location', () => {
-      it('creates Video in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
 
-        videoFunctions.deserializeVideo(entity, sceneComponent)
+      videoFunctions.deserializeVideo(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_VIDEO))
-      })
-
-      it('creates Video in Editor', () => {
-        Engine.isEditor = true
-
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
-        videoFunctions.deserializeVideo(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_VIDEO))
-
-        Engine.isEditor = false
-      })
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_VIDEO))
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/VideoFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/VideoFunctions.ts
@@ -15,7 +15,7 @@ import { Engine } from '../../../ecs/classes/Engine'
 import { accessEngineState, EngineActions } from '../../../ecs/classes/EngineService'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
-import { matchActionOnce, receiveActionOnce } from '../../../networking/functions/matchActionOnce'
+import { matchActionOnce } from '../../../networking/functions/matchActionOnce'
 import { ImageProjection } from '../../classes/ImageUtils'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
 import { ImageComponent } from '../../components/ImageComponent'
@@ -84,7 +84,7 @@ export const deserializeVideo: ComponentDeserializeFunction = (
 
   addComponent(entity, VideoComponent, props)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_VIDEO)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_VIDEO)
 
   updateVideo(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/VisibleFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/VisibleFunctions.test.ts
@@ -58,27 +58,13 @@ describe('VisibleFunctions', () => {
       assert(!getComponent(entity, Object3DComponent)?.value)
     })
 
-    describe('Editor vs Location', () => {
-      it('creates Visible in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
 
-        visibleFunctions.deserializeVisible(entity, sceneComponent)
+      visibleFunctions.deserializeVisible(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_VISIBLE))
-      })
-
-      it('creates Visible in Editor', () => {
-        Engine.isEditor = true
-
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
-        visibleFunctions.deserializeVisible(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_VISIBLE))
-        Engine.isEditor = false
-      })
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_VISIBLE))
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/VisibleFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/VisibleFunctions.ts
@@ -2,7 +2,6 @@ import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
 
 import { ComponentDeserializeFunction, ComponentSerializeFunction } from '../../../common/constants/PrefabFunctionType'
 import { isClient } from '../../../common/functions/isClient'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent, hasComponent } from '../../../ecs/functions/ComponentFunctions'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
@@ -13,7 +12,7 @@ export const SCENE_COMPONENT_VISIBLE_DEFAULT_VALUES = {}
 
 export const deserializeVisible: ComponentDeserializeFunction = (entity: Entity, _: ComponentJson<{}>) => {
   if (isClient) addComponent(entity, VisibleComponent, {})
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_VISIBLE)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_VISIBLE)
 }
 
 export const serializeVisible: ComponentSerializeFunction = (entity) => {

--- a/packages/engine/src/scene/functions/loaders/VolumetricFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/VolumetricFunctions.ts
@@ -1,7 +1,6 @@
 import { Box3 } from 'three'
 
 import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
-import { AvatarComponent } from '@xrengine/engine/src/avatar/components/AvatarComponent'
 import { AvatarDissolveComponent } from '@xrengine/engine/src/avatar/components/AvatarDissolveComponent'
 import { AvatarEffectComponent, MaterialMap } from '@xrengine/engine/src/avatar/components/AvatarEffectComponent'
 import { DissolveEffect } from '@xrengine/engine/src/avatar/DissolveEffect'
@@ -14,7 +13,6 @@ import {
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
 import { isClient } from '../../../common/functions/isClient'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent, removeComponent } from '../../../ecs/functions/ComponentFunctions'
 import { EngineRenderer } from '../../../renderer/WebGLRendererSystem'
@@ -68,7 +66,7 @@ export const deserializeVolumetric: ComponentDeserializeFunction = (
   const props = parseVolumetricProperties(json.props)
   addComponent(entity, VolumetricComponent, props)
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_VOLUMETRIC)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_VOLUMETRIC)
 
   updateVolumetric(entity, props)
 }

--- a/packages/engine/src/scene/functions/loaders/WaterFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/WaterFunctions.test.ts
@@ -62,6 +62,7 @@ describe('WaterFunctions', () => {
 
       const obj3d = getComponent(entity, Object3DComponent)?.value
       assert(obj3d && obj3d instanceof FakeWater, 'Water is not created')
+      assert(obj3d.userData.disableOutline, 'Water outline is not disabled')
     })
 
     it('will include this component into EntityNodeComponent', () => {
@@ -71,25 +72,6 @@ describe('WaterFunctions', () => {
 
       const entityNodeComponent = getComponent(entity, EntityNodeComponent)
       assert(entityNodeComponent.components.includes(SCENE_COMPONENT_WATER))
-    })
-
-    describe('Editor vs Location', () => {
-      it('creates Water in Location', () => {
-        waterFunctions.deserializeWater(entity, sceneComponent)
-
-        const obj3d = getComponent(entity, Object3DComponent)?.value
-        assert(obj3d && !obj3d.userData.disableOutline, 'Water outline is disabled')
-      })
-
-      it('creates Water in Editor', () => {
-        Engine.isEditor = true
-
-        waterFunctions.deserializeWater(entity, sceneComponent)
-
-        const obj3d = getComponent(entity, Object3DComponent)?.value
-        assert(obj3d && obj3d.userData.disableOutline, 'Water outline is not disabled')
-        Engine.isEditor = false
-      })
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/WaterFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/WaterFunctions.test.ts
@@ -64,25 +64,27 @@ describe('WaterFunctions', () => {
       assert(obj3d && obj3d instanceof FakeWater, 'Water is not created')
     })
 
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
+
+      waterFunctions.deserializeWater(entity, sceneComponent)
+
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_WATER))
+    })
+
     describe('Editor vs Location', () => {
       it('creates Water in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         waterFunctions.deserializeWater(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_WATER))
+        const obj3d = getComponent(entity, Object3DComponent)?.value
+        assert(obj3d && !obj3d.userData.disableOutline, 'Water outline is disabled')
       })
 
       it('creates Water in Editor', () => {
         Engine.isEditor = true
 
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
         waterFunctions.deserializeWater(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_WATER))
 
         const obj3d = getComponent(entity, Object3DComponent)?.value
         assert(obj3d && obj3d.userData.disableOutline, 'Water outline is not disabled')

--- a/packages/engine/src/scene/functions/loaders/WaterFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/WaterFunctions.ts
@@ -6,7 +6,6 @@ import {
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
 import { isClient } from '../../../common/functions/isClient'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { Water } from '../../classes/Water'
@@ -25,14 +24,13 @@ export const deserializeWater: ComponentDeserializeFunction = (
   if (!isClient) return
 
   const obj3d = new Water()
+  obj3d.userData.disableOutline = true
 
   addComponent(entity, Object3DComponent, { value: obj3d })
   addComponent(entity, WaterComponent, { ...json.props })
   addComponent(entity, UpdatableComponent, {})
 
   getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_WATER)
-
-  if (Engine.isEditor) obj3d.userData.disableOutline = true
 
   updateWater(entity, json.props)
 }

--- a/packages/engine/src/scene/functions/loaders/WaterFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/WaterFunctions.ts
@@ -30,11 +30,9 @@ export const deserializeWater: ComponentDeserializeFunction = (
   addComponent(entity, WaterComponent, { ...json.props })
   addComponent(entity, UpdatableComponent, {})
 
-  if (Engine.isEditor) {
-    getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_WATER)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_WATER)
 
-    obj3d.userData.disableOutline = true
-  }
+  if (Engine.isEditor) obj3d.userData.disableOutline = true
 
   updateWater(entity, json.props)
 }

--- a/packages/engine/src/scene/functions/loaders/WorldDataFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/WorldDataFunctions.test.ts
@@ -68,27 +68,13 @@ describe('WorldDataFunctions', () => {
       assert((obj3d as any)._data === sceneComponentData.data)
     })
 
-    describe('Editor vs Location', () => {
-      it('creates World Data in Location', () => {
-        addComponent(entity, EntityNodeComponent, { components: [] })
+    it('will include this component into EntityNodeComponent', () => {
+      addComponent(entity, EntityNodeComponent, { components: [] })
 
-        deserializeWorldData(entity, sceneComponent)
+      deserializeWorldData(entity, sceneComponent)
 
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(!entityNodeComponent.components.includes(SCENE_COMPONENT_WORLDDATA))
-      })
-
-      it('creates World Data in Editor', () => {
-        Engine.isEditor = true
-
-        addComponent(entity, EntityNodeComponent, { components: [] })
-
-        deserializeWorldData(entity, sceneComponent)
-
-        const entityNodeComponent = getComponent(entity, EntityNodeComponent)
-        assert(entityNodeComponent.components.includes(SCENE_COMPONENT_WORLDDATA))
-        Engine.isEditor = false
-      })
+      const entityNodeComponent = getComponent(entity, EntityNodeComponent)
+      assert(entityNodeComponent.components.includes(SCENE_COMPONENT_WORLDDATA))
     })
   })
 

--- a/packages/engine/src/scene/functions/loaders/WorldDataFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/WorldDataFunctions.ts
@@ -8,7 +8,6 @@ import {
   ComponentSerializeFunction,
   ComponentUpdateFunction
 } from '../../../common/constants/PrefabFunctionType'
-import { Engine } from '../../../ecs/classes/Engine'
 import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { useWorld } from '../../../ecs/functions/SystemHooks'
@@ -33,7 +32,7 @@ export const deserializeWorldData: ComponentDeserializeFunction = (
     createState({ action: '_metadata', interactionUserData: data } as InteractableComponentType)
   )
 
-  if (Engine.isEditor) getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_WORLDDATA)
+  getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_WORLDDATA)
 
   updateWorldData(entity, json.props)
 }

--- a/packages/gameserver/package.json
+++ b/packages/gameserver/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "check-errors": "tsc --noemit",
     "start": "cross-env APP_ENV=production ts-node --transpile-only src/index.ts",
-    "dev": "APP_ENV=development ts-node-dev --inspect=2995 --respawn --transpile-only src/index.ts",
+    "dev": "cross-env APP_ENV=development ts-node-dev --inspect=2995 --respawn --transpile-only src/index.ts",
     "dev-channel": "APP_ENV=development cross-env GAMESERVER_PORT=3032 ts-node-dev --inspect=2996 --respawn --transpile-only src/index.ts",
     "dev-nossl": "cross-env NOSSL=true ts-node-dev --respawn --transpile-only src/index.ts",
     "test": "exit 0",


### PR DESCRIPTION
## Summary

This PR contains following

- Made all node's helper available in location as well.
- Added a button to toggle these node helpers in location from debug menu accessible from `~` key
- Moved grid to engine package and also added button in debug menu of location to toggle grid as well.


## References

- [ ] #5447 


## Checklist
- [ ] CI/CD checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Typescript passing via `npm run check-errors`
  - [ ] Unit & Integration tests passing via `npm run test`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers
@HexaField 