### PR TITLE
Skipping logger.fatal on exit code 0

### DIFF
--- a/packages/server-core/src/appconfig.ts
+++ b/packages/server-core/src/appconfig.ts
@@ -14,7 +14,7 @@ const testEnabled = process.env.TEST === 'true'
 
 // ensure process fails properly
 process.on('exit', async (code) => {
-  logger.fatal(`Server EXIT(${code}).`)
+  if (code !== 0) logger.fatal(`Server EXIT(${code}).`)
 })
 
 process.on('SIGTERM', async (err) => {

--- a/scripts/install-projects.js
+++ b/scripts/install-projects.js
@@ -4,6 +4,7 @@ import Sequelize from 'sequelize';
 import path from "path";
 import fs from "fs";
 import appRootPath from 'app-root-path'
+import logger from '../packages/server-core/src/logger'
 
 dotenv.config();
 const db = {
@@ -20,11 +21,10 @@ db.url = process.env.MYSQL_URL ??
 
 
 async function installAllProjects() {
-  
   try {
     const localProjectDirectory = path.join(appRootPath.path, 'packages/projects/projects')
     if (!fs.existsSync(localProjectDirectory)) fs.mkdirSync(localProjectDirectory, { recursive: true })
-    console.log('running installAllProjects')
+    logger.info('running installAllProjects')
     const sequelizeClient = new Sequelize({
       ...db,
       define: {
@@ -32,7 +32,7 @@ async function installAllProjects() {
       }
     });
     await sequelizeClient.sync();
-    console.log('inited sequelize client')
+    logger.info('inited sequelize client')
 
     const Projects = sequelizeClient.define('project', {
       id: {
@@ -48,12 +48,12 @@ async function installAllProjects() {
 
     
     const projects = await Projects.findAll()
-    console.log('found projects', projects)
+    logger.info('found projects', projects)
     await Promise.all(projects.map((project) => download(project.name)))
   } catch (e) {
-    console.log(e)
+    logger.fatal(e)
   }
 
-};
+}
 
 installAllProjects();


### PR DESCRIPTION
## Summary

If server-core exits with code 0, it shouldn't kill everything else, which logger.fatal was doing.
logger.info was also causing crashes. Made it run logger.fatal only on non-zero exit codes.


## References

closes #_insert number here_


## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [x] Unit & Integration tests passing via `npm run test`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
