### PR TITLE
Fix bug when trying to delete broken project

### DIFF
--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -324,7 +324,7 @@ export class Project extends Service {
         const projectConfig = await getProjectConfig(name)
 
         // run project uninstall script
-        if (projectConfig.onEvent) {
+        if (projectConfig?.onEvent) {
           await onProjectEvent(this.app, name, projectConfig.onEvent, 'onUninstall')
         }
 


### PR DESCRIPTION
## Summary

Projects are ending up in a broken state, without an xrengine.config.ts file, but cannot be deleted.
getProjectConfig() returns null if it can't find that file, but the project.remove handler was expecting
it to be not null. Adding a conditional before the references to projectConfig.onEvent should fix this
and allow the project record to be deleted.


## References

closes #_insert number here_


## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [x] Unit & Integration tests passing via `npm run test`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
