### PR TITLE
Fixes for recent changes to how storage providers work.

### DIFF
--- a/packages/server-core/src/projects/project/downloadProjects.ts
+++ b/packages/server-core/src/projects/project/downloadProjects.ts
@@ -23,13 +23,15 @@ export const download = async (projectName) => {
 
     await Promise.all(
       files.map(async (filePath) => {
-        logger.info(`[ProjectLoader]: - downloading "${filePath}"`)
-        const fileResult = await storageProvider.getObject(filePath)
+        if (path.parse(filePath).ext.length > 0) {
+          logger.info(`[ProjectLoader]: - downloading "${filePath}"`)
+          const fileResult = await storageProvider.getObject(filePath)
 
-        if (fileResult.Body.length === 0) {
-          logger.info(`[ProjectLoader]: WARNING file "${filePath}" is empty`)
+          if (fileResult.Body.length === 0) {
+            logger.info(`[ProjectLoader]: WARNING file "${filePath}" is empty`)
+          }
+          writeFileSyncRecursive(path.join(appRootPath.path, 'packages/projects', filePath), fileResult.Body)
         }
-        writeFileSyncRecursive(path.join(appRootPath.path, 'packages/projects', filePath), fileResult.Body)
       })
     )
 

--- a/scripts/install-projects.js
+++ b/scripts/install-projects.js
@@ -1,4 +1,5 @@
 import { download } from "@xrengine/server-core/src/projects/project/downloadProjects";
+import { createDefaultStorageProvider } from "@xrengine/server-core/src/media/storageprovider/storageprovider";
 import dotenv from 'dotenv';
 import Sequelize from 'sequelize';
 import path from "path";
@@ -22,6 +23,7 @@ db.url = process.env.MYSQL_URL ??
 
 async function installAllProjects() {
   try {
+    createDefaultStorageProvider()
     const localProjectDirectory = path.join(appRootPath.path, 'packages/projects/projects')
     if (!fs.existsSync(localProjectDirectory)) fs.mkdirSync(localProjectDirectory, { recursive: true })
     logger.info('running installAllProjects')


### PR DESCRIPTION
## Summary

install-projects.js needs to call createDefaultStorageProvider(), since the provider is no longer set up automatically.

listObjects in local.storage.ts needs to use `**/*.*` to avoid returning directory paths, which cannot have read operations called on them.


## References

closes #_insert number here_


## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [x] Unit & Integration tests passing via `npm run test`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
