### PR TITLE
Fetching project files from storageProvider instead of local.

### DIFF
--- a/packages/editor/src/components/projects/ProjectsPage.tsx
+++ b/packages/editor/src/components/projects/ProjectsPage.tsx
@@ -228,7 +228,7 @@ const ProjectsPage = () => {
     if (activeProject) {
       try {
         // TODO: using repo path as IDs & names are not properly implemented for official projects
-        const proj = installedProjects.find((proj) => proj.repositoryPath === activeProject.repositoryPath)!
+        const proj = installedProjects.find((proj) => proj.id === activeProject.id)!
         await ProjectService.removeProject(proj.id)
         fetchInstalledProjects()
       } catch (err) {

--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -314,8 +314,6 @@ export class Project extends Service {
         )
       }
       return Promise.all(promises)
-    } else {
-      return uploadLocalProjectToProvider(projectName)
     }
   }
 

--- a/packages/server-core/src/projects/scene/scene.class.ts
+++ b/packages/server-core/src/projects/scene/scene.class.ts
@@ -1,10 +1,9 @@
-import { NullableId, Paginated, Params, ServiceMethods } from '@feathersjs/feathers'
+import { NullableId, Params, ServiceMethods } from '@feathersjs/feathers'
 import appRootPath from 'app-root-path'
 import fs from 'fs'
 import path from 'path'
 
-import { SceneData, SceneJson, SceneMetadata } from '@xrengine/common/src/interfaces/SceneInterface'
-import { isDev } from '@xrengine/common/src/utils/isDev'
+import { SceneData, SceneJson } from '@xrengine/common/src/interfaces/SceneInterface'
 import defaultSceneSeed from '@xrengine/projects/default-project/default.scene.json'
 
 import { Application } from '../../../declarations'
@@ -12,7 +11,6 @@ import logger from '../../logger'
 import { getCachedAsset } from '../../media/storageprovider/getCachedAsset'
 import { useStorageProvider } from '../../media/storageprovider/storageprovider'
 import { cleanString } from '../../util/cleanString'
-import { uploadLocalProjectToProvider } from '../project/project.class'
 import { cleanSceneDataCacheURLs, parseSceneDataCacheURLs } from './scene-parser'
 
 const storageProvider = useStorageProvider()

--- a/packages/server-core/src/projects/scene/scene.class.ts
+++ b/packages/server-core/src/projects/scene/scene.class.ts
@@ -18,34 +18,34 @@ import { cleanSceneDataCacheURLs, parseSceneDataCacheURLs } from './scene-parser
 const storageProvider = useStorageProvider()
 const NEW_SCENE_NAME = 'New-Scene'
 
