### PR TITLE
Added support to override global environment map for model nodes

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -129,6 +129,10 @@
       "lbl-intensity": "Intensity",
       "lbl-color": "Color"
     },
+    "envmap": {
+      "name": "Environment Map",
+      "description": "environment map properties"
+    },
     "asset": {
       "name": "Asset",
       "description": "A grouping of scene components which can be dynamically loaded and unloaded",

--- a/packages/editor/src/commands/PositionCommand.ts
+++ b/packages/editor/src/commands/PositionCommand.ts
@@ -38,7 +38,7 @@ export default class PositionCommand extends Command {
     this.addToPosition = params.addToPosition
 
     if (this.keepHistory) {
-      this.oldPositions = objects.map((o) => getComponent(o.entity, TransformComponent).position.clone())
+      this.oldPositions = objects.map((o) => getComponent(o.entity, TransformComponent)?.position.clone())
     }
   }
 

--- a/packages/editor/src/components/properties/EnvMapEditor.tsx
+++ b/packages/editor/src/components/properties/EnvMapEditor.tsx
@@ -1,0 +1,152 @@
+import React, { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { getDirectoryFromUrl } from '@xrengine/common/src/utils/getDirectoryFromUrl'
+import { useEngineState } from '@xrengine/engine/src/ecs/classes/EngineService'
+import { getComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
+import { EnvmapComponent } from '@xrengine/engine/src/scene/components/EnvmapComponent'
+import { ErrorComponent } from '@xrengine/engine/src/scene/components/ErrorComponent'
+import { EnvMapSourceType, EnvMapTextureType } from '@xrengine/engine/src/scene/constants/EnvMapEnum'
+import { deserializeEnvMap } from '@xrengine/engine/src/scene/functions/loaders/EnvMapFunctions'
+
+import { setPropertyOnSelectionEntities } from '../../classes/History'
+import ColorInput from '../inputs/ColorInput'
+import CompoundNumericInput from '../inputs/CompoundNumericInput'
+import FolderInput from '../inputs/FolderInput'
+import ImageInput from '../inputs/ImageInput'
+import InputGroup from '../inputs/InputGroup'
+import SelectInput from '../inputs/SelectInput'
+import NodeEditor from './NodeEditor'
+import { EditorComponentType, updateProperty } from './Util'
+
+/**
+ * EnvMapSourceOptions array containing SourceOptions for Envmap
+ */
+const EnvMapSourceOptions = [
+  {
+    label: 'Default',
+    value: EnvMapSourceType.Default
+  },
+  {
+    label: 'Texture',
+    value: EnvMapSourceType.Texture
+  },
+  {
+    label: 'Color',
+    value: EnvMapSourceType.Color
+  },
+  {
+    label: 'None',
+    value: EnvMapSourceType.None
+  }
+]
+
+/**
+ * EnvMapSourceOptions array containing SourceOptions for Envmap
+ */
+const EnvMapTextureOptions = [
+  {
+    label: 'Cubemap',
+    value: EnvMapTextureType.Cubemap
+  },
+  {
+    label: 'Equirectangular',
+    value: EnvMapTextureType.Equirectangular
+  }
+]
+
+/**
+ * EnvMapEditor provides the editor view for environment map property customization.
+ *
+ * @author Nayankumar Patel
+ * @param       props
+ * @constructor
+ */
+export const EnvMapEditor: EditorComponentType = (props) => {
+  const { t } = useTranslation()
+  const entity = props.node.entity
+  const engineState = useEngineState()
+
+  const onChangeCubemapURLSource = useCallback((value) => {
+    const directory = getDirectoryFromUrl(value)
+    if (directory !== envmapComponent.envMapSourceURL) {
+      setPropertyOnSelectionEntities({
+        component: EnvmapComponent,
+        properties: { envMapSourceURL: directory }
+      })
+    }
+  }, [])
+
+  let envmapComponent = getComponent(entity, EnvmapComponent)
+
+  // if component is not there for previously saved model entities then create one
+  if (!envmapComponent) {
+    deserializeEnvMap(props.node.entity, { name: 'envmap', props: { forModel: true } })
+    envmapComponent = getComponent(entity, EnvmapComponent)
+  }
+
+  const hasError = engineState.errorEntities[entity].get()
+  const errorComponent = getComponent(entity, ErrorComponent)
+
+  return (
+    <NodeEditor
+      {...props}
+      name={t('editor:properties.envmap.name')}
+      description={t('editor:properties.envmap.description')}
+    >
+      <InputGroup name="Envmap Source" label="Envmap Source">
+        <SelectInput
+          options={EnvMapSourceOptions}
+          value={envmapComponent.type}
+          onChange={updateProperty(EnvmapComponent, 'type')}
+        />
+      </InputGroup>
+      {envmapComponent.type === EnvMapSourceType.Color && (
+        <InputGroup name="EnvMapColor" label="EnvMap Color">
+          <ColorInput
+            value={envmapComponent.envMapSourceColor}
+            onChange={updateProperty(EnvmapComponent, 'envMapSourceColor')}
+          />
+        </InputGroup>
+      )}
+      {envmapComponent.type === EnvMapSourceType.Texture && (
+        <div>
+          <InputGroup name="Texture Type" label="Texture Type">
+            <SelectInput
+              options={EnvMapTextureOptions}
+              value={envmapComponent.envMapTextureType}
+              onChange={updateProperty(EnvmapComponent, 'envMapTextureType')}
+            />
+          </InputGroup>
+          <InputGroup name="Texture URL" label="Texture URL">
+            {envmapComponent.envMapTextureType === EnvMapTextureType.Cubemap && (
+              <FolderInput value={envmapComponent.envMapSourceURL} onChange={onChangeCubemapURLSource} />
+            )}
+            {envmapComponent.envMapTextureType === EnvMapTextureType.Equirectangular && (
+              <ImageInput
+                value={envmapComponent.envMapSourceURL}
+                onChange={updateProperty(EnvmapComponent, 'envMapSourceURL')}
+              />
+            )}
+            {hasError && errorComponent.envmapError && (
+              <div style={{ marginTop: 2, color: '#FF8C00' }}>{t('editor:properties.scene.error-url')}</div>
+            )}
+          </InputGroup>
+        </div>
+      )}
+
+      {envmapComponent.type !== EnvMapSourceType.None && (
+        <InputGroup name="EnvMap Intensity" label="EnvMap Intensity">
+          <CompoundNumericInput
+            min={0}
+            max={20}
+            value={envmapComponent.envMapIntensity}
+            onChange={updateProperty(EnvmapComponent, 'envMapIntensity')}
+          />
+        </InputGroup>
+      )}
+    </NodeEditor>
+  )
+}
+
+export default EnvMapEditor

--- a/packages/editor/src/components/properties/ModelNodeEditor.tsx
+++ b/packages/editor/src/components/properties/ModelNodeEditor.tsx
@@ -30,6 +30,7 @@ import InputGroup from '../inputs/InputGroup'
 import InteractableGroup from '../inputs/InteractableGroup'
 import ModelInput from '../inputs/ModelInput'
 import SelectInput from '../inputs/SelectInput'
+import EnvMapEditor from './EnvMapEditor'
 import NodeEditor from './NodeEditor'
 import ShadowProperties from './ShadowProperties'
 import { EditorComponentType, updateProperty } from './Util'
@@ -120,12 +121,6 @@ export const ModelNodeEditor: EditorComponentType = (props) => {
           <div style={{ marginTop: 2, color: '#FF8C00' }}>{t('editor:properties.model.error-url')}</div>
         )}
       </InputGroup>
-      <InputGroup name="Environment Map" label={t('editor:properties.model.lbl-envmapUrl')}>
-        <ModelInput value={modelComponent.envMapOverride} onChange={updateProperty(ModelComponent, 'envMapOverride')} />
-        {hasError && errorComponent?.envMapError && (
-          <div style={{ marginTop: 2, color: '#FF8C00' }}>{t('editor:properties.model.error-url')}</div>
-        )}
-      </InputGroup>
       <InputGroup name="Texture Override" label={t('editor:properties.model.lbl-textureOverride')}>
         <SelectInput
           options={textureOverrideEntities}
@@ -172,6 +167,7 @@ export const ModelNodeEditor: EditorComponentType = (props) => {
         <BooleanInput value={isInteractable} onChange={onChangeInteractable} />
       </InputGroup>
       {isInteractable && <InteractableGroup node={props.node}></InteractableGroup>}
+      <EnvMapEditor node={props.node} />
       <ShadowProperties node={props.node} />
     </NodeEditor>
   )

--- a/packages/editor/src/components/properties/SceneNodeEditor.tsx
+++ b/packages/editor/src/components/properties/SceneNodeEditor.tsx
@@ -12,70 +12,32 @@ import {
   VSMShadowMap
 } from 'three'
 
-import { getDirectoryFromUrl } from '@xrengine/common/src/utils/getDirectoryFromUrl'
 import { DistanceModel, DistanceModelOptions } from '@xrengine/engine/src/audio/constants/AudioConstants'
-import { useEngineState } from '@xrengine/engine/src/ecs/classes/EngineService'
 import { getComponent, hasComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
 import { PositionalAudioSettingsComponent } from '@xrengine/engine/src/scene/components/AudioSettingsComponent'
-import { EnvmapComponent } from '@xrengine/engine/src/scene/components/EnvmapComponent'
-import { ErrorComponent } from '@xrengine/engine/src/scene/components/ErrorComponent'
 import { FogComponent } from '@xrengine/engine/src/scene/components/FogComponent'
 import { MetaDataComponent } from '@xrengine/engine/src/scene/components/MetaDataComponent'
 import { RenderSettingComponent } from '@xrengine/engine/src/scene/components/RenderSettingComponent'
 import { SimpleMaterialTagComponent } from '@xrengine/engine/src/scene/components/SimpleMaterialTagComponent'
-import { EnvMapSourceType, EnvMapTextureType } from '@xrengine/engine/src/scene/constants/EnvMapEnum'
 import { FogType } from '@xrengine/engine/src/scene/constants/FogType'
 import { SCENE_COMPONENT_SIMPLE_MATERIALS } from '@xrengine/engine/src/scene/functions/loaders/SimpleMaterialFunctions'
 
 import LanguageIcon from '@mui/icons-material/Language'
 
-import { executeCommandWithHistoryOnSelection, setPropertyOnSelectionEntities } from '../../classes/History'
+import { executeCommandWithHistoryOnSelection } from '../../classes/History'
 import { TagComponentOperation } from '../../commands/TagComponentCommand'
 import EditorCommands from '../../constants/EditorCommands'
 import BooleanInput from '../inputs/BooleanInput'
 import ColorInput from '../inputs/ColorInput'
 import CompoundNumericInput from '../inputs/CompoundNumericInput'
-import FolderInput from '../inputs/FolderInput'
-import ImageInput from '../inputs/ImageInput'
 import InputGroup from '../inputs/InputGroup'
 import NumericInputGroup from '../inputs/NumericInputGroup'
 import SelectInput from '../inputs/SelectInput'
 import StringInput from '../inputs/StringInput'
 import Vector3Input from '../inputs/Vector3Input'
+import EnvMapEditor from './EnvMapEditor'
 import NodeEditor from './NodeEditor'
 import { EditorComponentType, updateProperty } from './Util'
-
-/**
- * EnvMapSourceOptions array containing SourceOptions for Envmap
- */
-const EnvMapSourceOptions = [
-  {
-    label: 'Default',
-    value: EnvMapSourceType.Default
-  },
-  {
-    label: 'Texture',
-    value: EnvMapSourceType.Texture
-  },
-  {
-    label: 'Color',
-    value: EnvMapSourceType.Color
-  }
-]
-
-/**
- * EnvMapSourceOptions array containing SourceOptions for Envmap
- */
-const EnvMapTextureOptions = [
-  {
-    label: 'Cubemap',
-    value: EnvMapTextureType.Cubemap
-  },
-  {
-    label: 'Equirectangular',
-    value: EnvMapTextureType.Equirectangular
-  }
-]
 
 /**
  * FogTypeOptions array containing fogType options.
@@ -166,17 +128,6 @@ const ShadowTypeOptions = [
 export const SceneNodeEditor: EditorComponentType = (props) => {
   const { t } = useTranslation()
   const entity = props.node.entity
-  const engineState = useEngineState()
-
-  const onChangeCubemapURLSource = useCallback((value) => {
-    const directory = getDirectoryFromUrl(value)
-    if (directory !== envmapComponent.envMapSourceURL) {
-      setPropertyOnSelectionEntities({
-        component: EnvmapComponent,
-        properties: { envMapSourceURL: directory }
-      })
-    }
-  }, [])
 
   const onChangeUseSimpleMaterials = useCallback((value) => {
     executeCommandWithHistoryOnSelection(EditorCommands.TAG_COMPONENT, {
@@ -189,12 +140,9 @@ export const SceneNodeEditor: EditorComponentType = (props) => {
   }, [])
 
   const metadata = getComponent(entity, MetaDataComponent)
-  const envmapComponent = getComponent(entity, EnvmapComponent)
   const fogComponent = getComponent(entity, FogComponent)
   const audioComponent = getComponent(entity, PositionalAudioSettingsComponent)
   const renderSettingComponent = getComponent(entity, RenderSettingComponent)
-  const hasError = engineState.errorEntities[entity].get()
-  const errorComponent = getComponent(entity, ErrorComponent)
 
   return (
     <NodeEditor
@@ -205,56 +153,7 @@ export const SceneNodeEditor: EditorComponentType = (props) => {
       <InputGroup name="Metadata" label="Metadata">
         <StringInput value={metadata.meta_data} onChange={updateProperty(MetaDataComponent, 'meta_data')} />
       </InputGroup>
-      <InputGroup name="Envmap Source" label="Envmap Source">
-        <SelectInput
-          options={EnvMapSourceOptions}
-          value={envmapComponent.type}
-          onChange={updateProperty(EnvmapComponent, 'type')}
-        />
-      </InputGroup>
-      {envmapComponent.type === EnvMapSourceType.Color && (
-        <InputGroup name="EnvMapColor" label="EnvMap Color">
-          <ColorInput
-            value={envmapComponent.envMapSourceColor}
-            onChange={updateProperty(EnvmapComponent, 'envMapSourceColor')}
-          />
-        </InputGroup>
-      )}
-      {envmapComponent.type === EnvMapSourceType.Texture && (
-        <div>
-          <InputGroup name="Texture Type" label="Texture Type">
-            <SelectInput
-              options={EnvMapTextureOptions}
-              value={envmapComponent.envMapTextureType}
-              onChange={updateProperty(EnvmapComponent, 'envMapTextureType')}
-            />
-          </InputGroup>
-          <InputGroup name="Texture URL" label="Texture URL">
-            {envmapComponent.envMapTextureType === EnvMapTextureType.Cubemap && (
-              <FolderInput value={envmapComponent.envMapSourceURL} onChange={onChangeCubemapURLSource} />
-            )}
-            {envmapComponent.envMapTextureType === EnvMapTextureType.Equirectangular && (
-              <ImageInput
-                value={envmapComponent.envMapSourceURL}
-                onChange={updateProperty(EnvmapComponent, 'envMapSourceURL')}
-              />
-            )}
-            {hasError && errorComponent.envmapError && (
-              <div style={{ marginTop: 2, color: '#FF8C00' }}>{t('editor:properties.scene.error-url')}</div>
-            )}
-          </InputGroup>
-        </div>
-      )}
-
-      <InputGroup name="EnvMap Intensity" label="EnvMap Intensity">
-        <CompoundNumericInput
-          min={0}
-          max={20}
-          value={envmapComponent.envMapIntensity}
-          onChange={updateProperty(EnvmapComponent, 'envMapIntensity')}
-        />
-      </InputGroup>
-
+      <EnvMapEditor node={props.node} />
       <InputGroup name="Fog Type" label={t('editor:properties.scene.lbl-fogType')}>
         <SelectInput
           options={FogTypeOptions}

--- a/packages/engine/src/scene/components/EnvmapComponent.ts
+++ b/packages/engine/src/scene/components/EnvmapComponent.ts
@@ -11,6 +11,7 @@ export type EnvmapComponentType = {
   envMapSourceURL: string
   envMapIntensity: number
   envMapCubemapBake: CubemapBakeSettings
+  forModel: boolean
 }
 
 export const EnvmapComponent = createMappedComponent<EnvmapComponentType>('EnvmapComponent')

--- a/packages/engine/src/scene/components/ModelComponent.ts
+++ b/packages/engine/src/scene/components/ModelComponent.ts
@@ -2,7 +2,6 @@ import { createMappedComponent } from '../../ecs/functions/ComponentFunctions'
 
 export type ModelComponentType = {
   src: string
-  envMapOverride: string
   textureOverride: string
   matrixAutoUpdate: boolean
   isUsingGPUInstancing: boolean

--- a/packages/engine/src/scene/constants/EnvMapEnum.ts
+++ b/packages/engine/src/scene/constants/EnvMapEnum.ts
@@ -1,7 +1,8 @@
 export const enum EnvMapSourceType {
   'Default',
   'Texture',
-  'Color'
+  'Color',
+  'None'
 }
 
 export const enum EnvMapTextureType {

--- a/packages/engine/src/scene/functions/loaders/EnvMapFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/EnvMapFunctions.ts
@@ -4,7 +4,9 @@ import {
   EquirectangularRefractionMapping,
   Mesh,
   MeshStandardMaterial,
+  Object3D,
   RGBAFormat,
+  Scene,
   sRGBEncoding,
   Vector3
 } from 'three'
@@ -25,6 +27,7 @@ import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunc
 import { matchActionOnce } from '../../../networking/functions/matchActionOnce'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
 import { EnvmapComponent, EnvmapComponentType } from '../../components/EnvmapComponent'
+import { Object3DComponent } from '../../components/Object3DComponent'
 import { EnvMapSourceType, EnvMapTextureType } from '../../constants/EnvMapEnum'
 import {
   cubeTextureLoader,
@@ -44,12 +47,13 @@ import { parseCubemapBakeProperties } from './CubemapBakeFunctions'
 
 export const SCENE_COMPONENT_ENVMAP = 'envmap'
 export const SCENE_COMPONENT_ENVMAP_DEFAULT_VALUES = {
-  type: 1,
+  type: EnvMapSourceType.None,
   envMapTextureType: 0,
-  envMapSourceColor: 0x000000,
+  envMapSourceColor: 0x123456,
   envMapSourceURL: '/hdr/cubemap/skyboxsun25deg/',
   envMapIntensity: 1,
-  envMapCubemapBake: {}
+  envMapCubemapBake: {},
+  forModel: true
 }
 
 const tempVector = new Vector3()
@@ -66,119 +70,138 @@ export const deserializeEnvMap: ComponentDeserializeFunction = (
 
   getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_ENVMAP)
 
-  updateEnvMap(entity)
+  updateEnvMap(entity, props)
 }
 
-export const updateEnvMap: ComponentUpdateFunction = (entity: Entity) => {
+export const updateEnvMap: ComponentUpdateFunction = (entity: Entity, properties: EnvmapComponentType) => {
   const component = getComponent(entity, EnvmapComponent)
+  const obj3d = component.forModel ? getComponent(entity, Object3DComponent)?.value : Engine.instance.scene
 
-  switch (component.type) {
-    case EnvMapSourceType.Color:
-      const col = component.envMapSourceColor ?? tempColor
-      const resolution = 1
-      const data = new Uint8Array(3 * resolution * resolution)
+  if (
+    typeof properties.type !== 'undefined' ||
+    typeof properties.envMapSourceColor !== 'undefined' ||
+    typeof properties.envMapTextureType !== 'undefined' ||
+    typeof properties.envMapCubemapBake !== 'undefined' ||
+    typeof properties.envMapSourceURL !== 'undefined'
+  ) {
+    switch (component.type) {
+      case EnvMapSourceType.Color:
+        const col = component.envMapSourceColor ?? tempColor
+        const resolution = 64 // Min value required
+        const size = resolution * resolution
+        const data = new Uint8Array(4 * size)
 
-      for (let i = 0; i < resolution * resolution; i++) {
-        data[i] = Math.floor(col.r * 255)
-        data[i + 1] = Math.floor(col.g * 255)
-        data[i + 2] = Math.floor(col.b * 255)
-      }
+        for (let i = 0; i < size; i++) {
+          const stride = i * 4
+          data[stride] = Math.floor(col.r * 255)
+          data[stride + 1] = Math.floor(col.g * 255)
+          data[stride + 2] = Math.floor(col.b * 255)
+          data[stride + 3] = 255
+        }
 
-      const texture = new DataTexture(data, resolution, resolution, RGBAFormat)
-      texture.needsUpdate = true
-      texture.encoding = sRGBEncoding
+        const texture = new DataTexture(data, resolution, resolution, RGBAFormat)
+        texture.needsUpdate = true
+        texture.encoding = sRGBEncoding
 
-      Engine.instance.scene.environment = getPmremGenerator().fromEquirectangular(texture).texture
-      break
+        applyEnvMap(obj3d, getPmremGenerator().fromEquirectangular(texture).texture)
+        break
 
-    case EnvMapSourceType.Texture:
-      switch (component.envMapTextureType) {
-        case EnvMapTextureType.Cubemap:
-          cubeTextureLoader.setPath(component.envMapSourceURL).load(
-            [posx, negx, posy, negy, posz, negz],
-            (texture) => {
-              const EnvMap = getPmremGenerator().fromCubemap(texture).texture
-              EnvMap.encoding = sRGBEncoding
-              Engine.instance.scene.environment = EnvMap
-              removeError(entity, 'envmapError')
-              texture.dispose()
-            },
-            (_res) => {
-              /* console.log(_res) */
-            },
-            (_) => {
-              addError(entity, 'envmapError', 'Skybox texture could not be found!')
-            }
-          )
-          break
-
-        case EnvMapTextureType.Equirectangular:
-          textureLoader.load(
-            component.envMapSourceURL,
-            (texture) => {
-              const EnvMap = getPmremGenerator().fromEquirectangular(texture).texture
-              EnvMap.encoding = sRGBEncoding
-              Engine.instance.scene.environment = EnvMap
-              removeError(entity, 'envmapError')
-              texture.dispose()
-            },
-            (_res) => {
-              /* console.log(_res) */
-            },
-            (_) => {
-              addError(entity, 'envmapError', 'Skybox texture could not be found!')
-            }
-          )
-          break
-      }
-      break
-
-    case EnvMapSourceType.Default:
-      const options = component.envMapCubemapBake
-      if (!options) return
-
-      SceneOptions.instance.bpcemOptions.bakeScale = options.bakeScale!
-      SceneOptions.instance.bpcemOptions.bakePositionOffset = options.bakePositionOffset!
-
-      matchActionOnce(Engine.instance.store, EngineActions.sceneLoaded.matches, () => {
-        switch (options.bakeType) {
-          case CubemapBakeTypes.Baked:
-            const texture = AssetLoader.Cache.get(options.envMapOrigin)
-            texture.mapping = EquirectangularRefractionMapping
-            Engine.instance.scene.environment = texture
-
+      case EnvMapSourceType.Texture:
+        switch (component.envMapTextureType) {
+          case EnvMapTextureType.Cubemap:
+            cubeTextureLoader.setPath(component.envMapSourceURL).load(
+              [posx, negx, posy, negy, posz, negz],
+              (texture) => {
+                const EnvMap = getPmremGenerator().fromCubemap(texture).texture
+                EnvMap.encoding = sRGBEncoding
+                applyEnvMap(obj3d, EnvMap)
+                removeError(entity, 'envmapError')
+                texture.dispose()
+              },
+              (_res) => {
+                /* console.log(_res) */
+              },
+              (_) => {
+                addError(entity, 'envmapError', 'Skybox texture could not be found!')
+              }
+            )
             break
-          case CubemapBakeTypes.Realtime:
-            // const map = new CubemapCapturer(EngineRenderer.instance.renderer, Engine.instance.scene, options.resolution)
-            // const EnvMap = (await map.update(options.bakePosition)).cubeRenderTarget.texture
-            // Engine.instance.scene.environment = EnvMap
+
+          case EnvMapTextureType.Equirectangular:
+            textureLoader.load(
+              component.envMapSourceURL,
+              (texture) => {
+                const EnvMap = getPmremGenerator().fromEquirectangular(texture).texture
+                EnvMap.encoding = sRGBEncoding
+                applyEnvMap(obj3d, EnvMap)
+                removeError(entity, 'envmapError')
+                texture.dispose()
+              },
+              (_res) => {
+                /* console.log(_res) */
+              },
+              (_) => {
+                addError(entity, 'envmapError', 'Skybox texture could not be found!')
+              }
+            )
             break
         }
-      })
+        break
 
-      const offset = options.bakePositionOffset!
-      tempVector.set(offset.x, offset.y, offset.z)
+      case EnvMapSourceType.Default:
+        const options = component.envMapCubemapBake
+        if (!options) return
 
-      SceneOptions.instance.boxProjection = options.boxProjection!
-      SceneOptions.instance.bpcemOptions.bakePositionOffset = tempVector
-      SceneOptions.instance.bpcemOptions.bakeScale = options.bakeScale!
-      break
+        if (!component.forModel) {
+          SceneOptions.instance.bpcemOptions.bakeScale = options.bakeScale!
+          SceneOptions.instance.bpcemOptions.bakePositionOffset = options.bakePositionOffset!
+        }
 
-    default:
-      break
+        matchActionOnce(Engine.instance.store, EngineActions.sceneLoaded.matches, () => {
+          switch (options.bakeType) {
+            case CubemapBakeTypes.Baked:
+              const texture = AssetLoader.Cache.get(options.envMapOrigin)
+              texture.mapping = EquirectangularRefractionMapping
+              applyEnvMap(obj3d, texture)
+
+              break
+            case CubemapBakeTypes.Realtime:
+              // const map = new CubemapCapturer(EngineRenderer.instance.renderer, Engine.scene, options.resolution)
+              // const EnvMap = (await map.update(options.bakePosition)).cubeRenderTarget.texture
+              // applyEnvMap(obj3d, EnvMap)
+              break
+          }
+        })
+
+        if (!component.forModel) {
+          const offset = options.bakePositionOffset!
+          tempVector.set(offset.x, offset.y, offset.z)
+
+          SceneOptions.instance.boxProjection = options.boxProjection!
+          SceneOptions.instance.bpcemOptions.bakePositionOffset = tempVector
+          SceneOptions.instance.bpcemOptions.bakeScale = options.bakeScale!
+        }
+        break
+
+      default:
+        applyEnvMap(obj3d, null)
+        break
+    }
   }
 
