### PR TITLE
Pinning kubectl version to 1.23.6 to avoid aws-cli user apiVersion issue

### DIFF
--- a/scripts/setup_helm.sh
+++ b/scripts/setup_helm.sh
@@ -12,7 +12,7 @@ apt-get -y install docker-ce docker-ce-cli containerd.io
 
 
 #install kubectl
-curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+curl -LO "https://dl.k8s.io/release/1.23.6-00/bin/linux/amd64/kubectl"
 install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 #install Helm


### PR DESCRIPTION
## Summary

kubectl v1.24 removed support for apiVersion client.authentication.k8s.io/v1alpha1. aws-cli is
current hard-coded to use that version, though. Pinning installation of kubectl to 1.23 until
aws-cli is updated to use v1beta1 or v1.


## References

closes #_insert number here_


## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [x] Unit & Integration tests passing via `npm run test`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