-export const getSceneData = (projectName, sceneName, metadataOnly, internal) => {
-  const newSceneJsonPath = path.resolve(
-    appRootPath.path,
-    `packages/projects/projects/${projectName}/${sceneName}.scene.json`
-  )
+export const getSceneData = async (projectName, sceneName, metadataOnly, internal, downloadIfNotPresent = false) => {
+  const scenePath = `projects/${projectName}/${sceneName}.scene.json`
+  const thumbnailPath = `projects/${projectName}/${sceneName}.thumbnail.jpeg`
 
-  if (!fs.existsSync(newSceneJsonPath)) throw new Error(`No scene named ${sceneName} exists in project ${projectName}`)
-
-  const sceneThumbnailPath = getCachedAsset(
-    `projects/${projectName}/${sceneName}.thumbnail.jpeg`,
+  const thumbnailUrl = getCachedAsset(
+    thumbnailPath,
     storageProvider.cacheDomain,
     internal
   )
 
-  const sceneData: SceneData = {
-    name: sceneName,
-    project: projectName,
-    thumbnailUrl: sceneThumbnailPath + `?${Date.now()}`,
-    scene: metadataOnly
-      ? undefined!
-      : parseSceneDataCacheURLs(
-          JSON.parse(fs.readFileSync(path.resolve(newSceneJsonPath), 'utf8')),
-          storageProvider.cacheDomain,
-          internal
-        )
+  const sceneExists = await storageProvider.doesExist(`${sceneName}.scene.json`, `projects/${projectName}/`)
+  if (sceneExists) {
+    const sceneResult = await storageProvider.getObject(scenePath)
+    const sceneData: SceneData = {
+      name: sceneName,
+      project: projectName,
+      thumbnailUrl: thumbnailUrl + `?${Date.now()}`,
+      scene: metadataOnly
+          ? undefined!
+          : parseSceneDataCacheURLs(
+              JSON.parse(sceneResult.Body.toString()),
+              storageProvider.cacheDomain,
+              internal
+          )
+    }
+    return sceneData
   }
-
-  return sceneData
+  throw new Error(`No scene named ${sceneName} exists in project ${projectName}`)
 }
 
 interface UpdateParams {
@@ -98,7 +98,7 @@ export class Scene implements ServiceMethods<any> {
     const project = await this.app.service('project').get(projectName, params)
     if (!project?.data) throw new Error(`No project named ${projectName} exists`)
 
-    const sceneData = getSceneData(projectName, sceneName, metadataOnly, params!.provider == null)
+    const sceneData = await getSceneData(projectName, sceneName, metadataOnly, params!.provider == null)
 
     return {
       data: sceneData
@@ -112,35 +112,20 @@ export class Scene implements ServiceMethods<any> {
     const project = await this.app.service('project').get(projectName, params)
     if (!project.data) throw new Error(`No project named ${projectName} exists`)
 
-    const projectPath = path.resolve(appRootPath.path, 'packages/projects/projects/' + projectName) + '/'
+    const projectPath = `projects/${projectName}/`
 
     let newSceneName = NEW_SCENE_NAME
     let counter = 1
 
     while (true) {
       if (counter > 1) newSceneName = NEW_SCENE_NAME + '-' + counter
-      if (!fs.existsSync(projectPath + newSceneName + '.scene.json')) break
+      if (!await storageProvider.doesExist(`${newSceneName}.scene.json`, projectPath)) break
 
       counter++
     }
 
-    fs.copyFileSync(
-      path.resolve(appRootPath.path, `packages/projects/default-project/default.thumbnail.jpeg`),
-      path.resolve(projectPath + newSceneName + '.thumbnail.jpeg')
-    )
-
-    fs.copyFileSync(
-      path.resolve(appRootPath.path, `packages/projects/default-project/default.scene.json`),
-      path.resolve(projectPath + newSceneName + '.scene.json')
-    )
-
-    /**
-     * For local development flow only
-     * Updates the local storage provider with the project's current files
-     */
-    if (isDev) {
-      await uploadLocalProjectToProvider(projectName)
-    }
+    await storageProvider.moveObject(`default.thumbnail.jpeg`, `${newSceneName}.thumbnail.jpeg`, `projects/default-project`, projectPath, true)
+    await storageProvider.moveObject(`default.scene.json`, `${newSceneName}.scene.json`, `projects/default-project`, projectPath, true)
 
     return { projectName, sceneName: newSceneName }
   }
@@ -151,31 +136,17 @@ export class Scene implements ServiceMethods<any> {
     const project = await this.app.service('project').get(projectName, params)
     if (!project.data) throw new Error(`No project named ${projectName} exists`)
 
-    const oldSceneJsonPath = path.resolve(
-      appRootPath.path,
-      `packages/projects/projects/${projectName}/${oldSceneName}.scene.json`
-    )
+    const projectPath = `projects/${projectName}/`
+    const oldSceneJsonName = `${oldSceneName}.scene.json`
+    const newSceneJsonName = `${newSceneName}.scene.json`
+    const oldSceneThumbnailName = `${oldSceneName}.thumbnail.jpeg`
+    const newSceneThumbnailName = `${newSceneName}.thumbnail.jpeg`
 
-    const oldSceneThumbNailPath = path.resolve(
-      appRootPath.path,
-      `packages/projects/projects/${projectName}/${oldSceneName}.thumbnail.jpeg`
-    )
+    if (await storageProvider.doesExist(oldSceneJsonName, projectPath))
+      await storageProvider.moveObject(oldSceneJsonName, newSceneJsonName, projectPath, projectPath)
 
-    if (fs.existsSync(oldSceneJsonPath)) {
-      const newSceneJsonPath = path.resolve(
-        appRootPath.path,
-        `packages/projects/projects/${projectName}/${newSceneName}.scene.json`
-      )
-      fs.renameSync(oldSceneJsonPath, newSceneJsonPath)
-    }
-
-    if (fs.existsSync(oldSceneThumbNailPath)) {
-      const newSceneThumbNailPath = path.resolve(
-        appRootPath.path,
-        `packages/projects/projects/${projectName}/${newSceneName}.thumbnail.jpeg`
-      )
-      fs.renameSync(oldSceneThumbNailPath, newSceneThumbNailPath)
-    }
+    if (await storageProvider.doesExist(oldSceneThumbnailName, projectPath))
+      await storageProvider.moveObject(oldSceneThumbnailName, newSceneThumbnailName, projectPath, projectPath)
 
     return
   }
@@ -187,31 +158,22 @@ export class Scene implements ServiceMethods<any> {
     const project = await this.app.service('project').get(projectName, params)
     if (!project.data) throw new Error(`No project named ${projectName} exists`)
 
-    const newSceneJsonPath = path.resolve(
-      appRootPath.path,
-      `packages/projects/projects/${projectName}/${sceneName}.scene.json`
-    )
+    const newSceneJsonPath = `projects/${projectName}/${sceneName}.scene.json`
 
     if (thumbnailBuffer) {
-      const sceneThumbnailPath = path.resolve(
-        appRootPath.path,
-        `packages/projects/projects/${projectName}/${sceneName}.thumbnail.jpeg`
-      )
-      fs.writeFileSync(path.resolve(sceneThumbnailPath), thumbnailBuffer as Buffer)
+      const sceneThumbnailPath = `projects/${projectName}/${sceneName}.thumbnail.jpeg`
+      await storageProvider.putObject({
+        Key: sceneThumbnailPath,
+        Body: thumbnailBuffer as Buffer,
+        ContentType: 'image/jpeg'
+      })
     }
 
-    fs.writeFileSync(
-      path.resolve(newSceneJsonPath),
-      JSON.stringify(cleanSceneDataCacheURLs(sceneData ?? defaultSceneSeed, storageProvider.cacheDomain), null, 2)
-    )
-
-    /**
-     * For local development flow only
-     * Updates the local storage provider with the project's current files
-     */
-    if (isDev) {
-      await uploadLocalProjectToProvider(projectName)
-    }
+    const result = await storageProvider.putObject({
+      Key: newSceneJsonPath,
+      Body: Buffer.from(JSON.stringify(cleanSceneDataCacheURLs(sceneData ?? defaultSceneSeed, storageProvider.cacheDomain))),
+      ContentType: 'application/json'
+    })
   }
 
   // async patch(sceneId: NullableId, data: PatchData, params: Params): Promise<SceneDetailInterface> {}
@@ -235,5 +197,7 @@ export class Scene implements ServiceMethods<any> {
     if (fs.existsSync(thumbnailPath)) {
       fs.rmSync(path.resolve(thumbnailPath))
     }
+
+    await storageProvider.deleteResources([`projects/${projectName}/${name}.scene.json`, `projects${projectName}/${name}.thumbnail.jpeg`])
   }
 }

--- a/packages/server-core/src/projects/scene/scene.class.ts
+++ b/packages/server-core/src/projects/scene/scene.class.ts
@@ -22,11 +22,7 @@ export const getSceneData = async (projectName, sceneName, metadataOnly, interna
   const scenePath = `projects/${projectName}/${sceneName}.scene.json`
   const thumbnailPath = `projects/${projectName}/${sceneName}.thumbnail.jpeg`
 
-  const thumbnailUrl = getCachedAsset(
-    thumbnailPath,
-    storageProvider.cacheDomain,
-    internal
-  )
+  const thumbnailUrl = getCachedAsset(thumbnailPath, storageProvider.cacheDomain, internal)
 
   const sceneExists = await storageProvider.doesExist(`${sceneName}.scene.json`, `projects/${projectName}/`)
   if (sceneExists) {
@@ -36,12 +32,8 @@ export const getSceneData = async (projectName, sceneName, metadataOnly, interna
       project: projectName,
       thumbnailUrl: thumbnailUrl + `?${Date.now()}`,
       scene: metadataOnly
-          ? undefined!
-          : parseSceneDataCacheURLs(
-              JSON.parse(sceneResult.Body.toString()),
-              storageProvider.cacheDomain,
-              internal
-          )
+        ? undefined!
+        : parseSceneDataCacheURLs(JSON.parse(sceneResult.Body.toString()), storageProvider.cacheDomain, internal)
     }
     return sceneData
   }
@@ -119,13 +111,25 @@ export class Scene implements ServiceMethods<any> {
 
     while (true) {
       if (counter > 1) newSceneName = NEW_SCENE_NAME + '-' + counter
-      if (!await storageProvider.doesExist(`${newSceneName}.scene.json`, projectPath)) break
+      if (!(await storageProvider.doesExist(`${newSceneName}.scene.json`, projectPath))) break
 
       counter++
     }
 
-    await storageProvider.moveObject(`default.thumbnail.jpeg`, `${newSceneName}.thumbnail.jpeg`, `projects/default-project`, projectPath, true)
-    await storageProvider.moveObject(`default.scene.json`, `${newSceneName}.scene.json`, `projects/default-project`, projectPath, true)
+    await storageProvider.moveObject(
+      `default.thumbnail.jpeg`,
+      `${newSceneName}.thumbnail.jpeg`,
+      `projects/default-project`,
+      projectPath,
+      true
+    )
+    await storageProvider.moveObject(
+      `default.scene.json`,
+      `${newSceneName}.scene.json`,
+      `projects/default-project`,
+      projectPath,
+      true
+    )
 
     return { projectName, sceneName: newSceneName }
   }
@@ -171,7 +175,9 @@ export class Scene implements ServiceMethods<any> {
 
     const result = await storageProvider.putObject({
       Key: newSceneJsonPath,
-      Body: Buffer.from(JSON.stringify(cleanSceneDataCacheURLs(sceneData ?? defaultSceneSeed, storageProvider.cacheDomain))),
+      Body: Buffer.from(
+        JSON.stringify(cleanSceneDataCacheURLs(sceneData ?? defaultSceneSeed, storageProvider.cacheDomain))
+      ),
       ContentType: 'application/json'
     })
   }
@@ -198,6 +204,9 @@ export class Scene implements ServiceMethods<any> {
       fs.rmSync(path.resolve(thumbnailPath))
     }
 
-    await storageProvider.deleteResources([`projects/${projectName}/${name}.scene.json`, `projects${projectName}/${name}.thumbnail.jpeg`])
+    await storageProvider.deleteResources([
+      `projects/${projectName}/${name}.scene.json`,
+      `projects${projectName}/${name}.thumbnail.jpeg`
+    ])
   }
 }

--- a/packages/server-core/src/projects/scene/scene.service.ts
+++ b/packages/server-core/src/projects/scene/scene.service.ts
@@ -1,7 +1,4 @@
 import { Params } from '@feathersjs/feathers'
-import appRootPath from 'app-root-path'
-import fs from 'fs'
-import path from 'path'
 
 import { SceneData } from '@xrengine/common/src/interfaces/SceneInterface'
 

--- a/packages/server-core/src/projects/scene/scene.service.ts
+++ b/packages/server-core/src/projects/scene/scene.service.ts
@@ -7,11 +7,11 @@ import { SceneData } from '@xrengine/common/src/interfaces/SceneInterface'
 
 import { Application } from '../../../declarations'
 import logger from '../../logger'
+import { useStorageProvider } from '../../media/storageprovider/storageprovider'
 import { getAllPortals, getCubemapBake, getPortal } from './scene-helper'
 import { getSceneData, Scene } from './scene.class'
 import projectDocs from './scene.docs'
 import hooks from './scene.hooks'
-import {useStorageProvider} from "../../media/storageprovider/storageprovider";
 
 const storageProvider = useStorageProvider()
 
@@ -46,14 +46,15 @@ export const getScenesForProject = (app: Application) => {
       const newSceneJsonPath = `projects/${projectName}/`
 
       const fileResults = await storageProvider.listObjects(newSceneJsonPath, false)
-      const files = fileResults.Contents
-          .map((dirent) => dirent.Key)
-          .filter((name) => name.endsWith('.scene.json'))
-          .map((name) => name.slice(0, -'.scene.json'.length))
+      const files = fileResults.Contents.map((dirent) => dirent.Key)
+        .filter((name) => name.endsWith('.scene.json'))
+        .map((name) => name.slice(0, -'.scene.json'.length))
 
-      const sceneData: SceneData[] = await Promise.all(files.map(async (sceneName) =>
-        getSceneData(projectName, sceneName.replace(newSceneJsonPath, ''), metadataOnly, internal)
-      ))
+      const sceneData: SceneData[] = await Promise.all(
+        files.map(async (sceneName) =>
+          getSceneData(projectName, sceneName.replace(newSceneJsonPath, ''), metadataOnly, internal)
+        )
+      )
 
       return {
         data: sceneData


### PR DESCRIPTION
## Summary

Using local files as source of projects prevented newly-created/updated
projects from being used until a whole rebuild was done. Changed all
local CRUD of project files/scenes to update the copy in the
storageProvider instead.

Fixed a client bug with selection of project to be deleted.

## References

closes #_insert number here_


## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [x] Unit & Integration tests passing via `npm run test`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