-  if (SceneOptions.instance.envMapIntensity !== component.envMapIntensity) {
-    SceneOptions.instance.envMapIntensity = component.envMapIntensity
-    Engine.instance.scene.traverse((obj: Mesh) => {
-      if (!obj.material) return
+  if (typeof properties.envMapIntensity !== 'undefined') {
+    if (SceneOptions.instance.envMapIntensity !== component.envMapIntensity) {
+      if (!component.forModel) SceneOptions.instance.envMapIntensity = component.envMapIntensity
+      obj3d.traverse((obj: Mesh) => {
+        if (!obj.material) return
 
-      if (Array.isArray(obj.material)) {
-        obj.material.forEach((m: MeshStandardMaterial) => (m.envMapIntensity = component.envMapIntensity))
-      } else {
-        ;(obj.material as MeshStandardMaterial).envMapIntensity = component.envMapIntensity
-      }
-    })
+        if (Array.isArray(obj.material)) {
+          obj.material.forEach((m: MeshStandardMaterial) => (m.envMapIntensity = component.envMapIntensity))
+        } else {
+          ;(obj.material as MeshStandardMaterial).envMapIntensity = component.envMapIntensity
+        }
+      })
+    }
   }
 }
 
@@ -194,7 +217,8 @@ export const serializeEnvMap: ComponentSerializeFunction = (entity) => {
       envMapSourceColor: component.envMapSourceColor.getHex(),
       envMapSourceURL: component.envMapSourceURL,
       envMapIntensity: component.envMapIntensity,
-      envMapCubemapBake: component.envMapCubemapBake
+      envMapCubemapBake: component.envMapCubemapBake,
+      forModel: component.forModel
     }
   }
 }
