### PR TITLE
Set isLoggedIn after LOADED_USER_DATA

### DIFF
--- a/packages/client-core/src/components/World/LoadLocationScene.tsx
+++ b/packages/client-core/src/components/World/LoadLocationScene.tsx
@@ -26,8 +26,13 @@ export const LoadLocationScene = () => {
       selfUser?.locationBans?.value?.find((ban) => ban.locationId === currentLocation.id.value) != null
     dispatch(LocationAction.socialSelfUserBanned(isUserBanned))
 
-    if (!isUserBanned && !locationState.fetchingCurrentLocation.value && locationState.locationName.value) {
-      retrieveLocationByName(authState, locationState.locationName.value)
+    if (
+      !isUserBanned &&
+      !locationState.fetchingCurrentLocation.value &&
+      locationState.locationName.value &&
+      authState.isLoggedIn.value
+    ) {
+      retrieveLocationByName(locationState.locationName.value)
     }
   }, [authState.isLoggedIn, locationState.locationName])
 

--- a/packages/client-core/src/components/World/LocationLoadHelper.tsx
+++ b/packages/client-core/src/components/World/LocationLoadHelper.tsx
@@ -27,18 +27,16 @@ import { addActionReceptor, dispatchAction } from '@xrengine/hyperflux'
 import { loadEngineInjection } from '@xrengine/projects/loadEngineInjection'
 import { getSystemsFromSceneData } from '@xrengine/projects/loadSystemInjection'
 
-export const retrieveLocationByName = (authState: AuthState, locationName: string) => {
-  if (authState.isLoggedIn.value === true && authState.user.id.value) {
-    if (locationName === globalThis.process.env['VITE_LOBBY_LOCATION_NAME']) {
-      const history = useHistory()
-      LocationService.getLobby()
-        .then((lobby) => {
-          history.replace('/location/' + lobby?.slugifiedName)
-        })
-        .catch((err) => console.log('getLobby error', err))
-    } else {
-      LocationService.getLocationByName(locationName)
-    }
+export const retrieveLocationByName = (locationName: string) => {
+  if (locationName === globalThis.process.env['VITE_LOBBY_LOCATION_NAME']) {
+    const history = useHistory()
+    LocationService.getLobby()
+      .then((lobby) => {
+        history.replace('/location/' + lobby?.slugifiedName)
+      })
+      .catch((err) => console.log('getLobby error', err))
+  } else {
+    LocationService.getLocationByName(locationName)
   }
 }
 

--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -79,7 +79,9 @@ store.receptors.push((action: AuthActionType | StoredLocalActionType): void => {
       case 'ACTION_PROCESSING':
         return s.merge({ isProcessing: action.processing, error: '' })
       case 'LOGIN_USER_SUCCESS':
-        return s.merge({ isLoggedIn: true, authUser: action.authUser })
+        return s.merge({ authUser: action.authUser })
+      case 'LOADED_USER_DATA':
+        return s.merge({ isLoggedIn: true, user: action.user })
       case 'LOGIN_USER_ERROR':
         return s.merge({ error: action.message })
       case 'LOGIN_USER_BY_GITHUB_SUCCESS':
@@ -98,9 +100,6 @@ store.receptors.push((action: AuthActionType | StoredLocalActionType): void => {
         return s.merge({ isLoggedIn: false, user: UserSeed, authUser: AuthUserSeed })
       case 'DID_VERIFY_EMAIL':
         return s.identityProvider.merge({ isVerified: action.result })
-
-      case 'LOADED_USER_DATA':
-        return s.merge({ user: action.user })
       case 'RESTORE': {
         const stored = accessStoredLocalState().attach(Downgraded).authData.value
         return s.merge({

--- a/packages/hyperflux/package.json
+++ b/packages/hyperflux/package.json
@@ -3,7 +3,6 @@
   "version": "0.5.3",
   "main": "index.ts",
   "description": "State Management for XREngine",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "git://github.com/XRFoundation/XREngine.git"


### PR DESCRIPTION
## Summary

Logged in state should be dependent on user data being loaded. Before this, `authState.isLoggedIn` could be true while `authState.user` while calling `retrieveLocationByName`. Now this is not possible, 

## References

closes #_insert number here_


## Checklist
- [ ] CI/CD checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Typescript passing via `npm run check-errors`
  - [ ] Unit & Integration tests passing via `npm run test`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
