### PR TITLE
setup_helm_builder.sh now uses same commands as setup_helm.sh

### DIFF
--- a/scripts/setup_helm_builder.sh
+++ b/scripts/setup_helm_builder.sh
@@ -2,12 +2,16 @@ set -e
 set -x
 
 sudo apt-get -y update
-sudo apt-cache madison snapd
-sudo apt-get install -y snapd
 
-sudo snap install kubectl --classic
+#install kubectl
+curl -LO "https://dl.k8s.io/release/v1.23.6/bin/linux/amd64/kubectl"
+sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
-sudo snap install helm --classic
+#install Helm
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
+
 
 helm repo add xrengine https://helm.xrengine.io
 


### PR DESCRIPTION
## Summary

kubectl version that doesn't work with aws-cli seems to have been published to snap.
Made setup_helm_builder.sh not use snap to standardize deployments.



## References

closes #_insert number here_


## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [x] Unit & Integration tests passing via `npm run test`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