@@ -208,6 +232,23 @@ const parseEnvMapProperties = (props): EnvmapComponentType => {
     envMapIntensity: props.envMapIntensity ?? SCENE_COMPONENT_ENVMAP_DEFAULT_VALUES.envMapIntensity,
     envMapCubemapBake: parseCubemapBakeProperties({
       options: props.envMapCubemapBake ?? SCENE_COMPONENT_ENVMAP_DEFAULT_VALUES.envMapCubemapBake
-    }).options
+    }).options,
+    forModel: Boolean(props.forModel)
+  }
+}
+
+function applyEnvMap(obj3d: Object3D, envmap) {
+  if (!obj3d) return
+
+  if (obj3d instanceof Scene) {
+    obj3d.environment = envmap
+  } else {
+    obj3d.traverse((child: Mesh<any, MeshStandardMaterial>) => {
+      if (child.material) child.material.envMap = envmap
+    })
+
+    if ((obj3d as Mesh<any, MeshStandardMaterial>).material) {
+      ;(obj3d as Mesh<any, MeshStandardMaterial>).material.envMap = envmap
+    }
   }
 }

--- a/packages/engine/src/scene/functions/loaders/ModelFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/ModelFunctions.ts
@@ -19,7 +19,6 @@ import { overrideTexture, parseGLTFModel } from '../loadGLTFModel'
 export const SCENE_COMPONENT_MODEL = 'gltf-model'
 export const SCENE_COMPONENT_MODEL_DEFAULT_VALUE = {
   src: '',
-  envMapOverride: undefined,
   textureOverride: '',
   matrixAutoUpdate: true,
   isUsingGPUInstancing: false,
@@ -52,15 +51,6 @@ export const updateModel: ComponentUpdateFunction = (entity: Entity, properties:
     }
   }
 
