### PR TITLE
Cleanup time conventions and world time origins

### DIFF
--- a/packages/client-core/src/components/World/OfflineLocation.tsx
+++ b/packages/client-core/src/components/World/OfflineLocation.tsx
@@ -38,8 +38,8 @@ export const OfflineLocation = () => {
 
       const avatarSpawnPose = SpawnPoints.instance.getRandomSpawnPoint()
       receiveJoinWorld({
-        elapsedTime: 0,
-        clockTime: Date.now(),
+        highResTimeOrigin: performance.timeOrigin,
+        worldStartTime: performance.now(),
         client: {
           index: 1,
           name: authState.user.name.value

--- a/packages/engine/src/avatar/AnimationSystem.ts
+++ b/packages/engine/src/avatar/AnimationSystem.ts
@@ -52,7 +52,7 @@ export default async function AnimationSystem(world: World) {
   await AnimationManager.instance.loadDefaultAnimations()
 
   return () => {
-    const { delta } = world
+    const { deltaSeconds: delta } = world
 
     for (const entity of desiredTransformQuery(world)) {
       const desiredTransform = getComponent(entity, DesiredTransformComponent)

--- a/packages/engine/src/avatar/AvatarInputSchema.ts
+++ b/packages/engine/src/avatar/AvatarInputSchema.ts
@@ -282,7 +282,7 @@ export const setCameraRotation: InputBehaviorType = (
   inputKey: InputAlias,
   inputValue: InputValue
 ): void => {
-  const { delta } = useWorld()
+  const { deltaSeconds: delta } = useWorld()
   const followComponent = getComponent(entity, FollowCameraComponent)
 
   switch (inputKey) {

--- a/packages/engine/src/avatar/AvatarLoadingSystem.ts
+++ b/packages/engine/src/avatar/AvatarLoadingSystem.ts
@@ -30,7 +30,7 @@ export default async function AvatarLoadingSystem(world: World) {
   const dissolveQuery = defineQuery([AvatarComponent, Object3DComponent, AvatarDissolveComponent])
 
   return () => {
-    const { delta } = world
+    const { deltaSeconds: delta } = world
 
     for (const entity of growQuery.enter(world)) {
       const object = getComponent(entity, Object3DComponent).value

--- a/packages/engine/src/avatar/functions/moveAvatar.test.ts
+++ b/packages/engine/src/avatar/functions/moveAvatar.test.ts
@@ -107,7 +107,7 @@ describe('moveAvatar function tests', () => {
     const world = Engine.instance.currentWorld
     /* mock */
     world.physics.timeScale = 1
-    world.fixedDelta = 1000 / 60
+    world.fixedDeltaSeconds = 1000 / 60
 
     const entity = createMovingAvatar(world)
 
@@ -133,7 +133,7 @@ describe('moveAvatar function tests', () => {
     const world = Engine.instance.currentWorld
     /* mock */
     world.physics.timeScale = 1
-    world.fixedDelta = 1000 / 120
+    world.fixedDeltaSeconds = 1000 / 120
 
     const entity = createMovingAvatar(world)
 
@@ -159,7 +159,7 @@ describe('moveAvatar function tests', () => {
     const world = Engine.instance.currentWorld
     /* mock */
     world.physics.timeScale = 1 / 2
-    world.fixedDelta = 1000 / 60
+    world.fixedDeltaSeconds = 1000 / 60
 
     const entity = createMovingAvatar(world)
 
@@ -185,7 +185,7 @@ describe('moveAvatar function tests', () => {
     const world = Engine.instance.currentWorld
     /* mock */
     world.physics.timeScale = 1
-    world.fixedDelta = 1000 / 60
+    world.fixedDeltaSeconds = 1000 / 60
 
     const entity = createMovingAvatar(world)
 

--- a/packages/engine/src/avatar/functions/moveAvatar.ts
+++ b/packages/engine/src/avatar/functions/moveAvatar.ts
@@ -34,7 +34,7 @@ export const avatarCameraOffset = new Vector3(0, 0.14, 0.1)
  */
 export const moveAvatar = (world: World, entity: Entity, camera: PerspectiveCamera | OrthographicCamera): any => {
   const {
-    fixedDelta,
+    fixedDeltaSeconds: fixedDelta,
     physics: { timeScale }
   } = world
 
@@ -258,7 +258,7 @@ export const alignXRCameraRotationWithAvatar = (entity: Entity, camera: Perspect
 
 const moveAvatarController = (world: World, entity: Entity, displacement: any) => {
   const {
-    fixedDelta,
+    fixedDeltaSeconds: fixedDelta,
     physics: { timeScale }
   } = world
 

--- a/packages/engine/src/camera/systems/CameraSystem.ts
+++ b/packages/engine/src/camera/systems/CameraSystem.ts
@@ -264,7 +264,7 @@ export default async function CameraSystem(world: World) {
   const targetCameraRotationQuery = defineQuery([FollowCameraComponent, TargetCameraRotationComponent])
   let cameraInitialized = Engine.instance.isEditor
   return () => {
-    const { delta } = world
+    const { deltaSeconds: delta } = world
     if (getEngineState().sceneLoaded.value && !cameraInitialized) {
       initializeCameraComponent(world)
       cameraInitialized = true

--- a/packages/engine/src/ecs/classes/Engine.ts
+++ b/packages/engine/src/ecs/classes/Engine.ts
@@ -3,6 +3,7 @@ import { AudioListener, Object3D, OrthographicCamera, PerspectiveCamera, Scene, 
 import type { UserId } from '@xrengine/common/src/interfaces/UserId'
 import { createHyperStore } from '@xrengine/hyperflux'
 
+import { nowMilliseconds } from '../../common/functions/nowMilliseconds'
 import type { InputValue } from '../../input/interfaces/InputValue'
 import type { World } from '../classes/World'
 import type { SystemModuleType } from '../functions/SystemFunctions'
@@ -20,10 +21,13 @@ export class Engine {
   store = createHyperStore({
     name: 'ENGINE',
     getDispatchId: () => 'engine',
-    getDispatchTime: () => Engine.instance.elapsedTime
+    getDispatchTime: () => Engine.instance.frameTime
   })
 
-  elapsedTime = 0
+  /**
+   * Current frame timestamp, relative to performance.timeOrigin
+   */
+  frameTime = nowMilliseconds()
 
   engineTimer: { start: Function; stop: Function; clear: Function } = null!
 

--- a/packages/engine/src/ecs/functions/FixedPipelineSystem.test.ts
+++ b/packages/engine/src/ecs/functions/FixedPipelineSystem.test.ts
@@ -40,18 +40,18 @@ describe('FixedPipelineSystem', () => {
     const world = Engine.instance.currentWorld
     const mockState = getState(world.store, MockState)
 
-    assert.equal(world.elapsedTime, 0)
-    assert.equal(world.fixedElapsedTime, 0)
+    assert.equal(world.elapsedSeconds, 0)
+    assert.equal(world.fixedElapsedSeconds, 0)
     assert.equal(world.fixedTick, 0)
     assert.equal(mockState.count.value, 0)
 
     const ticks = 3
-    const delta = ticks / 60
-    world.execute(delta)
-    assert.equal(world.elapsedTime, delta)
-    assert.equal(world.fixedElapsedTime, delta)
+    const deltaSeconds = ticks / 60
+    world.execute(world.startTime + 1000 * deltaSeconds)
+    assert.equal(world.elapsedSeconds, deltaSeconds)
+    assert.equal(world.fixedElapsedSeconds, deltaSeconds)
     assert.equal(world.fixedTick, ticks)
-    assert.equal(world.fixedDelta, 1 / 60)
+    assert.equal(world.fixedDeltaSeconds, 1 / 60)
     assert.equal(mockState.count.value, ticks)
   })
 
@@ -70,15 +70,16 @@ describe('FixedPipelineSystem', () => {
     const world = Engine.instance.currentWorld
     const mockState = getState(world.store, MockState)
 
-    assert.equal(world.elapsedTime, 0)
-    assert.equal(world.fixedElapsedTime, 0)
+    world.startTime = 0
+    assert.equal(world.elapsedSeconds, 0)
+    assert.equal(world.fixedElapsedSeconds, 0)
     assert.equal(world.fixedTick, 0)
     assert.equal(mockState.count.value, 0)
 
-    const delta = 1000
-    world.execute(delta)
-    assert.equal(world.elapsedTime, delta)
-    assert.equal(world.fixedElapsedTime, delta)
+    const deltaSeconds = 1000
+    world.execute(1000 * deltaSeconds)
+    assert.equal(world.elapsedSeconds, deltaSeconds)
+    assert.equal(world.fixedElapsedSeconds, deltaSeconds)
     assert.equal(world.fixedTick, 60000)
     assert((mockState.count.value * 1) / 60 < 5)
   })

--- a/packages/engine/src/ecs/functions/FixedPipelineSystem.ts
+++ b/packages/engine/src/ecs/functions/FixedPipelineSystem.ts
@@ -13,7 +13,7 @@ export default async function FixedPipelineSystem(world: World, args: { tickRate
   const limit = timestep * 2000
   const updatesLimit = args.tickRate
 
-  world.fixedDelta = timestep
+  world.fixedDeltaSeconds = timestep
 
   // If the difference between fixedElapsedTime and elapsedTime becomes too large,
   // we should simply skip ahead.
@@ -24,26 +24,26 @@ export default async function FixedPipelineSystem(world: World, args: { tickRate
     let timeUsed = 0
     let updatesCount = 0
 
-    let accumulator = world.elapsedTime - world.fixedElapsedTime
+    let accumulator = world.elapsedSeconds - world.fixedElapsedSeconds
 
     let accumulatorDepleted = accumulator < timestep
     let timeout = timeUsed > limit
     let updatesLimitReached = updatesCount > updatesLimit
 
     while (!accumulatorDepleted && !timeout && !updatesLimitReached) {
-      world.fixedElapsedTime += world.fixedDelta
-      world.fixedTick = Math.floor(world.fixedElapsedTime / world.fixedDelta)
+      world.fixedElapsedSeconds += world.fixedDeltaSeconds
+      world.fixedTick = Math.floor(world.fixedElapsedSeconds / world.fixedDeltaSeconds)
       getEngineState().fixedTick.set(world.fixedTick)
 
       for (const s of world.pipelines[SystemUpdateType.FIXED_EARLY]) s.execute()
       for (const s of world.pipelines[SystemUpdateType.FIXED]) s.execute()
       for (const s of world.pipelines[SystemUpdateType.FIXED_LATE]) s.execute()
 
-      accumulator -= world.fixedDelta
+      accumulator -= world.fixedDeltaSeconds
       ++updatesCount
 
       timeUsed = nowMilliseconds() - start
-      accumulatorDepleted = accumulator < world.fixedDelta
+      accumulatorDepleted = accumulator < world.fixedDeltaSeconds
       timeout = timeUsed > limit
       updatesLimitReached = updatesCount >= updatesLimit
     }
@@ -52,8 +52,8 @@ export default async function FixedPipelineSystem(world: World, args: { tickRate
       console.warn(
         'FixedPipelineSystem: update limit reached, skipping world.fixedElapsedTime ahead to catch up with world.elapsedTime'
       )
-      world.fixedElapsedTime = world.elapsedTime
-      world.fixedTick = Math.floor(world.fixedElapsedTime / world.fixedDelta)
+      world.fixedElapsedSeconds = world.elapsedSeconds
+      world.fixedTick = Math.floor(world.fixedElapsedSeconds / world.fixedDeltaSeconds)
     }
   }
 }

--- a/packages/engine/src/initializeEngine.ts
+++ b/packages/engine/src/initializeEngine.ts
@@ -101,11 +101,11 @@ export const initializeNode = () => {
   // node currently does not need to initialize anything
 }
 
-const executeWorlds = (delta, elapsedTime) => {
-  Engine.instance.elapsedTime = elapsedTime
+const executeWorlds = (elapsedTime) => {
+  Engine.instance.frameTime = elapsedTime
   ActionFunctions.applyIncomingActions(Engine.instance.store)
   for (const world of Engine.instance.worlds) {
-    world.execute(delta)
+    world.execute(elapsedTime)
   }
 }
 

--- a/packages/engine/src/interaction/functions/interactUI.ts
+++ b/packages/engine/src/interaction/functions/interactUI.ts
@@ -220,7 +220,7 @@ export const updateInteractUI = (modelEntity: Entity, xrui: ReturnType<typeof cr
   }
 
   if (nextMode !== currentMode) {
-    transitionStartTime.set(modelEntity, world.elapsedTime)
+    transitionStartTime.set(modelEntity, world.elapsedSeconds)
     xrui.state.mode.set(nextMode)
     if (nextMode === 'interacting') {
       Engine.instance.camera.attach(uiContainer)
@@ -238,7 +238,7 @@ export const updateInteractUI = (modelEntity: Entity, xrui: ReturnType<typeof cr
   }
 
   const transitionStart = transitionStartTime.get(modelEntity)
-  const transitionElapsed = transitionStart ? world.elapsedTime - transitionStart : 0
+  const transitionElapsed = transitionStart ? world.elapsedSeconds - transitionStart : 0
   const alpha = Math.min(transitionElapsed / TRANSITION_DURATION, 1)
 
   const root = uiContainer.rootLayer
@@ -316,7 +316,7 @@ export const updateInteractUI = (modelEntity: Entity, xrui: ReturnType<typeof cr
     }
 
     const modelTargetPosition = _vect.copy(anchoredPosition)
-    modelTargetPosition.y += MODEL_ELEVATION_ACTIVE + Math.sin(world.elapsedTime) * 0.05
+    modelTargetPosition.y += MODEL_ELEVATION_ACTIVE + Math.sin(world.elapsedSeconds) * 0.05
     modelGroup.position.lerp(modelTargetPosition, alpha)
     modelGroup.quaternion.slerp(anchoredRotation, alpha)
     modelGroup.scale.lerp(MODEL_SCALE_ACTIVE, alpha)

--- a/packages/engine/src/networking/functions/NetworkActionReceptor.ts
+++ b/packages/engine/src/networking/functions/NetworkActionReceptor.ts
@@ -200,10 +200,6 @@ const setUserTyping = (action) => {
 const createNetworkActionReceptor = (world: World) =>
   addActionReceptor(world.store, function NetworkActionReceptor(action) {
     matches(action)
-      .when(NetworkWorldAction.timeSync.matches, ({ elapsedTime, clockTime }) => {
-        // todo: smooth out time sync over multiple frames
-        world.elapsedTime = elapsedTime + (Date.now() - clockTime) / 1000
-      })
       .when(NetworkWorldAction.createClient.matches, ({ $from, name, index: userIndex }) =>
         addClient(world, $from, name, userIndex)
       )

--- a/packages/engine/src/networking/functions/NetworkWorldAction.ts
+++ b/packages/engine/src/networking/functions/NetworkWorldAction.ts
@@ -29,16 +29,6 @@ export class NetworkWorldAction {
     $to: 'others'
   })
 
-  static timeSync = defineAction({
-    store: 'WORLD',
-    type: 'network.TIME_SYNC',
-    elapsedTime: matchesWithDefault(matches.number, () => Engine.instance.currentWorld.elapsedTime),
-    clockTime: matchesWithDefault(matches.number, () => Date.now()),
-    $time: -1,
-    $from: matchesHost,
-    $to: 'others'
-  })
-
   static setXRMode = defineAction({
     store: 'WORLD',
     type: 'network.SET_XR_MODE',

--- a/packages/engine/src/networking/systems/OutgoingActionSystem.ts
+++ b/packages/engine/src/networking/systems/OutgoingActionSystem.ts
@@ -20,12 +20,7 @@ const sendOutgoingActions = (world: World) => {
 }
 
 export default async function OutgoingActionSystem(world: World) {
-  let lastTickSync = 0
   return () => {
-    if (world.isHosting && world.fixedTick - lastTickSync > 60 * 60 * 2) {
-      dispatchAction(world.store, NetworkWorldAction.timeSync({}))
-      lastTickSync = world.fixedTick
-    }
     sendOutgoingActions(world)
   }
 }

--- a/packages/engine/src/particles/systems/ParticleSystem.ts
+++ b/packages/engine/src/particles/systems/ParticleSystem.ts
@@ -6,7 +6,7 @@ export default async function ParticleSystem(world: World) {
   const emitterQuery = defineQuery([ParticleEmitterComponent])
 
   return () => {
-    const { delta } = world
+    const { deltaSeconds: delta } = world
     for (const entity of emitterQuery(world)) {
       const emitter = getComponent(entity, ParticleEmitterComponent)
       emitter.update(delta)

--- a/packages/engine/src/physics/systems/PhysicsSystem.ts
+++ b/packages/engine/src/physics/systems/PhysicsSystem.ts
@@ -227,7 +227,7 @@ export default async function PhysicsSystem(world: World) {
 
     // step physics world
     for (let i = 0; i < world.physics.substeps; i++) {
-      world.physics.scene.simulate((world.physics.timeScale * world.fixedDelta) / world.physics.substeps, true)
+      world.physics.scene.simulate((world.physics.timeScale * world.fixedDeltaSeconds) / world.physics.substeps, true)
       world.physics.scene.fetchResults(true)
     }
   }

--- a/packages/engine/src/renderer/WebGLRendererSystem.ts
+++ b/packages/engine/src/renderer/WebGLRendererSystem.ts
@@ -242,7 +242,7 @@ export default async function WebGLRendererSystem(world: World) {
   addActionReceptor(Engine.instance.store, EngineRendererReceptor)
 
   return () => {
-    EngineRenderer.instance.execute(world.delta)
+    EngineRenderer.instance.execute(world.deltaSeconds)
   }
 }
 

--- a/packages/engine/src/scene/systems/HyperspacePortalSystem.ts
+++ b/packages/engine/src/scene/systems/HyperspacePortalSystem.ts
@@ -30,7 +30,7 @@ export default async function HyperspacePortalSystem(world: World) {
   light.layers.enable(ObjectLayers.Portal)
 
   return () => {
-    const { delta } = world
+    const { deltaSeconds: delta } = world
 
     const playerObj = getComponent(world.localClientEntity, Object3DComponent)
 

--- a/packages/engine/src/scene/systems/RendererUpdateSystem.ts
+++ b/packages/engine/src/scene/systems/RendererUpdateSystem.ts
@@ -14,7 +14,7 @@ export default async function RendererUpdateSystem(world: World) {
   return () => {
     for (const entity of renderedQuery()) {
       const obj = getComponent(entity, Object3DComponent)
-      ;(obj.value as unknown as Updatable).update(world.delta)
+      ;(obj.value as unknown as Updatable).update(world.deltaSeconds)
     }
   }
 }

--- a/packages/engine/src/scene/systems/SceneObjectSystem.ts
+++ b/packages/engine/src/scene/systems/SceneObjectSystem.ts
@@ -141,7 +141,7 @@ export default async function SceneObjectSystem(world: World) {
 
     for (const entity of updatableQuery()) {
       const obj = getComponent(entity, Object3DComponent)?.value as unknown as Updatable
-      obj?.update(world.fixedDelta)
+      obj?.update(world.fixedDeltaSeconds)
     }
 
     for (const _ of simpleMaterialsQuery.enter()) {

--- a/packages/engine/src/xr/functions/controllerAnimation.ts
+++ b/packages/engine/src/xr/functions/controllerAnimation.ts
@@ -9,7 +9,7 @@ export const updateXRControllerAnimations = (inputSource: XRInputSourceComponent
 
   for (const mixer of mixers) {
     if (!mixer) continue
-    mixer.update(world.delta)
+    mixer.update(world.deltaSeconds)
   }
 }
 

--- a/packages/engine/src/xrui/functions/createTransitionState.ts
+++ b/packages/engine/src/xrui/functions/createTransitionState.ts
@@ -15,7 +15,7 @@ export const createTransitionState = (transitionPeriodSeconds: number) => {
 
   const update = (world: World, callback: (alpha: number) => void) => {
     if (currentState !== 'NONE') {
-      alpha += world.delta / transitionPeriodSeconds
+      alpha += world.deltaSeconds / transitionPeriodSeconds
       alpha = MathUtils.clamp(alpha, 0, 1)
       callback(currentState === 'IN' ? alpha : 1 - alpha)
       if (alpha >= 1) setState('NONE')

--- a/packages/engine/tests/ecs/ecs.test.ts
+++ b/packages/engine/tests/ecs/ecs.test.ts
@@ -16,7 +16,7 @@ import { useWorld } from '../../src/ecs/functions/SystemHooks'
 import { SystemUpdateType } from '../../src/ecs/functions/SystemUpdateType'
 import { createEngine } from '../../src/initializeEngine'
 
-const mockDelta = 1 / 60
+const mockDeltaMillis = 1000 / 60
 
 type MockComponentData = {
   mockValue: number
@@ -157,14 +157,14 @@ describe('ECS', () => {
     const mockValue = Math.random()
     addComponent(entity, MockComponent, { mockValue })
     const component = getComponent(entity, MockComponent)
-    world.execute(mockDelta)
+    world.execute(world.startTime + mockDeltaMillis)
     assert.strictEqual(component.mockValue, MockSystemState.get(world)![0])
 
     const entity2 = createEntity()
     const mockValue2 = Math.random()
     addComponent(entity2, MockComponent, { mockValue: mockValue2 })
     const component2 = getComponent(entity2, MockComponent)
-    world.execute(mockDelta)
+    world.execute(world.startTime + mockDeltaMillis * 2)
     assert.strictEqual(component2.mockValue, MockSystemState.get(world)![1])
   })
 
@@ -182,7 +182,7 @@ describe('ECS', () => {
     assert.deepStrictEqual(query.enter(), [])
     assert.deepStrictEqual(query.exit(), [])
 
-    world.execute(mockDelta)
+    world.execute(world.startTime + mockDeltaMillis)
     assert.deepStrictEqual(MockSystemState.get(world)!, [])
   })
 
@@ -195,7 +195,7 @@ describe('ECS', () => {
     addComponent(entity, MockComponent, { mockValue })
 
     removeComponent(entity, MockComponent)
-    world.execute(mockDelta)
+    world.execute(world.startTime + mockDeltaMillis)
     assert.deepStrictEqual(state, [])
 
     const newMockValue = 1 + Math.random()
@@ -206,8 +206,8 @@ describe('ECS', () => {
     console.log(component)
     assert(component)
     assert.strictEqual(component.mockValue, newMockValue)
-    world.execute(mockDelta)
-    world.execute(mockDelta)
+    world.execute(world.startTime + mockDeltaMillis * 2)
+    world.execute(world.startTime + mockDeltaMillis * 3)
     assert.strictEqual(newMockValue, state[0])
   })
 
@@ -222,7 +222,7 @@ describe('ECS', () => {
     removeEntity(entity)
     assert.ok(!getComponent(entity, MockComponent))
     assert.ok(getComponent(entity, MockComponent, true))
-    world.execute(mockDelta)
+    world.execute(world.startTime + mockDeltaMillis)
     assert.deepStrictEqual(MockSystemState.get(world)!, [])
     assert.ok(!world.entityQuery().includes(entity))
   })
@@ -238,7 +238,7 @@ describe('ECS', () => {
     removeEntity(entity)
     removeEntity(entity)
     removeEntity(entity)
-    world.execute(mockDelta)
+    world.execute(world.startTime + mockDeltaMillis)
 
     const entities = world.entityQuery()
     assert.equal(entities.length, lengthBefore - 1)

--- a/packages/engine/tests/physics.test.ts
+++ b/packages/engine/tests/physics.test.ts
@@ -91,9 +91,9 @@ describe('Physics Interation Tests', () => {
     const runPhysics = await PhysicsSystem(world)
 
     const execute = () => {
-      world.fixedDelta = mockDelta
+      world.fixedDeltaSeconds = mockDelta
       world.fixedTick += 1
-      world.elapsedTime += mockDelta
+      world.elapsedSeconds += mockDelta
       runPhysics()
     }
 

--- a/packages/gameserver/src/NetworkFunctions.ts
+++ b/packages/gameserver/src/NetworkFunctions.ts
@@ -6,6 +6,7 @@ import { User } from '@xrengine/common/src/interfaces/User'
 import { UserId } from '@xrengine/common/src/interfaces/UserId'
 import { SpawnPoints } from '@xrengine/engine/src/avatar/AvatarSpawnSystem'
 import checkPositionIsValid from '@xrengine/engine/src/common/functions/checkPositionIsValid'
+import { performance } from '@xrengine/engine/src/common/functions/performance'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { getComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
 import { Network } from '@xrengine/engine/src/networking/classes/Network'
@@ -343,8 +344,8 @@ export const handleJoinWorld = async (
   logger.info('Sending cached actions: %o', cachedActions)
 
   callback({
-    elapsedTime: world.elapsedTime,
-    clockTime: Date.now(),
+    highResTimeOrigin: performance.timeOrigin,
+    worldStartTime: world.startTime,
     client: { name: client.name, index: client.index },
     cachedActions,
     avatarDetail: client.avatarDetail!,

--- a/packages/hyperflux/README.md
+++ b/packages/hyperflux/README.md
@@ -13,8 +13,7 @@ createHyperStore({
     getDispatchTime: () => Engine.instance.elapsedTime
 })
 // Engine timer callback:
-const executeWorlds = (delta, elapsedTime) => {
-  Engine.instance.elapsedTime = elapsedTime
+const executeWorlds = (elapsedTime) => {
   ActionFunctions.applyIncomingActions(Engine.instance.store)
   // ...
 }


### PR DESCRIPTION
- Standardized and clarified time units with property name conventions:
Variables with *Time = UTC millisecond timestamp
All other time is expressed in seconds, with *Seconds naming convention
- Cleaned up Timer and timing logic, passing standard high-resolution timestamps everywhere rather than passing delta time or otherwise manipulated (scaled) time values