### PR TITLE
Fixes for several A/V problems

### DIFF
--- a/packages/client-core/src/components/Layout/index.module.scss
+++ b/packages/client-core/src/components/Layout/index.module.scss
@@ -75,6 +75,18 @@ body {
     }
   }
 
+  @media (min-width: 769px) {
+    &:hover,
+    &:focus {
+      [class*="user-controls"] {
+        padding: 10px 10px 10px 25px;
+        z-index: 10;
+        min-width: 150px;
+        width: auto;
+      }
+    }
+  }
+
   @media (max-width: 450px) {
     padding-left: 0;
     padding-right: 0;

--- a/packages/client-core/src/components/PartyParticipantWindow/index.module.scss
+++ b/packages/client-core/src/components/PartyParticipantWindow/index.module.scss
@@ -196,16 +196,6 @@
         width: 20px;
       }
     }
-
-    &:hover,
-    &:focus {
-      .user-controls {
-        padding: 10px 10px 10px 25px;
-        z-index: 10;
-        min-width: 150px;
-        width: auto;
-      }
-    }
   }
 
   @media (max-width: 768px) {

--- a/packages/client-core/src/components/PartyParticipantWindow/index.tsx
+++ b/packages/client-core/src/components/PartyParticipantWindow/index.tsx
@@ -354,9 +354,13 @@ const PartyParticipantWindow = (props: Props): JSX.Element => {
       else await resumeProducer(mediaTransport, MediaStreams.instance.screenVideoProducer)
       setVideoStreamPaused(videoPaused)
     } else {
-      if (videoStream.paused === false) await pauseConsumer(mediaTransport, videoStream)
-      else await resumeConsumer(mediaTransport, videoStream)
-      setVideoStreamPaused(videoStream.paused)
+      if (videoStream.paused === false) {
+        await pauseConsumer(mediaTransport, videoStream)
+        setVideoStreamPaused(true)
+      } else {
+        await resumeConsumer(mediaTransport, videoStream)
+        setVideoStreamPaused(false)
+      }
     }
   }
 
@@ -374,9 +378,13 @@ const PartyParticipantWindow = (props: Props): JSX.Element => {
       else await resumeProducer(mediaTransport, MediaStreams.instance.screenAudioProducer)
       setAudioStreamPaused(audioPaused)
     } else {
-      if (audioStream.paused === false) await pauseConsumer(mediaTransport, audioStream)
-      else await resumeConsumer(mediaTransport, audioStream)
-      setAudioStreamPaused(audioStream.paused)
+      if (audioStream.paused === false) {
+        await pauseConsumer(mediaTransport, audioStream)
+        setAudioStreamPaused(true)
+      } else {
+        await resumeConsumer(mediaTransport, audioStream)
+        setAudioStreamPaused(false)
+      }
     }
   }
 
@@ -494,7 +502,7 @@ const PartyParticipantWindow = (props: Props): JSX.Element => {
                 </Tooltip>
               }
             </div>