-  if (properties.envMapOverride) {
-    try {
-      // ToDo: Add right method to load envMap
-      removeError(entity, 'envMapError')
-    } catch (err) {
-      addError(entity, 'envMapError', err.message)
-    }
-  }
-
   if (typeof properties.textureOverride !== 'undefined') {
     overrideTexture(entity)
   }
@@ -73,7 +63,6 @@ export const serializeModel: ComponentSerializeFunction = (entity) => {
     name: SCENE_COMPONENT_MODEL,
     props: {
       src: component.src,
-      envMapOverride: component.envMapOverride !== '' ? component.envMapOverride : undefined,
       textureOverride: component.textureOverride,
       matrixAutoUpdate: component.matrixAutoUpdate,
       isUsingGPUInstancing: component.isUsingGPUInstancing,
@@ -85,7 +74,6 @@ export const serializeModel: ComponentSerializeFunction = (entity) => {
 const parseModelProperties = (props): ModelComponentType => {
   return {
     src: props.src ?? SCENE_COMPONENT_MODEL_DEFAULT_VALUE.src,
-    envMapOverride: props.envMapOverride ?? SCENE_COMPONENT_MODEL_DEFAULT_VALUE.envMapOverride,
     textureOverride: props.textureOverride ?? SCENE_COMPONENT_MODEL_DEFAULT_VALUE.textureOverride,
     matrixAutoUpdate: props.matrixAutoUpdate ?? SCENE_COMPONENT_MODEL_DEFAULT_VALUE.matrixAutoUpdate,
     isUsingGPUInstancing: props.isUsingGPUInstancing ?? SCENE_COMPONENT_MODEL_DEFAULT_VALUE.isUsingGPUInstancing,

--- a/packages/engine/src/scene/functions/registerPrefabs.ts
+++ b/packages/engine/src/scene/functions/registerPrefabs.ts
@@ -25,6 +25,7 @@ import {
   SCENE_COMPONENT_DIRECTIONAL_LIGHT,
   SCENE_COMPONENT_DIRECTIONAL_LIGHT_DEFAULT_VALUES
 } from './loaders/DirectionalLightFunctions'
+import { SCENE_COMPONENT_ENVMAP, SCENE_COMPONENT_ENVMAP_DEFAULT_VALUES } from './loaders/EnvMapFunctions'
 import {
   SCENE_COMPONENT_GROUND_PLANE,
   SCENE_COMPONENT_GROUND_PLANE_DEFAULT_VALUES
@@ -194,6 +195,7 @@ export const registerPrefabs = (world: World) => {
   world.scenePrefabRegistry.set(ScenePrefabs.model, [
     ...defaultSpatialComponents,
     { name: SCENE_COMPONENT_MODEL, props: SCENE_COMPONENT_MODEL_DEFAULT_VALUE },
+    { name: SCENE_COMPONENT_ENVMAP, props: SCENE_COMPONENT_ENVMAP_DEFAULT_VALUES },
     { name: SCENE_COMPONENT_LOOP_ANIMATION, props: SCENE_COMPONENT_LOOP_ANIMATION_DEFAULT_VALUE }
   ])
 


### PR DESCRIPTION
## Summary

Now `EnvmapComponent` will be used in `Model` prefabs to override global environment.

## References

- [x] #5805 


## Checklist
- [ ] CI/CD checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Typescript passing via `npm run check-errors`
  - [ ] Unit & Integration tests passing via `npm run test`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

@HexaField @dinomut1 
