### PR TITLE
Fix: 'Rename Scene' Click Away Listener

### DIFF
--- a/packages/editor/src/components/assets/ScenesPanel.tsx
+++ b/packages/editor/src/components/assets/ScenesPanel.tsx
@@ -9,6 +9,7 @@ import { EngineActions } from '@xrengine/engine/src/ecs/classes/EngineService'
 import { dispatchAction } from '@xrengine/hyperflux'
 
 import { MoreVert } from '@mui/icons-material'
+import { ClickAwayListener } from '@mui/material'
 import { IconButton, InputBase, Menu, MenuItem, Paper } from '@mui/material'
 
 import { disposeProject } from '../../functions/projectFunctions'
@@ -108,15 +109,17 @@ export default function ScenesPanel({ loadScene, newScene, toggleRefetchScenes }
     setNewName(activeScene!.name)
   }
 
+  const finishRenaming = async () => {
+    setRenaming(false)
+    await renameScene(editorState.projectName.value as string, newName, activeScene!.name)
+    dispatch(EditorAction.sceneChanged(newName))
+    history.push(`/editor/${editorState.projectName.value}/${newName}`)
+    setNewName('')
+    fetchItems()
+  }
+
   const renameSceneToNewName = async (e) => {
-    if (e.key == 'Enter' && activeScene) {
-      await renameScene(editorState.projectName.value as string, newName, activeScene.name)
-      dispatch(EditorAction.sceneChanged(newName))
-      history.push(`/editor/${editorState.projectName.value}/${newName}`)
-      setRenaming(false)
-      setNewName('')
-      fetchItems()
-    }
+    if (e.key == 'Enter' && activeScene) finishRenaming()
   }
 
   return (
@@ -138,19 +141,21 @@ export default function ScenesPanel({ loadScene, newScene, toggleRefetchScenes }
                   <div className={styles.detailBlock}>
                     {activeScene === scene && isRenaming ? (
                       <Paper component="div" className={styles.inputContainer}>
-                        <InputBase
-                          className={styles.input}
-                          name="name"
-                          style={{ color: '#fff' }}
-                          autoComplete="off"
-                          autoFocus
-                          value={newName}
-                          onClick={(e) => {
-                            e.stopPropagation()
-                          }}
-                          onChange={(e) => setNewName(e.target.value)}
-                          onKeyPress={renameSceneToNewName}
-                        />
+                        <ClickAwayListener onClickAway={finishRenaming}>
+                          <InputBase
+                            className={styles.input}
+                            name="name"
+                            style={{ color: '#fff' }}
+                            autoComplete="off"
+                            autoFocus
+                            value={newName}
+                            onClick={(e) => {
+                              e.stopPropagation()
+                            }}
+                            onChange={(e) => setNewName(e.target.value)}
+                            onKeyPress={renameSceneToNewName}
+                          />
+                        </ClickAwayListener>
                       </Paper>
                     ) : (
                       <InfoTooltip title={scene.name}>


### PR DESCRIPTION
## Summary

adds click away listener to the 'Rename Scene' text button

## References

closes #_insert number here_


## Checklist
- [ ] CI/CD checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Typescript passing via `npm run check-errors`
  - [ ] Unit & Integration tests passing via `npm run test`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
