### PR TITLE
Storage Provider no longer in Global Scope

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  'fail-zero': true,
+  failZero: false,
   parallel: true,
   spec: ['tests/**/*.test.ts'],
   require: [

--- a/packages/client-core/.mocharc.js
+++ b/packages/client-core/.mocharc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  'fail-zero': true,
+  failZero: false,
   parallel: true,
   spec: ['tests/**/*.test.*'],
   require: [

--- a/packages/client/.mocharc.js
+++ b/packages/client/.mocharc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  'fail-zero': true,
+  failZero: false,
   parallel: true,
   spec: ['tests/**/*.test.ts'],
   require: [

--- a/packages/editor/.mocharc.js
+++ b/packages/editor/.mocharc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  'fail-zero': true,
+  failZero: false,
   parallel: true,
   spec: ['**/*.test.ts'],
   require: [

--- a/packages/engine/.mocharc.js
+++ b/packages/engine/.mocharc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  'fail-zero': true,
+  failZero: false,
   parallel: false,
   spec: ['**/*.test.ts'],
   require: [

--- a/packages/engine/src/assets/classes/AssetLoader.ts
+++ b/packages/engine/src/assets/classes/AssetLoader.ts
@@ -18,7 +18,7 @@ import { isAbsolutePath } from '../../common/functions/isAbsolutePath'
 import { isClient } from '../../common/functions/isClient'
 import { Engine } from '../../ecs/classes/Engine'
 import { generateMeshBVH } from '../../scene/functions/bvhWorkerPool'
-import { DEFAULT_LOD_DISTANCES, LODS_REGEXP } from '../constants/LoaderConstants'
+import { LODS_REGEXP } from '../constants/LoaderConstants'
 import { AssetClass } from '../enum/AssetClass'
 import { AssetType } from '../enum/AssetType'
 import { createGLTFLoader } from '../functions/createGLTFLoader'
@@ -122,7 +122,7 @@ const handleLODs = (asset: Object3D): Object3D => {
     value[0].object.parent?.add(lod)
 
     value.forEach(({ level, object }) => {
-      lod.addLevel(object, AssetLoader.LOD_DISTANCES[level])
+      lod.addLevel(object, Engine.instance.currentWorld.LOD_DISTANCES[level])
     })
   })
 
@@ -291,7 +291,6 @@ const getFromCache = (url: string) => {
 export const AssetLoader = {
   Cache: new Map<string, any>(),
   loaders: new Map<number, any>(),
-  LOD_DISTANCES: DEFAULT_LOD_DISTANCES,
   processModelAsset,
   handleLODs,
   getAbsolutePath,

--- a/packages/engine/src/ecs/classes/World.ts
+++ b/packages/engine/src/ecs/classes/World.ts
@@ -5,6 +5,7 @@ import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
 import { UserId } from '@xrengine/common/src/interfaces/UserId'
 import { createHyperStore } from '@xrengine/hyperflux'
 
+import { DEFAULT_LOD_DISTANCES } from '../../assets/constants/LoaderConstants'
 import { AvatarComponent } from '../../avatar/components/AvatarComponent'
 import { SceneLoaderType } from '../../common/constants/PrefabFunctionType'
 import { isClient } from '../../common/functions/isClient'
@@ -227,6 +228,8 @@ export class World {
   get receptors() {
     return this.store.receptors
   }
+
+  LOD_DISTANCES = DEFAULT_LOD_DISTANCES
 
   /**
    * Execute systems on this world

--- a/packages/engine/src/scene/functions/loaders/RenderSettingsFunction.ts
+++ b/packages/engine/src/scene/functions/loaders/RenderSettingsFunction.ts
@@ -2,7 +2,6 @@ import { DirectionalLight, Light, LinearToneMapping, Mesh, PCFSoftShadowMap, Per
 
 import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
 
-import { AssetLoader } from '../../../assets/classes/AssetLoader'
 import { DEFAULT_LOD_DISTANCES } from '../../../assets/constants/LoaderConstants'
 import { CSM } from '../../../assets/csm/CSM'
 import {
@@ -54,7 +53,7 @@ export const updateRenderSetting: ComponentUpdateFunction = (
   const component = getComponent(entity, RenderSettingComponent)
 
   if (typeof properties.LODs !== 'undefined' && component.LODs)
-    AssetLoader.LOD_DISTANCES = { '0': component.LODs.x, '1': component.LODs.y, '2': component.LODs.z }
+    Engine.instance.currentWorld.LOD_DISTANCES = { '0': component.LODs.x, '1': component.LODs.y, '2': component.LODs.z }
 
   if (typeof properties.overrideRendererSettings !== 'undefined') {
     if (properties.overrideRendererSettings) {
@@ -186,7 +185,7 @@ export const resetEngineRenderer = (resetLODs = false, resetCSM = true) => {
   EngineRenderer.instance.renderer.toneMapping = LinearToneMapping
   EngineRenderer.instance.renderer.toneMappingExposure = 0.8
 
-  if (resetLODs) AssetLoader.LOD_DISTANCES = Object.assign({}, DEFAULT_LOD_DISTANCES)
+  if (resetLODs) Engine.instance.currentWorld.LOD_DISTANCES = Object.assign({}, DEFAULT_LOD_DISTANCES)
 
   if (resetCSM) disposeCSM()
 }

--- a/packages/engine/tests/mocha.env.js
+++ b/packages/engine/tests/mocha.env.js
@@ -1,4 +1,4 @@
-// process.env.APP_ENV = 'test'
+process.env.APP_ENV = 'test'
 process.env.TS_NODE_FILES = true
 process.env.TS_NODE_PROJECT = 'tsconfig.json'
 process.env.TS_NODE_COMPILER_OPTIONS = '{\"module\": \"commonjs\" }'

--- a/packages/gameserver/.mocharc.js
+++ b/packages/gameserver/.mocharc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  'fail-zero': true,
+  failZero: false,
   parallel: true,
   spec: ['tests/**/*.test.ts'],
   require: [

--- a/packages/hyperflux/.mocharc.js
+++ b/packages/hyperflux/.mocharc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  'fail-zero': true,
+  failZero: false,
   parallel: true,
   spec: ['**/*.test.ts', '**/*.test.tsx'],
   require: [

--- a/packages/projects/template-project/.mocharc.js
+++ b/packages/projects/template-project/.mocharc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  'fail-zero': false,
+  failZero: false,
   parallel: false,
   spec: ['tests/**/*.test.ts'],
   require: [

--- a/packages/server-core/.mocharc.js
+++ b/packages/server-core/.mocharc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  'fail-zero': true,
+  failZero: false,
   parallel: false,
   spec: ['**/*.test.ts'],
   require: [

--- a/packages/server-core/src/createApp.ts
+++ b/packages/server-core/src/createApp.ts
@@ -18,6 +18,8 @@ import sequelize from '@xrengine/server-core/src/sequelize'
 import services from '@xrengine/server-core/src/services'
 import authentication from '@xrengine/server-core/src/user/authentication'
 
+import { createDefaultStorageProvider } from './media/storageprovider/storageprovider'
+
 export const configureOpenAPI = () => (app: Application) => {
   app.configure(
     swagger({
@@ -115,6 +117,8 @@ export const serverPipe = pipe(configureOpenAPI(), configureSocketIO(), configur
 ) => Application
 
 export const createFeathersExpressApp = (configurationPipe = serverPipe): Application => {
+  createDefaultStorageProvider()
+
   const app = express(feathers()) as Application
   app.set('nextReadyEmitter', new EventEmitter())
 

--- a/packages/server-core/src/hooks/convert-video.ts
+++ b/packages/server-core/src/hooks/convert-video.ts
@@ -9,7 +9,7 @@ export {}
 // import AWS from 'aws-sdk';
 // import S3BlobStore from 's3-blob-store';
 // import { Application } from '../../../declarations';
-// import { useStorageProvider } from '../storage/storageprovider';
+// import { getStorageProvider } from '../storage/storageprovider';
 // import createStaticResource from './create-static-resource';
 //
 // import fs from 'fs';
@@ -81,7 +81,7 @@ export {}
 //             };
 //
 //             localContext.params.mimeType = mimetype;
-//             localContext.params.storageProvider = useStorageProvider();
+//             localContext.params.storageProvider = getStorageProvider();
 //             localContext.params.uploadPath = path.join('public',
 //               localContext.params.videoSource, fileId, 'video');
 //
@@ -149,7 +149,7 @@ export {}
 //     let thumbnailUploadResult: any;
 //     const localContext = _.cloneDeep(context);
 //
-//     localContext.params.storageProvider = useStorageProvider();
+//     localContext.params.storageProvider = getStorageProvider();
 //     localContext.params.uploadPath = path.join('public', localContext.params.videoSource, fileId, 'video');
 //
 //     if (localContext.data.metadata.thumbnailUrl != null && localContext.data.metadata.thumbnailUrl.length > 0) {
@@ -281,7 +281,7 @@ export {}
 //         if (!localContext.data.metadata.thumbnailUrl ||
 //             localContext.data.metadata.thumbnailUrl.length === 0) {
 //           console.log('Getting thumbnail from youtube-dl');
-//           localContext.params.storageProvider = useStorageProvider();
+//           localContext.params.storageProvider = getStorageProvider();
 //           localContext.params.uploadPath = s3Path;
 //           await fs.promises.rmdir(localFilePath, { recursive: true });
 //           await fs.promises.mkdir(localFilePath, { recursive: true });

--- a/packages/server-core/src/hooks/remove-previous-file.ts
+++ b/packages/server-core/src/hooks/remove-previous-file.ts
@@ -2,7 +2,7 @@ import { HookContext } from '@feathersjs/feathers'
 
 import config from '../appconfig'
 import logger from '../logger'
-import { useStorageProvider } from '../media/storageprovider/storageprovider'
+import { getStorageProvider } from '../media/storageprovider/storageprovider'
 import { Application } from './../../declarations.d'
 
 export default () => {
@@ -15,7 +15,7 @@ export default () => {
         },
         attributes: ['key']
       })
-      const storage = useStorageProvider().getStorage()
+      const storage = getStorageProvider().getStorage()
       // Remove previous thumbnail, no point in keeping it since client sends new thumbnail anyway
       storage.remove(
         {

--- a/packages/server-core/src/hooks/replace-thumbnail-link.ts
+++ b/packages/server-core/src/hooks/replace-thumbnail-link.ts
@@ -2,7 +2,7 @@ import { Hook, HookContext } from '@feathersjs/feathers'
 import _ from 'lodash'
 
 import config from '../appconfig'
-import { useStorageProvider } from '../media/storageprovider/storageprovider'
+import { getStorageProvider } from '../media/storageprovider/storageprovider'
 import uploadThumbnailLinkHook from './upload-thumbnail-link'
 
 export default (): Hook => {
@@ -34,7 +34,7 @@ export default (): Hook => {
         const bucketName = config.aws.s3.staticResourceBucket
         params.uploadPath = data.url.replace('https://s3.amazonaws.com/' + bucketName + '/', '')
         params.uploadPath = params.uploadPath.replace('/manifest.mpd', '')
-        params.storageProvider = useStorageProvider()
+        params.storageProvider = getStorageProvider()
         const contextClone = _.cloneDeep(context)
         const result = await (uploadThumbnailLinkHook() as any)(contextClone)
         data.metadata.thumbnailUrl = result.params.thumbnailUrl.replace(

--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -35,17 +35,13 @@ interface PatchParams {
  */
 
 export class FileBrowserService implements ServiceMethods<any> {
-  store: StorageProviderInterface
   app: Application
 
   constructor(app: Application) {
     this.app = app
   }
 
-  async setup(_app, _path: string): Promise<void> {
-    this.store = getStorageProvider()
-  }
-
+  async setup(app: Application, path: string) {}
   async find(_params?: Params) {}
 
   /**
@@ -55,8 +51,9 @@ export class FileBrowserService implements ServiceMethods<any> {
    * @returns
    */
   async get(directory: string, _params?: Params): Promise<FileContentType[]> {
+    const storageProvider = getStorageProvider()
     if (directory[0] === '/') directory = directory.slice(1) // remove leading slash
-    const result = await this.store.listFolderContent(directory)
+    const result = await storageProvider.listFolderContent(directory)
     return result
   }
 
@@ -67,12 +64,13 @@ export class FileBrowserService implements ServiceMethods<any> {
    * @returns
    */
   async create(directory) {
+    const storageProvider = getStorageProvider()
     if (directory[0] === '/') directory = directory.slice(1) // remove leading slash
 
     const parentPath = path.dirname(directory)
-    const key = await getIncrementalName(path.basename(directory), parentPath, this.store, true)
+    const key = await getIncrementalName(path.basename(directory), parentPath, storageProvider, true)
 
-    const result = await this.store.putObject({ Key: path.join(parentPath, key) } as StorageObjectInterface, {
+    const result = await storageProvider.putObject({ Key: path.join(parentPath, key) } as StorageObjectInterface, {
       isDirectory: true
     })
 
@@ -89,12 +87,13 @@ export class FileBrowserService implements ServiceMethods<any> {
    * @returns
    */
   async update(_id: NullableId, data: UpdateParamsType, _params?: Params) {
+    const storageProvider = getStorageProvider()
     const _oldPath = data.oldPath[0] === '/' ? data.oldPath.substring(1) : data.oldPath
     const _newPath = data.newPath[0] === '/' ? data.newPath.substring(1) : data.newPath
 
-    const isDirectory = await this.store.isDirectory(data.oldName, _oldPath)
-    const fileName = await getIncrementalName(data.newName, _newPath, this.store, isDirectory)
-    const result = await this.store.moveObject(data.oldName, fileName, _oldPath, _newPath, data.isCopy)
+    const isDirectory = await storageProvider.isDirectory(data.oldName, _oldPath)
+    const fileName = await getIncrementalName(data.newName, _newPath, storageProvider, isDirectory)
+    const result = await storageProvider.moveObject(data.oldName, fileName, _oldPath, _newPath, data.isCopy)
 
     const oldNamePath = path.join(projectsRootFolder, _oldPath, data.oldName)
     const newNamePath = path.join(projectsRootFolder, _newPath, fileName)
@@ -115,9 +114,10 @@ export class FileBrowserService implements ServiceMethods<any> {
    * @param params
    */
   async patch(_id: NullableId, data: PatchParams, params?: Params) {
+    const storageProvider = getStorageProvider()
     const key = path.join(data.path[0] === '/' ? data.path.substring(1) : data.path, data.fileName)
 
-    await this.store.putObject(
+    await storageProvider.putObject(
       {
         Key: key,
         Body: data.body,
@@ -130,7 +130,7 @@ export class FileBrowserService implements ServiceMethods<any> {
 
     fs.writeFileSync(path.join(projectsRootFolder, key), data.body)
 
-    return getCachedAsset(key, this.store.cacheDomain, params && params.provider == null)
+    return getCachedAsset(key, storageProvider.cacheDomain, params && params.provider == null)
   }
 
   /**
@@ -140,8 +140,9 @@ export class FileBrowserService implements ServiceMethods<any> {
    * @returns
    */
   async remove(key: string, _params?: Params) {
-    const dirs = await this.store.listObjects(key, true)
-    const result = await this.store.deleteResources([key, ...dirs.Contents.map((a) => a.Key)])
+    const storageProvider = getStorageProvider()
+    const dirs = await storageProvider.listObjects(key, true)
+    const result = await storageProvider.deleteResources([key, ...dirs.Contents.map((a) => a.Key)])
 
     const filePath = path.join(projectsRootFolder, key)
     if (fs.lstatSync(filePath).isDirectory()) {

--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -8,7 +8,7 @@ import { FileContentType } from '@xrengine/common/src/interfaces/FileContentType
 import { Application } from '../../../declarations'
 import { copyRecursiveSync, getIncrementalName } from '../FileUtil'
 import { getCachedAsset } from '../storageprovider/getCachedAsset'
-import { useStorageProvider } from '../storageprovider/storageprovider'
+import { getStorageProvider } from '../storageprovider/storageprovider'
 import { StorageObjectInterface, StorageProviderInterface } from '../storageprovider/storageprovider.interface'
 
 export const projectsRootFolder = path.join(appRootPath.path, 'packages/projects')
@@ -43,7 +43,7 @@ export class FileBrowserService implements ServiceMethods<any> {
   }
 
   async setup(_app, _path: string): Promise<void> {
-    this.store = useStorageProvider()
+    this.store = getStorageProvider()
   }
 
   async find(_params?: Params) {}

--- a/packages/server-core/src/media/file-browser/file-browser.test.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.test.ts
@@ -5,6 +5,7 @@ import path from 'path/posix'
 import { Application } from '../../../declarations'
 import { createFeathersExpressApp } from '../../createApp'
 import LocalStorage from '../storageprovider/local.storage'
+import { getStorageProvider } from '../storageprovider/storageprovider'
 import { projectsRootFolder } from './file-browser.class'
 
 const TEST_PROJECT = 'test-project'
@@ -18,7 +19,7 @@ describe('file browser service', () => {
     app = createFeathersExpressApp()
     await app.setup()
 
-    STORAGE_ROOT = (app.service('file-browser').store as LocalStorage).PATH_PREFIX
+    STORAGE_ROOT = (getStorageProvider() as LocalStorage).PATH_PREFIX
     STORAGE_PATH = path.join(STORAGE_ROOT, TEST_PROJECT)
 
     if (fs.existsSync(PROJECT_PATH)) fs.rmSync(PROJECT_PATH, { force: true, recursive: true })
@@ -279,10 +280,7 @@ describe('file browser service', () => {
       contentType: 'any'
     })
 
-    assert.equal(
-      result,
-      `https://${(app.service('file-browser').store as LocalStorage).cacheDomain}/${path.join(TEST_PROJECT, fileName)}`
-    )
+    assert.equal(result, `https://${getStorageProvider().cacheDomain}/${path.join(TEST_PROJECT, fileName)}`)
 
     assert(fs.existsSync(filePath))
     assert(fs.existsSync(fileStoragePath))

--- a/packages/server-core/src/media/storageprovider/storageProviderUtils.ts
+++ b/packages/server-core/src/media/storageprovider/storageProviderUtils.ts
@@ -1,9 +1,8 @@
 import logger from '../../logger'
-import { useStorageProvider } from './storageprovider'
-
-const storageProvider = useStorageProvider()
+import { getStorageProvider } from './storageprovider'
 
 export const getFileKeysRecursive = async (path: string) => {
+  const storageProvider = getStorageProvider()
   const files: string[] = []
   try {
     const response = await storageProvider.listObjects(path, true)

--- a/packages/server-core/src/media/storageprovider/storageprovider.ts
+++ b/packages/server-core/src/media/storageprovider/storageprovider.ts
@@ -3,9 +3,24 @@ import LocalStorage from './local.storage'
 import S3Storage from './s3.storage'
 import { StorageProviderInterface } from './storageprovider.interface'
 
-const provider: StorageProviderInterface =
-  config.server.storageProvider !== 'aws' && config.server.storageProvider !== 'ipfs'
-    ? new LocalStorage()
-    : new S3Storage()
+const providers = {} as { [constructor: string]: StorageProviderInterface }
 
-export const useStorageProvider = () => provider
+export const getStorageProvider = (provider = 'default') => providers[provider]
+
+interface StorageProviderConstructor {
+  new (): StorageProviderInterface
+}
+
+export const createStorageProvider = (constructor: StorageProviderConstructor) => {
+  const storageProvider = new constructor()
+  providers[constructor.name] = storageProvider
+  return storageProvider
+}
+
+export const createDefaultStorageProvider = () => {
+  const StorageProvider =
+    config.server.storageProvider !== 'aws' && config.server.storageProvider !== 'ipfs' ? LocalStorage : S3Storage
+  const provider = createStorageProvider(StorageProvider)
+  providers['default'] = provider
+  return provider
+}

--- a/packages/server-core/src/media/upload-media/upload-asset.service.ts
+++ b/packages/server-core/src/media/upload-media/upload-asset.service.ts
@@ -9,7 +9,7 @@ import restrictUserRole from '../../hooks/restrict-user-role'
 import logger from '../../logger'
 import { AvatarUploadArguments } from '../../user/avatar/avatar-helper'
 import { getCachedAsset } from '../storageprovider/getCachedAsset'
-import { useStorageProvider } from '../storageprovider/storageprovider'
+import { getStorageProvider } from '../storageprovider/storageprovider'
 import hooks from './upload-asset.hooks'
 
 const multipartMiddleware = multer({ limits: { fieldSize: Infinity } })
@@ -25,7 +25,7 @@ export const addGenericAssetToS3AndStaticResources = async (
   file: Buffer,
   args: AdminAssetUploadArgumentsType
 ) => {
-  const provider = useStorageProvider()
+  const provider = getStorageProvider()
   // make userId optional and safe for feathers create
   const userIdQuery = args.userId ? { userId: args.userId } : {}
   const key = args.key

--- a/packages/server-core/src/projects/project/downloadProjects.ts
+++ b/packages/server-core/src/projects/project/downloadProjects.ts
@@ -4,13 +4,12 @@ import fs from 'fs'
 import path from 'path'
 
 import logger from '../../logger'
-import { useStorageProvider } from '../../media/storageprovider/storageprovider'
+import { getStorageProvider } from '../../media/storageprovider/storageprovider'
 import { getFileKeysRecursive } from '../../media/storageprovider/storageProviderUtils'
 import { deleteFolderRecursive, writeFileSyncRecursive } from '../../util/fsHelperFunctions'
 
-const storageProvider = useStorageProvider()
-
 export const download = async (projectName) => {
+  const storageProvider = getStorageProvider()
   try {
     logger.info(`[ProjectLoader]: Installing project "${projectName}"...`)
     const files = await getFileKeysRecursive(`projects/${projectName}/`)

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -6,12 +6,12 @@ import { ProjectConfigInterface, ProjectEventHooks } from '@xrengine/projects/Pr
 import { Application } from '../../../declarations'
 import config from '../../appconfig'
 import logger from '../../logger'
-import { useStorageProvider } from '../../media/storageprovider/storageprovider'
+import { getStorageProvider } from '../../media/storageprovider/storageprovider'
 
 export const retriggerBuilderService = async (app: Application) => {
   try {
     // invalidate cache for all installed projects
-    await useStorageProvider().createInvalidation(['projects*'])
+    await getStorageProvider().createInvalidation(['projects*'])
   } catch (e) {
     logger.error(e, `[Project Rebuild]: Failed to invalidate cache with error: ${e.message}`)
   }

--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -12,7 +12,7 @@ import { Application } from '../../../declarations'
 import config from '../../appconfig'
 import logger from '../../logger'
 import { getCachedAsset } from '../../media/storageprovider/getCachedAsset'
-import { useStorageProvider } from '../../media/storageprovider/storageprovider'
+import { getStorageProvider } from '../../media/storageprovider/storageprovider'
 import { getFileKeysRecursive } from '../../media/storageprovider/storageProviderUtils'
 import { cleanString } from '../../util/cleanString'
 import { getContentType } from '../../util/fileUtils'
@@ -37,11 +37,11 @@ const getRemoteURLFromGitData = (project) => {
   return data.remote.origin.url
 }
 
-const storageProvider = useStorageProvider()
 export const getStorageProviderPath = (projectName: string) =>
-  `https://${storageProvider.cacheDomain}/projects/${projectName}/`
+  `https://${getStorageProvider().cacheDomain}/projects/${projectName}/`
 
 export const deleteProjectFilesInStorageProvider = async (projectName: string) => {
+  const storageProvider = getStorageProvider()
   try {
     const existingFiles = await getFileKeysRecursive(`projects/${projectName}`)
     if (existingFiles.length) {
@@ -60,6 +60,7 @@ export const deleteProjectFilesInStorageProvider = async (projectName: string) =
  * @param projectName
  */
 export const uploadLocalProjectToProvider = async (projectName, remove = true) => {
+  const storageProvider = getStorageProvider()
   // remove exiting storage provider files
   logger.info(`uploadLocalProjectToProvider for project "${projectName}" started at "${new Date()}".`)
   if (remove) {

--- a/packages/server-core/src/projects/project/project.service.ts
+++ b/packages/server-core/src/projects/project/project.service.ts
@@ -2,7 +2,7 @@ import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role
 
 import { Application } from '../../../declarations'
 import authenticate from '../../hooks/authenticate'
-import { useStorageProvider } from '../../media/storageprovider/storageprovider'
+import { getStorageProvider } from '../../media/storageprovider/storageprovider'
 import { retriggerBuilderService } from './project-helper'
 import { Project } from './project.class'
 import projectDocs from './project.docs'
@@ -45,7 +45,7 @@ export default (app: Application): void => {
   app.use('project-invalidate', {
     patch: async ({ projectName }, params) => {
       if (projectName) {
-        return await useStorageProvider().createInvalidation([`projects/${projectName}*`])
+        return await getStorageProvider().createInvalidation([`projects/${projectName}*`])
       }
     }
   })

--- a/packages/server-core/src/projects/scene/scene-parser.ts
+++ b/packages/server-core/src/projects/scene/scene-parser.ts
@@ -1,5 +1,5 @@
 import { PortalDetail } from '@xrengine/common/src/interfaces/PortalInterface'
-import { SceneData, SceneJson } from '@xrengine/common/src/interfaces/SceneInterface'
+import { SceneData } from '@xrengine/common/src/interfaces/SceneInterface'
 import { isDev } from '@xrengine/common/src/utils/isDev'
 
 import config from '../../appconfig'

--- a/packages/server-core/src/projects/scene/scene-schema-parse.test.ts
+++ b/packages/server-core/src/projects/scene/scene-schema-parse.test.ts
@@ -1,7 +1,7 @@
 import assert from 'assert'
 import _ from 'lodash'
 
-import { useStorageProvider } from '../../media/storageprovider/storageprovider'
+import { createDefaultStorageProvider, getStorageProvider } from '../../media/storageprovider/storageprovider'
 import {
   cleanSceneDataCacheURLs,
   corsPath,
@@ -11,8 +11,8 @@ import {
 } from './scene-parser'
 
 describe('Scene Helper Functions', () => {
-  const storageProvider = useStorageProvider()
   describe('should replace cache domain', () => {
+    const storageProvider = createDefaultStorageProvider()
     const mockValue = `abcdef2144536`
     const mockValue2 = `08723ikjbolicujhc0asc`
 
@@ -53,11 +53,13 @@ describe('Scene Helper Functions', () => {
     }
 
     it('should parse saved data', async function () {
+      const storageProvider = getStorageProvider()
       const parsedData = parseSceneDataCacheURLs(_.cloneDeep(savedMockData) as any, storageProvider.cacheDomain)
       assert.deepStrictEqual(parsedMockData, parsedData)
     })
 
     it('should unparse parsed data', async function () {
+      const storageProvider = getStorageProvider()
       const unparsedData = cleanSceneDataCacheURLs(_.cloneDeep(parsedMockData) as any, storageProvider.cacheDomain)
       assert.deepStrictEqual(savedMockData, unparsedData)
     })

--- a/packages/server-core/src/projects/scene/scene.class.ts
+++ b/packages/server-core/src/projects/scene/scene.class.ts
@@ -10,14 +10,14 @@ import defaultSceneSeed from '@xrengine/projects/default-project/default.scene.j
 import { Application } from '../../../declarations'
 import logger from '../../logger'
 import { getCachedAsset } from '../../media/storageprovider/getCachedAsset'
-import { useStorageProvider } from '../../media/storageprovider/storageprovider'
+import { getStorageProvider } from '../../media/storageprovider/storageprovider'
 import { cleanString } from '../../util/cleanString'
 import { cleanSceneDataCacheURLs, parseSceneDataCacheURLs } from './scene-parser'
 
-const storageProvider = useStorageProvider()
 const NEW_SCENE_NAME = 'New-Scene'
 
 export const getSceneData = async (projectName, sceneName, metadataOnly, internal, downloadIfNotPresent = false) => {
+  const storageProvider = getStorageProvider()
   const scenePath = `projects/${projectName}/${sceneName}.scene.json`
   const thumbnailPath = `projects/${projectName}/${sceneName}.thumbnail.jpeg`
 
@@ -100,6 +100,8 @@ export class Scene implements ServiceMethods<any> {
     const { projectName } = data
     logger.info('[scene.create]: ' + projectName)
 
+    const storageProvider = getStorageProvider()
+
     const project = await this.app.service('project').get(projectName, params)
     if (!project.data) throw new Error(`No project named ${projectName} exists`)
 
@@ -147,6 +149,8 @@ export class Scene implements ServiceMethods<any> {
 
   async patch(id: NullableId, data: RenameParams, params?: Params): Promise<any> {
     const { newSceneName, oldSceneName, projectName } = data
+
+    const storageProvider = getStorageProvider()
 
     const project = await this.app.service('project').get(projectName, params)
     if (!project.data) throw new Error(`No project named ${projectName} exists`)
@@ -198,6 +202,8 @@ export class Scene implements ServiceMethods<any> {
     const { sceneName, sceneData, thumbnailBuffer } = data
     logger.info('[scene.update]: ', projectName, data)
 
+    const storageProvider = getStorageProvider()
+
     const project = await this.app.service('project').get(projectName, params)
     if (!project.data) throw new Error(`No project named ${projectName} exists`)
 
@@ -245,6 +251,8 @@ export class Scene implements ServiceMethods<any> {
 
   // @ts-ignore
   async remove({ projectName, sceneName }, params?: Params): Promise<any> {
+    const storageProvider = getStorageProvider()
+
     const name = cleanString(sceneName)
 
     const project = await this.app.service('project').get(projectName, params)

--- a/packages/server-core/src/projects/scene/scene.service.ts
+++ b/packages/server-core/src/projects/scene/scene.service.ts
@@ -4,13 +4,11 @@ import { SceneData } from '@xrengine/common/src/interfaces/SceneInterface'
 
 import { Application } from '../../../declarations'
 import logger from '../../logger'
-import { useStorageProvider } from '../../media/storageprovider/storageprovider'
+import { getStorageProvider } from '../../media/storageprovider/storageprovider'
 import { getAllPortals, getCubemapBake, getPortal } from './scene-helper'
 import { getSceneData, Scene } from './scene.class'
 import projectDocs from './scene.docs'
 import hooks from './scene.hooks'
-
-const storageProvider = useStorageProvider()
 
 declare module '@xrengine/common/declarations' {
   interface ServiceTypes {
@@ -35,6 +33,7 @@ type GetScenesArgsType = {
 
 export const getScenesForProject = (app: Application) => {
   return async function (args: GetScenesArgsType, params?: Params): Promise<{ data: SceneData[] }> {
+    const storageProvider = getStorageProvider()
     const { projectName, metadataOnly, internal } = args
     try {
       const project = await app.service('project').get(projectName, params)

--- a/packages/server-core/src/projects/scene/scene.test.ts
+++ b/packages/server-core/src/projects/scene/scene.test.ts
@@ -7,12 +7,9 @@ import defaultSceneSeed from '@xrengine/projects/default-project/default.scene.j
 
 import { Application } from '../../../declarations'
 import { createFeathersExpressApp } from '../../createApp'
-import { useStorageProvider } from '../../media/storageprovider/storageprovider'
+import { getStorageProvider } from '../../media/storageprovider/storageprovider'
 import { deleteFolderRecursive } from '../../util/fsHelperFunctions'
 import { parseSceneDataCacheURLs } from './scene-parser'
-
-const storageProvider = useStorageProvider()
-const parsedData = parseSceneDataCacheURLs(_.cloneDeep(defaultSceneSeed) as any, storageProvider.cacheDomain)
 
 const defaultProjectName = 'default-project'
 const defaultSceneName = 'default'
@@ -25,10 +22,14 @@ const params = { isInternal: true }
 
 describe('scene.test', () => {
   let app: Application
+  let parsedData
+
   before(() => {
     const projectDir = path.resolve(appRootPath.path, `packages/projects/projects/${newProjectName}/`)
     deleteFolderRecursive(projectDir)
     app = createFeathersExpressApp()
+    const storageProvider = getStorageProvider()
+    parsedData = parseSceneDataCacheURLs(_.cloneDeep(defaultSceneSeed) as any, storageProvider.cacheDomain)
   })
 
   // wait for initial project loading to occur in CI/CD

--- a/packages/server-core/src/user/avatar/avatar-helper.ts
+++ b/packages/server-core/src/user/avatar/avatar-helper.ts
@@ -7,10 +7,7 @@ import { CommonKnownContentTypes } from '@xrengine/common/src/utils/CommonKnownC
 
 import { Application } from '../../../declarations'
 import logger from '../../logger'
-import { useStorageProvider } from '../../media/storageprovider/storageprovider'
 import { addGenericAssetToS3AndStaticResources } from '../../media/upload-media/upload-asset.service'
-
-const provider = useStorageProvider()
 
 export type AvatarUploadArguments = {
   avatar: Buffer


### PR DESCRIPTION
## Summary

The storage provider is being created in global scope, which makes it hard to override in tests. This also allows us to have better clarity over which storage provider will be in use when we move to support multiple storage providers.


## References

closes #_insert number here_


## Checklist
- [ ] CI/CD checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Typescript passing via `npm run check-errors`
  - [ ] Unit & Integration tests passing via `npm run test`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