-            {audioProducerGlobalMute === true && <div className={styles['global-mute']}>Muted by Admin</div>}
+            {audioProducerGlobalMute && <div className={styles['global-mute']}>Muted by Admin</div>}
             {audioStream &&
               !audioProducerPaused &&
               !audioProducerGlobalMute &&

--- a/packages/client-core/src/media/services/MediaStreamService.ts
+++ b/packages/client-core/src/media/services/MediaStreamService.ts
@@ -37,6 +37,8 @@ store.receptors.push((action: MediaStreamActionType): any => {
 export const accessMediaStreamState = () => state
 export const useMediaStreamState = () => useState(state)
 
+let updateConsumerTimeout
+
 //Service
 export const MediaStreamService = {
   updateCamVideoState: () => {
@@ -44,8 +46,13 @@ export const MediaStreamService = {
     store.dispatch(MediaStreamAction.setCamVideoState(ms != null && ms.camVideoProducer != null && !ms.videoPaused))
   },
   triggerUpdateConsumers: () => {
-    const ms = MediaStreams.instance
-    store.dispatch(MediaStreamAction.setConsumers(ms != null ? ms.consumers : []))
+    if (!updateConsumerTimeout) {
+      updateConsumerTimeout = setTimeout(() => {
+        const ms = MediaStreams.instance
+        store.dispatch(MediaStreamAction.setConsumers(ms != null ? ms.consumers : []))
+        updateConsumerTimeout = null
+      }, 1000)
+    }
   },
   triggerUpdateNearbyLayerUsers: () => {
     const ms = MediaStreams.instance

--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -19,8 +19,8 @@ import {
   accessMediaInstanceConnectionState,
   MediaLocationInstanceConnectionAction
 } from '../common/services/MediaInstanceConnectionService'
-import { MediaStreamService } from '../media/services/MediaStreamService'
-import { useDispatch } from '../store'
+import { MediaStreamAction, MediaStreamService } from '../media/services/MediaStreamService'
+import { store, useDispatch } from '../store'
 import { accessAuthState } from '../user/services/AuthService'
 import { getSearchParamFromURL } from '../util/getSearchParamFromURL'
 import { getMediaTransport, SocketWebRTCClientTransport } from './SocketWebRTCClientTransport'
@@ -138,14 +138,19 @@ export async function onConnectToWorldInstance(networkTransport: SocketWebRTCCli
     })
   }
 
-  async function updateNearbyLayerUsersHandler(action) {
-    matches(action).when(MediaStreams.actions.updateNearbyLayerUsers.matches, async () => {
-      const { userIds } = await networkTransport.request(MessageTypes.WebRTCRequestNearbyUsers.toString())
-      dispatchAction(Engine.instance.store, MediaStreams.actions.triggerRequestCurrentProducers({ userIds }))
-    })
+  async function reconnectHandler() {
+    dispatchAction(Engine.instance.store, SocketWebRTCClientTransport.actions.worldInstanceReconnected())
+    networkTransport.reconnecting = false
+    await onConnectToInstance(networkTransport)
+    const transportRequestData = {
+      inviteCode: getSearchParamFromURL('inviteCode')!
+    }
+    await networkTransport.request(MessageTypes.JoinWorld.toString(), transportRequestData).then(receiveJoinWorld)
+    networkTransport.socket.io.off('reconnect', reconnectHandler)
+    networkTransport.socket.off('disconnect', disconnectHandler)
   }
 
-  networkTransport.socket.on('disconnect', async () => {
+  async function disconnectHandler() {
     dispatchAction(Engine.instance.store, SocketWebRTCClientTransport.actions.worldInstanceDisconnected())
     networkTransport.reconnecting = true
     networkTransport.socket.off(MessageTypes.ActionData.toString(), actionDataHandler)
@@ -154,16 +159,17 @@ export async function onConnectToWorldInstance(networkTransport: SocketWebRTCCli
     networkTransport.socket.off(MessageTypes.WebRTCConsumeData.toString(), consumeDataHandler)
 
     removeActionReceptor(Engine.instance.store, updateNearbyLayerUsersHandler)
-  })
-  networkTransport.socket.io.on('reconnect', async () => {
-    dispatchAction(Engine.instance.store, SocketWebRTCClientTransport.actions.worldInstanceReconnected())
-    networkTransport.reconnecting = false
-    await onConnectToInstance(networkTransport)
-    const transportRequestData = {
-      inviteCode: getSearchParamFromURL('inviteCode')!
-    }
-    await networkTransport.request(MessageTypes.JoinWorld.toString(), transportRequestData).then(receiveJoinWorld)
-  })
+  }
+
+  async function updateNearbyLayerUsersHandler(action) {
+    matches(action).when(MediaStreams.actions.updateNearbyLayerUsers.matches, async () => {
+      const { userIds } = await networkTransport.request(MessageTypes.WebRTCRequestNearbyUsers.toString())
+      dispatchAction(Engine.instance.store, MediaStreams.actions.triggerRequestCurrentProducers({ userIds }))
+    })
+  }
+
+  networkTransport.socket.on('disconnect', disconnectHandler)
+  networkTransport.socket.io.on('reconnect', reconnectHandler)
 
   networkTransport.socket.on(MessageTypes.ActionData.toString(), actionDataHandler)
 
@@ -199,13 +205,15 @@ export async function onConnectToMediaInstance(networkTransport: SocketWebRTCCli
   async function webRTCCreateProducerHandler(socketId, mediaTag, producerId, channelType: ChannelType, channelId) {
     const selfProducerIds = [MediaStreams.instance?.camVideoProducer?.id, MediaStreams.instance?.camAudioProducer?.id]
     const channelConnectionState = accessMediaInstanceConnectionState()
+
+    const consumerMatch = MediaStreams.instance?.consumers?.find(
+      (c) => c?.appData?.peerId === socketId && c?.appData?.mediaTag === mediaTag && c?.producerId === producerId
+    )
     if (
       producerId != null &&
       // channelType === self.channelType &&
       selfProducerIds.indexOf(producerId) < 0 &&
-      // (MediaStreams.instance?.consumers?.find(
-      //   c => c?.appData?.peerId === socketId && c?.appData?.mediaTag === mediaTag
-      // ) == null /*&&
+      (consumerMatch == null || (consumerMatch._track?.muted && consumerMatch._track?.enabled)) &&
       (channelType === 'instance'
         ? channelConnectionState.channelType.value === 'instance'
         : channelConnectionState.channelType.value === channelType &&
@@ -231,23 +239,7 @@ export async function onConnectToMediaInstance(networkTransport: SocketWebRTCCli
       })
   }
 
-  const channelConnectionState = accessMediaInstanceConnectionState()
-  networkTransport.socket.on('disconnect', async () => {
-    dispatchAction(Engine.instance.store, SocketWebRTCClientTransport.actions.mediaInstanceDisconnected())
-    networkTransport.reconnecting = true
-
-    networkTransport.socket.off(MessageTypes.WebRTCPauseConsumer.toString(), webRTCPauseConsumerHandler)
-
-    networkTransport.socket.off(MessageTypes.WebRTCResumeConsumer.toString(), webRTCResumeConsumerHandler)
-
-    networkTransport.socket.off(MessageTypes.WebRTCCloseConsumer.toString(), webRTCCloseConsumerHandler)
-
-    removeActionReceptor(Engine.instance.store, consumerHandler)
-  })
-
-  networkTransport.socket.on(MessageTypes.WebRTCCreateProducer.toString(), webRTCCreateProducerHandler)
-
-  networkTransport.socket.io.on('reconnect', async () => {
+  async function reconnectHandler() {
     dispatchAction(Engine.instance.store, SocketWebRTCClientTransport.actions.mediaInstanceReconnected())
     networkTransport.reconnecting = false
     await onConnectToInstance(networkTransport)
@@ -279,6 +271,8 @@ export async function onConnectToMediaInstance(networkTransport: SocketWebRTCCli
       }
       MediaStreamService.updateCamAudioState()
     }
+    networkTransport.socket.io.off('reconnect', reconnectHandler)
+    networkTransport.socket.off('disconnect', disconnectHandler)
     // if (MediaStreams.instance.screenVideoProducer) {
     //   if (socket.connected === true && typeof request === 'function')
     //     await request(MessageTypes.WebRTCCloseProducer.toString(), {
@@ -293,8 +287,25 @@ export async function onConnectToMediaInstance(networkTransport: SocketWebRTCCli
     //     })
     //   await MediaStreams.instance.screenAudioProducer?.close()
     // }
-  })
+  }
 
+  async function disconnectHandler() {
+    if (networkTransport.recvTransport?.closed !== true) await networkTransport.recvTransport.close()
+    if (networkTransport.sendTransport?.closed !== true) await networkTransport.sendTransport.close()
+    MediaStreams.instance?.consumers.forEach((consumer) => closeConsumer(networkTransport, consumer))
+    networkTransport.socket.off(MessageTypes.WebRTCCreateProducer.toString(), webRTCCreateProducerHandler)
+    dispatchAction(Engine.instance.store, SocketWebRTCClientTransport.actions.mediaInstanceDisconnected())
+    networkTransport.reconnecting = true
+    networkTransport.socket.off(MessageTypes.WebRTCPauseConsumer.toString(), webRTCPauseConsumerHandler)
+    networkTransport.socket.off(MessageTypes.WebRTCResumeConsumer.toString(), webRTCResumeConsumerHandler)
+    networkTransport.socket.off(MessageTypes.WebRTCCloseConsumer.toString(), webRTCCloseConsumerHandler)
+    removeActionReceptor(Engine.instance.store, consumerHandler)
+  }
+
+  const channelConnectionState = accessMediaInstanceConnectionState()
+  networkTransport.socket.on('disconnect', disconnectHandler)
+  networkTransport.socket.on(MessageTypes.WebRTCCreateProducer.toString(), webRTCCreateProducerHandler)
+  networkTransport.socket.io.on('reconnect', reconnectHandler)
   networkTransport.socket.on(MessageTypes.WebRTCPauseConsumer.toString(), webRTCPauseConsumerHandler)
   networkTransport.socket.on(MessageTypes.WebRTCResumeConsumer.toString(), webRTCResumeConsumerHandler)
   networkTransport.socket.on(MessageTypes.WebRTCCloseConsumer.toString(), webRTCCloseConsumerHandler)
@@ -731,8 +742,9 @@ export async function subscribeToTrack(
   const channelType = channelConnectionState.channelType.value
   const channelId = channelConnectionState.channelId.value
   // if we do already have a consumer, we shouldn't have called this method
-  let consumer = MediaStreams.instance?.consumers.find(
-    (c: any) => c.appData.peerId === peerId && c.appData.mediaTag === mediaTag
+
+  const existingConsumer = MediaStreams.instance?.consumers?.find(
+    (c) => c?.appData?.peerId === peerId && c?.appData?.mediaTag === mediaTag
   )
 
   // ask the server to create a server-side consumer object and send us back the info we need to create a client-side consumer
@@ -747,15 +759,11 @@ export async function subscribeToTrack(
   // Only continue if we have a valid id
   if (consumerParameters?.id == null) return
 
-  consumer = await networkTransport.recvTransport.consume({
+  const consumer = await networkTransport.recvTransport.consume({
     ...consumerParameters,
     appData: { peerId, mediaTag, channelType },
     paused: true
   })
-
-  const existingConsumer = MediaStreams.instance?.consumers?.find(
-    (c) => c?.appData?.peerId === peerId && c?.appData?.mediaTag === mediaTag
-  )
   if (existingConsumer == null) {
     MediaStreams.instance?.consumers.push(consumer)
     dispatchAction(Engine.instance.store, MediaStreams.actions.triggerUpdateConsumers())
@@ -765,9 +773,7 @@ export async function subscribeToTrack(
     await resumeConsumer(networkTransport, consumer)
   } else if (existingConsumer?._track?.muted) {
     await closeConsumer(networkTransport, existingConsumer)
-    console.log('consumers before splice', MediaStreams.instance?.consumers)
-    // MediaStreams.instance?.consumers.splice(existingConsumerIndex, 0, consumer) // existingConsumerIndex is undefined...
-    console.log('consumers after splice', MediaStreams.instance?.consumers)
+    MediaStreams.instance.consumers.push(consumer)
     dispatchAction(Engine.instance.store, MediaStreams.actions.triggerUpdateConsumers())
     MediaStreamService.triggerUpdateNearbyLayerUsers()
 
@@ -857,14 +863,14 @@ export async function globalUnmuteProducer(transport: SocketWebRTCClientTranspor
 }
 
 export async function closeConsumer(transport: SocketWebRTCClientTransport, consumer: any) {
+  await consumer?.close()
+
+  const ms = MediaStreams.instance
+  ms.consumers = ms.consumers.filter((c: any) => !(c.id === consumer.id)) as any[]
+  store.dispatch(MediaStreamAction.setConsumers(ms.consumers))
   await transport.request(MessageTypes.WebRTCCloseConsumer.toString(), {
     consumerId: consumer.id
   })
-  await consumer?.close()
-
-  MediaStreams.instance.consumers = MediaStreams.instance?.consumers.filter(
-    (c: any) => !(c.id === consumer.id)
-  ) as any[]
 }
 
 export async function leave(networkTransport: SocketWebRTCClientTransport, kicked?: boolean) {


### PR DESCRIPTION
## Summary

Many A/V listeners were being registered more than once, especially on reconnections,
which were not clearing old listeners. Listeners should all now be registered exactly
once at any given time.

Prior behavior for receiving list of producers was to re-create consumers for each one
while clearing the existing ones. This was unnecessarily resource-intensive. Consumers
are now created only if there isn't already one for that producer.

Fixed issue with transports not always being cleared on disconnect/reconnect, which
was causing some problems with creating new consumer on some quick reconnects.

Made hover-expansion of user A/V controls occur anywhere on the locationUser container.
Hover CSS just on the individual users left gaps between them that would cause everything
to shrink, which was annoying.


## References

closes #_insert number here_


## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [x] Unit & Integration tests passing via `npm run test`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
