### PR TITLE
Move scene and camera objects from Engine to World

### DIFF
--- a/packages/client-core/src/components/Debug/index.tsx
+++ b/packages/client-core/src/components/Debug/index.tsx
@@ -114,7 +114,7 @@ export const Debug = () => {
   }
 
   const toggleNodeHelpers = () => {
-    Engine.instance.camera.layers.toggle(ObjectLayers.NodeHelper)
+    Engine.instance.currentWorld.camera.layers.toggle(ObjectLayers.NodeHelper)
     dispatchAction(
       Engine.instance.store,
       EngineRendererAction.changeNodeHelperVisibility(!accessEngineRendererState().nodeHelperVisibility.value)
@@ -122,7 +122,7 @@ export const Debug = () => {
   }
 
   const toggleGridHelper = () => {
-    Engine.instance.camera.layers.toggle(ObjectLayers.Gizmos)
+    Engine.instance.currentWorld.camera.layers.toggle(ObjectLayers.Gizmos)
     dispatchAction(
       Engine.instance.store,
       EngineRendererAction.changeGridToolVisibility(!accessEngineRendererState().gridVisibility.value)

--- a/packages/client-core/src/systems/AvatarUISystem.tsx
+++ b/packages/client-core/src/systems/AvatarUISystem.tsx
@@ -27,14 +27,14 @@ export const renderAvatarContextMenu = (world: World, userId: UserId, contextMen
   const { avatarHeight } = getComponent(userEntity, AvatarComponent)
 
   contextMenuXRUI.container.scale.setScalar(
-    Math.max(1, Engine.instance.camera.position.distanceTo(userTransform.position) / 3)
+    Math.max(1, Engine.instance.currentWorld.camera.position.distanceTo(userTransform.position) / 3)
   )
   contextMenuXRUI.container.position.copy(userTransform.position)
   contextMenuXRUI.container.position.y += avatarHeight - 0.3
   contextMenuXRUI.container.position.x += 0.1
   contextMenuXRUI.container.position.z +=
-    contextMenuXRUI.container.position.z > Engine.instance.camera.position.z ? -0.4 : 0.4
-  contextMenuXRUI.container.rotation.setFromRotationMatrix(Engine.instance.camera.matrix)
+    contextMenuXRUI.container.position.z > Engine.instance.currentWorld.camera.position.z ? -0.4 : 0.4
+  contextMenuXRUI.container.rotation.setFromRotationMatrix(Engine.instance.currentWorld.camera.matrix)
 }
 
 export default async function AvatarUISystem(world: World) {
@@ -60,11 +60,11 @@ export default async function AvatarUISystem(world: World) {
       const xrui = getComponent(ui.entity, XRUIComponent)
       if (!xrui) continue
       xrui.container.scale.setScalar(
-        Math.max(1, Engine.instance.camera.position.distanceTo(userTransform.position) / 3)
+        Math.max(1, Engine.instance.currentWorld.camera.position.distanceTo(userTransform.position) / 3)
       )
       xrui.container.position.copy(userTransform.position)
       xrui.container.position.y += avatarHeight + 0.3
-      xrui.container.rotation.setFromRotationMatrix(Engine.instance.camera.matrix)
+      xrui.container.rotation.setFromRotationMatrix(Engine.instance.currentWorld.camera.matrix)
     }
 
     for (const userEntity of userQuery.exit()) {

--- a/packages/client-core/src/systems/XRUILoadingSystem.tsx
+++ b/packages/client-core/src/systems/XRUILoadingSystem.tsx
@@ -46,17 +46,17 @@ export default async function XRUILoadingSystem(world: World) {
   // flip inside out
   mesh.scale.set(-1, 1, 1)
   mesh.renderOrder = 1
-  Engine.instance.camera.add(mesh)
-  Engine.instance.scene.add(Engine.instance.camera)
+  Engine.instance.currentWorld.camera.add(mesh)
+  Engine.instance.currentWorld.scene.add(Engine.instance.currentWorld.camera)
 
   setObjectLayers(mesh, ObjectLayers.UI)
 
   return () => {
-    mesh.quaternion.copy(Engine.instance.camera.quaternion).invert()
+    mesh.quaternion.copy(Engine.instance.currentWorld.camera.quaternion).invert()
 
     // add a slow rotation to animate on desktop, otherwise just keep it static for VR
     // if (!getEngineState().joinedWorld.value) {
-    //   Engine.instance.camera.rotateY(world.delta * 0.35)
+    //   Engine.instance.currentWorld.camera.rotateY(world.delta * 0.35)
     // } else {
     //   // todo: figure out how to make this work properly for VR
     // }
@@ -72,7 +72,7 @@ export default async function XRUILoadingSystem(world: World) {
       const scale = ObjectFitFunctions.computeContentFitScaleForCamera(dist, contentWidth, contentHeight, 'cover')
       xrui.container.scale.x = xrui.container.scale.y = scale * 1.1
       xrui.container.position.z = -dist
-      xrui.container.parent = Engine.instance.camera
+      xrui.container.parent = Engine.instance.currentWorld.camera
 
       transition.update(world, (opacity) => {
         if (opacity !== LoadingSystemState.opacity.value) LoadingSystemState.opacity.set(opacity)

--- a/packages/editor/src/components/EditorContainer.tsx
+++ b/packages/editor/src/components/EditorContainer.tsx
@@ -264,7 +264,7 @@ const EditorContainer = () => {
           setDialogComponent(
             <SaveNewProjectDialog
               thumbnailUrl={URL.createObjectURL(blob!)}
-              initialName={Engine.instance.scene.name}
+              initialName={Engine.instance.currentWorld.scene.name}
               onConfirm={resolve}
               onCancel={resolve}
             />
@@ -344,11 +344,11 @@ const EditorContainer = () => {
   }
 
   const onExportScene = async () => {
-    const projectFile = await sceneToGLTF([Engine.instance.scene as any])
+    const projectFile = await sceneToGLTF([Engine.instance.currentWorld.scene as any])
     const projectJson = JSON.stringify(projectFile)
     const projectBlob = new Blob([projectJson])
     const el = document.createElement('a')
-    const fileName = Engine.instance.scene.name.toLowerCase().replace(/\s+/g, '-')
+    const fileName = Engine.instance.currentWorld.scene.name.toLowerCase().replace(/\s+/g, '-')
     el.download = fileName + '.xre.gltf'
     el.href = URL.createObjectURL(projectBlob)
     document.body.appendChild(el)

--- a/packages/editor/src/components/hierarchy/HierarchyPanelContainer.tsx
+++ b/packages/editor/src/components/hierarchy/HierarchyPanelContainer.tsx
@@ -161,7 +161,7 @@ export default function HierarchyPanel() {
 
   const onClick = useCallback((e: MouseEvent, node: HeirarchyTreeNodeType) => {
     if (e.detail === 2) {
-      const cameraComponent = getComponent(Engine.instance.activeCameraEntity, EditorCameraComponent)
+      const cameraComponent = getComponent(Engine.instance.currentWorld.activeCameraEntity, EditorCameraComponent)
       cameraComponent.focusedObjects = [node.entityNode]
       cameraComponent.refocus = true
     }
@@ -334,7 +334,7 @@ export default function HierarchyPanel() {
   return (
     <>
       <div className={styles.panelContainer}>
-        {Engine.instance.scene && (
+        {Engine.instance.currentWorld.scene && (
           <AutoSizer>
             {({ height, width }) => (
               <FixedSizeList

--- a/packages/editor/src/components/properties/PortalNodeEditor.tsx
+++ b/packages/editor/src/components/properties/PortalNodeEditor.tsx
@@ -105,7 +105,7 @@ export const PortalNodeEditor: EditorComponentType = (props) => {
       {/* TODO */}
       {/* <InputGroup name="Cubemap Bake" label={t('editor:properties.portal.lbl-cubemapBake')}>
         <SelectInput
-          options={Engine.instance.scene.children
+          options={Engine.instance.currentWorld.scene.children
             .filter((obj: Object3D) => {
               return (obj as any).nodeName === CubemapBakeportalComponent.nodeName
             })

--- a/packages/editor/src/components/toolbar/tools/HelperToggleTool.tsx
+++ b/packages/editor/src/components/toolbar/tools/HelperToggleTool.tsx
@@ -30,7 +30,7 @@ export const HelperToggleTool = () => {
   }
 
   const toggleNodeHelpers = () => {
-    Engine.instance.camera.layers.toggle(ObjectLayers.NodeHelper)
+    Engine.instance.currentWorld.camera.layers.toggle(ObjectLayers.NodeHelper)
     dispatchAction(
       Engine.instance.store,
       EngineRendererAction.changeNodeHelperVisibility(!engineRenderState.nodeHelperVisibility.value)

--- a/packages/editor/src/controls/PlayModeControls.ts
+++ b/packages/editor/src/controls/PlayModeControls.ts
@@ -11,7 +11,7 @@ import { ActionSets, EditorMapping, FlyMapping } from './input-mappings'
 
 export function enterPlayMode(): void {
   executeCommandWithHistory(EditorCommands.REPLACE_SELECTION, [])
-  Engine.instance.camera.layers.set(ObjectLayers.Scene)
+  Engine.instance.currentWorld.camera.layers.set(ObjectLayers.Scene)
 
   EngineRenderer.instance.renderer.domElement.addEventListener('click', onClickCanvas)
   document.addEventListener('pointerlockchange', onPointerLockChange)
@@ -19,7 +19,7 @@ export function enterPlayMode(): void {
 }
 
 export function leavePlayMode(): void {
-  Engine.instance.camera.layers.enableAll()
+  Engine.instance.currentWorld.camera.layers.enableAll()
 
   addInputActionMapping(ActionSets.EDITOR, EditorMapping)
 

--- a/packages/editor/src/functions/createCameraEntity.ts
+++ b/packages/editor/src/functions/createCameraEntity.ts
@@ -10,7 +10,7 @@ import { EditorCameraComponent } from '../classes/EditorCameraComponent'
 
 export const createCameraEntity = (): Entity => {
   const entity = createEntity()
-  addComponent(entity, Object3DComponent, { value: Engine.instance.camera })
+  addComponent(entity, Object3DComponent, { value: Engine.instance.currentWorld.camera })
   addComponent(entity, EditorCameraComponent, {
     center: new Vector3(),
     zoomDelta: 0,

--- a/packages/editor/src/functions/getIntersectingNode.ts
+++ b/packages/editor/src/functions/getIntersectingNode.ts
@@ -30,7 +30,7 @@ export function getIntersectingNode(results: Intersection<Object3DWithEntity>[])
   for (const result of results as RaycastIntersectionNode[]) {
     const obj = getParentEntity(result.object)
 
-    if (obj && (obj as Object3D) !== Engine.instance.scene) {
+    if (obj && (obj as Object3D) !== Engine.instance.currentWorld.scene) {
       result.obj3d = obj
       result.node = useWorld().entityTree.entityNodeMap.get(obj.entity)
       return result
@@ -42,14 +42,14 @@ export const getIntersectingNodeOnScreen = (
   raycaster: Raycaster,
   coord: Vector2,
   target: Intersection<Object3D>[] = [],
-  camera: Camera = Engine.instance.camera,
+  camera: Camera = Engine.instance.currentWorld.camera,
   object?: Object3D,
   recursive: boolean = true
 ): RaycastIntersectionNode | undefined => {
   raycaster.setFromCamera(coord, camera)
   raycaster.layers.enable(ObjectLayers.NodeHelper)
   raycaster.intersectObject<Object3DWithEntity>(
-    object ?? Engine.instance.scene,
+    object ?? Engine.instance.currentWorld.scene,
     recursive,
     target as Intersection<Object3DWithEntity>[]
   )

--- a/packages/editor/src/functions/sceneRenderFunctions.ts
+++ b/packages/editor/src/functions/sceneRenderFunctions.ts
@@ -55,30 +55,30 @@ export const SceneState: SceneStateType = {
 export async function initializeScene(projectFile: SceneJson): Promise<Error[] | void> {
   SceneState.isInitialized = false
 
-  if (!Engine.instance.scene) Engine.instance.scene = new Scene()
+  if (!Engine.instance.currentWorld.scene) Engine.instance.currentWorld.scene = new Scene()
 
   // getting scene data
   await loadSceneFromJSON(projectFile, [])
 
-  Engine.instance.camera.position.set(0, 5, 10)
-  Engine.instance.camera.lookAt(new Vector3())
-  Engine.instance.camera.layers.enable(ObjectLayers.Scene)
-  Engine.instance.camera.layers.enable(ObjectLayers.NodeHelper)
-  Engine.instance.camera.layers.enable(ObjectLayers.Gizmos)
+  Engine.instance.currentWorld.camera.position.set(0, 5, 10)
+  Engine.instance.currentWorld.camera.lookAt(new Vector3())
+  Engine.instance.currentWorld.camera.layers.enable(ObjectLayers.Scene)
+  Engine.instance.currentWorld.camera.layers.enable(ObjectLayers.NodeHelper)
+  Engine.instance.currentWorld.camera.layers.enable(ObjectLayers.Gizmos)
 
   SceneState.transformGizmo = new TransformGizmo()
 
   SceneState.gizmoEntity = createGizmoEntity(SceneState.transformGizmo)
-  Engine.instance.activeCameraEntity = createCameraEntity()
+  Engine.instance.currentWorld.activeCameraEntity = createCameraEntity()
   SceneState.editorEntity = createEditorEntity()
 
-  Engine.instance.scene.add(Engine.instance.camera)
-  Engine.instance.scene.add(SceneState.transformGizmo)
+  Engine.instance.currentWorld.scene.add(Engine.instance.currentWorld.camera)
+  Engine.instance.currentWorld.scene.add(SceneState.transformGizmo)
 
   // Require when changing scene
-  if (!Engine.instance.scene.children.includes(InfiniteGridHelper.instance)) {
+  if (!Engine.instance.currentWorld.scene.children.includes(InfiniteGridHelper.instance)) {
     InfiniteGridHelper.instance = new InfiniteGridHelper()
-    Engine.instance.scene.add(InfiniteGridHelper.instance)
+    Engine.instance.currentWorld.scene.add(InfiniteGridHelper.instance)
   }
 
   SceneState.isInitialized = true
@@ -163,11 +163,11 @@ export async function exportScene(options = {} as DefaultExportOptionsType) {
 
   executeCommand(EditorCommands.REPLACE_SELECTION, [])
 
-  if ((Engine.instance.scene as any).entity == undefined) {
-    ;(Engine.instance.scene as any).entity = useWorld().entityTree.rootNode.entity
+  if ((Engine.instance.currentWorld.scene as any).entity == undefined) {
+    ;(Engine.instance.currentWorld.scene as any).entity = useWorld().entityTree.rootNode.entity
   }
 
-  const clonedScene = serializeForGLTFExport(Engine.instance.scene)
+  const clonedScene = serializeForGLTFExport(Engine.instance.currentWorld.scene)
 
   if (shouldCombineMeshes) await MeshCombinationGroup.combineMeshes(clonedScene)
   if (shouldRemoveUnusedObjects) removeUnusedObjects(clonedScene)
@@ -218,13 +218,14 @@ export async function exportScene(options = {} as DefaultExportOptionsType) {
 export function disposeScene() {
   EngineRenderer.instance.activeCSMLightEntity = null
   EngineRenderer.instance.directionalLightEntities = []
-  if (Engine.instance.activeCameraEntity) removeEntity(Engine.instance.activeCameraEntity, true)
+  if (Engine.instance.currentWorld.activeCameraEntity)
+    removeEntity(Engine.instance.currentWorld.activeCameraEntity, true)
   if (SceneState.gizmoEntity) removeEntity(SceneState.gizmoEntity, true)
   if (SceneState.editorEntity) removeEntity(SceneState.editorEntity, true)
 
-  if (Engine.instance.scene) {
+  if (Engine.instance.currentWorld.scene) {
     // Empty existing scene
-    Engine.instance.scene.traverse((child: any) => {
+    Engine.instance.currentWorld.scene.traverse((child: any) => {
       if (child.geometry) child.geometry.dispose()
 
       if (child.material) {
@@ -246,7 +247,7 @@ export function disposeScene() {
     emptyEntityTree(eTree)
     eTree.entityNodeMap.clear()
     eTree.uuidNodeMap.clear()
-    Engine.instance.scene.clear()
+    Engine.instance.currentWorld.scene.clear()
   }
 
   SceneState.isInitialized = false

--- a/packages/editor/src/functions/takeScreenshot.ts
+++ b/packages/editor/src/functions/takeScreenshot.ts
@@ -42,7 +42,7 @@ export async function takeScreenshot(width: number, height: number): Promise<Blo
     deserializeScenePreviewCamera(entity, null!)
 
     scenePreviewCamera = getComponent(entity, Object3DComponent).value as PerspectiveCamera
-    Engine.instance.camera.matrix.decompose(
+    Engine.instance.currentWorld.camera.matrix.decompose(
       scenePreviewCamera.position,
       scenePreviewCamera.quaternion,
       scenePreviewCamera.scale
@@ -58,7 +58,7 @@ export async function takeScreenshot(width: number, height: number): Promise<Blo
   scenePreviewCamera.layers.set(ObjectLayers.Scene)
 
   // Rendering the scene to the new canvas with given size
-  EngineRenderer.instance.renderer.render(Engine.instance.scene, scenePreviewCamera)
+  EngineRenderer.instance.renderer.render(Engine.instance.currentWorld.scene, scenePreviewCamera)
   const blob = await getCanvasBlob(getResizedCanvas(EngineRenderer.instance.renderer.domElement, width, height))
 
   // Restoring previous state

--- a/packages/editor/src/functions/uploadCubemapBake.ts
+++ b/packages/editor/src/functions/uploadCubemapBake.ts
@@ -75,7 +75,7 @@ export const uploadBakeToServer = async (entity: Entity) => {
   const position = getScenePositionForBake(world, isSceneEntity ? null : entity)
 
   // inject bpcem logic into material
-  Engine.instance.scene.traverse((child: Mesh<any, MeshBasicMaterial>) => {
+  Engine.instance.currentWorld.scene.traverse((child: Mesh<any, MeshBasicMaterial>) => {
     if (!child.material) return
     if (typeof child.material.onBeforeCompile === 'function')
       child.material.userData.previousOnBeforeCompile = child.material.onBeforeCompile
@@ -87,13 +87,13 @@ export const uploadBakeToServer = async (entity: Entity) => {
 
   const cubemapCapturer = new CubemapCapturer(
     EngineRenderer.instance.renderer,
-    Engine.instance.scene,
+    Engine.instance.currentWorld.scene,
     bakeComponent.options.resolution
   )
   const renderTarget = cubemapCapturer.update(position)
 
   // remove injected bpcem logic from material
-  Engine.instance.scene.traverse((child: Mesh<any, MeshBasicMaterial>) => {
+  Engine.instance.currentWorld.scene.traverse((child: Mesh<any, MeshBasicMaterial>) => {
     if (!child.material) return
     if (typeof child.material.userData.previousOnBeforeCompile === 'function') {
       child.material.onBeforeCompile = child.material.userData.previousOnBeforeCompile
@@ -101,7 +101,7 @@ export const uploadBakeToServer = async (entity: Entity) => {
     }
   })
 
-  if (isSceneEntity) Engine.instance.scene.environment = renderTarget.texture
+  if (isSceneEntity) Engine.instance.currentWorld.scene.environment = renderTarget.texture
 
   const { blob } = await convertCubemapToEquiImageData(
     EngineRenderer.instance.renderer,

--- a/packages/editor/src/systems/EditorControlSystem.ts
+++ b/packages/editor/src/systems/EditorControlSystem.ts
@@ -124,14 +124,14 @@ export default async function EditorControlSystem(_: World) {
   }
 
   const getRaycastPosition = (coords: Vector2, target: Vector3, snapAmount: number = 0): void => {
-    raycaster.setFromCamera(coords, Engine.instance.camera)
+    raycaster.setFromCamera(coords, Engine.instance.currentWorld.camera)
     raycasterResults.length = 0
     raycastIgnoreLayers.set(1)
     const os = selectionState.selectedParentEntities.value.map(
       (entity) => getComponent(entity, Object3DComponent).value
     )
 
-    findIntersectObjects(Engine.instance.scene, os, raycastIgnoreLayers)
+    findIntersectObjects(Engine.instance.currentWorld.scene, os, raycastIgnoreLayers)
     findIntersectObjects(InfiniteGridHelper.instance)
 
     raycasterResults.sort((a, b) => a.distance - b.distance)
@@ -248,8 +248,11 @@ export default async function EditorControlSystem(_: World) {
           )
           constraint = TransformAxisConstraints.XYZ
         } else {
-          ray.origin.setFromMatrixPosition(Engine.instance.camera.matrixWorld)
-          ray.direction.set(cursorPosition.x, cursorPosition.y, 0).unproject(Engine.instance.camera).sub(ray.origin)
+          ray.origin.setFromMatrixPosition(Engine.instance.currentWorld.camera.matrixWorld)
+          ray.direction
+            .set(cursorPosition.x, cursorPosition.y, 0)
+            .unproject(Engine.instance.currentWorld.camera)
+            .sub(ray.origin)
           ray.intersectPlane(transformPlane, planeIntersection)
           constraint = TransformAxisConstraints[gizmoObj.selectedAxis!]
         }
@@ -339,7 +342,7 @@ export default async function EditorControlSystem(_: World) {
               selectedAxisInfo.startMarkerLocal!.position.copy(gizmoObj.position)
               selectedAxisInfo.startMarkerLocal!.quaternion.copy(gizmoObj.quaternion)
               selectedAxisInfo.startMarkerLocal!.scale.copy(gizmoObj.scale)
-              Engine.instance.scene.add(selectedAxisInfo.startMarkerLocal!)
+              Engine.instance.currentWorld.scene.add(selectedAxisInfo.startMarkerLocal!)
             }
           }
 
@@ -362,7 +365,7 @@ export default async function EditorControlSystem(_: World) {
             selectedAxisInfo.rotationTarget!.rotation.set(0, 0, 0)
             if (transformSpace !== TransformSpace.World) {
               const startMarkerLocal = selectedAxisInfo.startMarkerLocal
-              if (startMarkerLocal) Engine.instance.scene.remove(startMarkerLocal)
+              if (startMarkerLocal) Engine.instance.currentWorld.scene.remove(startMarkerLocal)
             }
           }
         } else if (transformMode === TransformMode.Scale) {
@@ -378,7 +381,7 @@ export default async function EditorControlSystem(_: World) {
           let scaleFactor =
             gizmoObj.selectedAxis === TransformAxis.XYZ
               ? 1 +
-                Engine.instance.camera
+                Engine.instance.currentWorld.camera
                   .getWorldDirection(viewDirection)
                   .applyQuaternion(gizmoObj.quaternion)
                   .dot(deltaDragVector)
@@ -413,7 +416,7 @@ export default async function EditorControlSystem(_: World) {
       }
 
       selectionCounter = selectionState.selectionCounter.value
-      cameraComponent = getComponent(Engine.instance.activeCameraEntity, EditorCameraComponent)
+      cameraComponent = getComponent(Engine.instance.currentWorld.activeCameraEntity, EditorCameraComponent)
       const shift = getInput(EditorActionSet.shift)
 
       if (selectEnd) {

--- a/packages/editor/src/systems/GizmoSystem.ts
+++ b/packages/editor/src/systems/GizmoSystem.ts
@@ -18,7 +18,7 @@ export default async function GizmoSystem(_: World) {
       const gizmoObj = getComponent(entity, Object3DComponent)?.value as TransformGizmo
       if (!gizmoObj || !gizmoObj.visible) return
 
-      const eyeDistance = gizmoObj.position.distanceTo(Engine.instance.camera.position) / GIZMO_SIZE
+      const eyeDistance = gizmoObj.position.distanceTo(Engine.instance.currentWorld.camera.position) / GIZMO_SIZE
       gizmoObj.scale.set(eyeDistance, eyeDistance, eyeDistance)
     }
   }

--- a/packages/editor/src/systems/RenderSystem.ts
+++ b/packages/editor/src/systems/RenderSystem.ts
@@ -8,8 +8,8 @@ export default async function EditorInfoSystem(world: World) {
     if (SceneState.onUpdateStats) {
       EngineRenderer.instance.renderer.info.reset()
       const renderStat = EngineRenderer.instance.renderer.info.render as any
-      renderStat.fps = 1 / world.delta
-      renderStat.frameTime = world.delta * 1000
+      renderStat.fps = 1 / world.deltaSeconds
+      renderStat.frameTime = world.deltaSeconds * 1000
       SceneState.onUpdateStats(EngineRenderer.instance.renderer.info)
     }
   }

--- a/packages/engine/src/audio/systems/AudioSystem.ts
+++ b/packages/engine/src/audio/systems/AudioSystem.ts
@@ -37,7 +37,7 @@ export default async function AudioSystem(world: World) {
     window.removeEventListener('pointerdown', startAudio, true)
     console.log('starting audio')
     audioReady = true
-    Engine.instance.audioListener.context.resume()
+    Engine.instance.currentWorld.audioListener.context.resume()
     dispatchAction(Engine.instance.store, EngineActions.startSuspendedContexts())
 
     callbacks.forEach((cb) => cb())

--- a/packages/engine/src/avatar/AvatarControllerSystem.ts
+++ b/packages/engine/src/avatar/AvatarControllerSystem.ts
@@ -58,22 +58,22 @@ export default async function AvatarControllerSystem(world: World) {
 
     for (const entity of localXRInputQuery(world)) {
       if (!hasComponent(entity, XRCameraRotateYComponent)) {
-        moveXRAvatar(world, entity, Engine.instance.camera, lastCamPos, displacement)
-        rotateXRAvatar(world, entity, Engine.instance.camera)
+        moveXRAvatar(world, entity, Engine.instance.currentWorld.camera, lastCamPos, displacement)
+        rotateXRAvatar(world, entity, Engine.instance.currentWorld.camera)
       }
     }
 
     for (const entity of cameraRotationQuery.exit(world)) {
-      const camera = Engine.instance.camera
+      const camera = Engine.instance.currentWorld.camera
       lastCamPos.subVectors(camera.position, camera.parent!.position)
-      alignXRCameraPositionWithAvatar(entity, Engine.instance.camera)
+      alignXRCameraPositionWithAvatar(entity, Engine.instance.currentWorld.camera)
       lastCamPos.add(camera.parent!.position)
     }
 
     for (const entity of cameraRotationQuery.enter(world)) {
       const avatarTransform = getComponent(entity, TransformComponent)
       const rotation = getComponent(entity, XRCameraRotateYComponent)
-      const cam = Engine.instance.camera
+      const cam = Engine.instance.currentWorld.camera
       const camParent = cam.parent!
 
       camRotation.setFromAxisAngle(up, rotation.angle)
@@ -85,7 +85,7 @@ export default async function AvatarControllerSystem(world: World) {
     }
 
     for (const entity of controllerQuery(world)) {
-      const displace = moveAvatar(world, entity, Engine.instance.camera)
+      const displace = moveAvatar(world, entity, Engine.instance.currentWorld.camera)
       displacement.set(displace.x, displace.y, displace.z)
 
       const controller = getComponent(entity, AvatarControllerComponent)

--- a/packages/engine/src/avatar/AvatarSystem.ts
+++ b/packages/engine/src/avatar/AvatarSystem.ts
@@ -136,7 +136,7 @@ export default async function AvatarSystem(world: World) {
 
       xrInputSourceComponent.container.name = 'XR Container'
       xrInputSourceComponent.head.name = 'XR Head'
-      Engine.instance.scene.add(xrInputSourceComponent.container, xrInputSourceComponent.head)
+      Engine.instance.currentWorld.scene.add(xrInputSourceComponent.container, xrInputSourceComponent.head)
 
       // Add head IK Solver
       if (!isEntityLocalClient(entity)) {

--- a/packages/engine/src/avatar/AvatarTeleportSystem.ts
+++ b/packages/engine/src/avatar/AvatarTeleportSystem.ts
@@ -117,12 +117,12 @@ export default async function AvatarTeleportSystem(world: World) {
   return () => {
     for (const entity of avatarSwerveQuery.enter(world)) {
       const avatarSewerveComponent = getComponent(entity, AvatarSwerveComponent)
-      const cameraParentRotation = Engine.instance.camera.parent?.rotation
+      const cameraParentRotation = Engine.instance.currentWorld.camera.parent?.rotation
       if (cameraParentRotation) {
         let rad = swerveByDegrees * Deg2Rad()
         tempSwerveVec.copy(avatarSewerveComponent.axis).multiplyScalar(rad)
 
-        const quat = new Quaternion().copy(Engine.instance.camera.parent!.quaternion)
+        const quat = new Quaternion().copy(Engine.instance.currentWorld.camera.parent!.quaternion)
         rotate(quat, tempSwerveVec.x, tempSwerveVec.y, tempSwerveVec.z)
         cameraParentRotation.setFromQuaternion(quat)
       }

--- a/packages/engine/src/avatar/DissolveEffect.ts
+++ b/packages/engine/src/avatar/DissolveEffect.ts
@@ -195,11 +195,11 @@ export class DissolveEffect {
       }
       if (isPhysicMaterial) {
         //@ts-ignore
-        myMaterial.envMap = Engine.instance.scene?.environment
+        myMaterial.envMap = Engine.instance.currentWorld.scene?.environment
         //@ts-ignore
         myMaterial.envMapIntensity = { value: 1 }
         myMaterial.uniforms.envMap = {
-          value: Engine.instance.scene?.environment
+          value: Engine.instance.currentWorld.scene?.environment
         }
         myMaterial.uniforms.envMapIntensity = { value: 1 }
       }

--- a/packages/engine/src/avatar/functions/moveAvatar.ts
+++ b/packages/engine/src/avatar/functions/moveAvatar.ts
@@ -250,7 +250,7 @@ export const alignXRCameraPositionWithAvatar = (entity: Entity, camera: Perspect
 export const alignXRCameraRotationWithAvatar = (entity: Entity, camera: PerspectiveCamera | OrthographicCamera) => {
   const avatarTransform = getComponent(entity, TransformComponent)
   const camParentRot = camera.parent!.quaternion
-  tempVec1.set(0, 0, 1).applyQuaternion(Engine.instance.camera.quaternion).setY(0).normalize()
+  tempVec1.set(0, 0, 1).applyQuaternion(Engine.instance.currentWorld.camera.quaternion).setY(0).normalize()
   quat.setFromUnitVectors(tempVec2.set(0, 0, 1), tempVec1).invert()
   tempVec1.set(0, 0, -1).applyQuaternion(avatarTransform.rotation).setY(0).normalize()
   camParentRot.setFromUnitVectors(tempVec2.set(0, 0, 1), tempVec1).multiply(quat)

--- a/packages/engine/src/camera/systems/CameraSystem.ts
+++ b/packages/engine/src/camera/systems/CameraSystem.ts
@@ -117,12 +117,12 @@ export const getMaxCamDistance = (entity: Entity, target: Vector3) => {
 
   camRayCastClock.start()
 
-  const sceneObjects = Array.from(Engine.instance.objectLayerList[ObjectLayers.Scene] || [])
+  const sceneObjects = Array.from(Engine.instance.currentWorld.objectLayerList[ObjectLayers.Scene] || [])
 
   const followCamera = getComponent(entity, FollowCameraComponent)
 
   // Raycast to keep the line of sight with avatar
-  const cameraTransform = getComponent(Engine.instance.activeCameraEntity, TransformComponent)
+  const cameraTransform = getComponent(Engine.instance.currentWorld.activeCameraEntity, TransformComponent)
   const targetToCamVec = tempVec1.subVectors(cameraTransform.position, target)
   // followCamera.raycaster.ray.origin.sub(targetToCamVec.multiplyScalar(0.1)) // move origin behind camera
 
@@ -220,7 +220,7 @@ export const updateFollowCamera = (entity: Entity, delta: number) => {
   const thetaRad = MathUtils.degToRad(theta)
   const phiRad = MathUtils.degToRad(followCamera.phi)
 
-  const cameraTransform = getComponent(Engine.instance.activeCameraEntity, TransformComponent)
+  const cameraTransform = getComponent(Engine.instance.currentWorld.activeCameraEntity, TransformComponent)
   cameraTransform.position.set(
     tempVec.x + followCamera.distance * Math.sin(thetaRad) * Math.cos(phiRad),
     tempVec.y + followCamera.distance * Math.sin(phiRad),
@@ -244,7 +244,7 @@ export const updateFollowCamera = (entity: Entity, delta: number) => {
 
 export const initializeCameraComponent = (world: World) => {
   const cameraEntity = createEntity()
-  const camObj = Engine.instance.camera
+  const camObj = Engine.instance.currentWorld.camera
   addComponent(cameraEntity, Object3DComponent, { value: camObj })
   addComponent(cameraEntity, PersistTagComponent, {})
 
@@ -254,7 +254,7 @@ export const initializeCameraComponent = (world: World) => {
     scale: camObj.scale
   })
 
-  Engine.instance.activeCameraEntity = cameraEntity
+  Engine.instance.currentWorld.activeCameraEntity = cameraEntity
 
   return cameraEntity
 }
@@ -275,7 +275,7 @@ export default async function CameraSystem(world: World) {
         cameraFollow.raycaster.layers.set(ObjectLayers.Scene) // Ignore avatars
         ;(cameraFollow.raycaster as any).firstHitOnly = true // three-mesh-bvh setting
         cameraFollow.raycaster.far = cameraFollow.maxDistance
-        Engine.instance.activeCameraFollowTarget = entity
+        Engine.instance.currentWorld.activeCameraFollowTarget = entity
         //check for initialized raycast properties
         if (!cameraFollow.raycastProps) {
           cameraFollow.raycastProps = RAYCAST_PROPERTIES_DEFAULT_VALUES
@@ -287,14 +287,14 @@ export default async function CameraSystem(world: World) {
             const arrow = new ArrowHelper()
             coneDebugHelpers.push(arrow)
             setObjectLayers(arrow, ObjectLayers.Gizmos)
-            Engine.instance.scene.add(arrow)
+            Engine.instance.currentWorld.scene.add(arrow)
           }
         }
       }
     }
 
     for (const entity of followCameraQuery.exit()) {
-      Engine.instance.activeCameraFollowTarget = null
+      Engine.instance.currentWorld.activeCameraFollowTarget = null
       camRayCastCache.maxDistance = -1
     }
 
@@ -311,15 +311,15 @@ export default async function CameraSystem(world: World) {
 
       if (EngineRenderer.instance.xrManager?.isPresenting) {
         // Current WebXRManager.updateCamera() typedef is incorrect
-        ;(EngineRenderer.instance.xrManager as any).updateCamera(Engine.instance.camera)
+        ;(EngineRenderer.instance.xrManager as any).updateCamera(Engine.instance.currentWorld.camera)
 
         removeComponent(Engine.instance.currentWorld.localClientEntity, XRCameraUpdatePendingTagComponent)
       } else if (followCameraEntity !== undefined) {
-        const transform = getComponent(Engine.instance.activeCameraEntity, TransformComponent)
-        Engine.instance.camera.position.copy(transform.position)
-        Engine.instance.camera.quaternion.copy(transform.rotation)
-        Engine.instance.camera.scale.copy(transform.scale)
-        Engine.instance.camera.updateMatrixWorld()
+        const transform = getComponent(Engine.instance.currentWorld.activeCameraEntity, TransformComponent)
+        Engine.instance.currentWorld.camera.position.copy(transform.position)
+        Engine.instance.currentWorld.camera.quaternion.copy(transform.rotation)
+        Engine.instance.currentWorld.camera.scale.copy(transform.scale)
+        Engine.instance.currentWorld.camera.updateMatrixWorld()
       }
     }
   }

--- a/packages/engine/src/debug/systems/DebugHelpersSystem.ts
+++ b/packages/engine/src/debug/systems/DebugHelpersSystem.ts
@@ -45,7 +45,7 @@ cubeGeometry.rotateX(-Math.PI * 0.5)
 
 export default async function DebugHelpersSystem(world: World) {
   InfiniteGridHelper.instance = new InfiniteGridHelper()
-  Engine.instance.scene.add(InfiniteGridHelper.instance)
+  Engine.instance.currentWorld.scene.add(InfiniteGridHelper.instance)
 
   let physicsDebugRenderer = DebugRenderer()
 
@@ -112,19 +112,19 @@ export default async function DebugHelpersSystem(world: World) {
       const velocityColor = 0x0000ff
       const velocityArrowHelper = new ArrowHelper(new Vector3(), new Vector3(0, 0, 0), 0.5, velocityColor)
       velocityArrowHelper.visible = accessEngineRendererState().avatarDebugEnable.value
-      Engine.instance.scene.add(velocityArrowHelper)
+      Engine.instance.currentWorld.scene.add(velocityArrowHelper)
       helpersByEntity.velocityArrow.set(entity, velocityArrowHelper)
     }
 
     for (const entity of avatarDebugQuery.exit()) {
       // view vector
       // const arrowHelper = helpersByEntity.viewVector.get(entity) as Object3D
-      // Engine.instance.scene.remove(arrowHelper)
+      // Engine.instance.currentWorld.scene.remove(arrowHelper)
       // helpersByEntity.viewVector.delete(entity)
 
       // velocity
       const velocityArrowHelper = helpersByEntity.velocityArrow.get(entity) as Object3D
-      Engine.instance.scene.remove(velocityArrowHelper)
+      Engine.instance.currentWorld.scene.remove(velocityArrowHelper)
       helpersByEntity.velocityArrow.delete(entity)
     }
 
@@ -157,9 +157,9 @@ export default async function DebugHelpersSystem(world: World) {
       debugHead.visible = engineRendererState.avatarDebugEnable.value
       debugLeft.visible = engineRendererState.avatarDebugEnable.value
       debugRight.visible = engineRendererState.avatarDebugEnable.value
-      Engine.instance.scene.add(debugHead)
-      Engine.instance.scene.add(debugLeft)
-      Engine.instance.scene.add(debugRight)
+      Engine.instance.currentWorld.scene.add(debugHead)
+      Engine.instance.currentWorld.scene.add(debugLeft)
+      Engine.instance.currentWorld.scene.add(debugRight)
       helpersByEntity.ikExtents.set(entity, [debugHead, debugLeft, debugRight])
     }
 
@@ -186,12 +186,12 @@ export default async function DebugHelpersSystem(world: World) {
     for (const entity of colliderQuery.exit()) {
       // view vector
       const arrowHelper = helpersByEntity.viewVector.get(entity) as Object3D
-      Engine.instance.scene.remove(arrowHelper)
+      Engine.instance.currentWorld.scene.remove(arrowHelper)
       helpersByEntity.viewVector.delete(entity)
 
       // velocity
       const velocityArrowHelper = helpersByEntity.velocityArrow.get(entity) as Object3D
-      Engine.instance.scene.remove(velocityArrowHelper)
+      Engine.instance.currentWorld.scene.remove(velocityArrowHelper)
       helpersByEntity.velocityArrow.delete(entity)
     }
 
@@ -212,14 +212,14 @@ export default async function DebugHelpersSystem(world: World) {
         hex
       )
       arrowHelper.visible = engineRendererState.avatarDebugEnable.value
-      Engine.instance.scene.add(arrowHelper)
+      Engine.instance.currentWorld.scene.add(arrowHelper)
       helpersByEntity.viewVector.set(entity, arrowHelper)
 
       // velocity
       const velocityColor = 0x0000ff
       const velocityArrowHelper = new ArrowHelper(new Vector3(), new Vector3(0, 0, 0), 0.5, velocityColor)
       velocityArrowHelper.visible = engineRendererState.avatarDebugEnable.value
-      Engine.instance.scene.add(velocityArrowHelper)
+      Engine.instance.currentWorld.scene.add(velocityArrowHelper)
       helpersByEntity.velocityArrow.set(entity, velocityArrowHelper)
     }
 
@@ -269,7 +269,7 @@ export default async function DebugHelpersSystem(world: World) {
     // bounding box
     for (const entity of boundingBoxQuery.exit()) {
       const boxHelper = helpersByEntity.box.get(entity) as Box3Helper
-      Engine.instance.scene.remove(boxHelper)
+      Engine.instance.currentWorld.scene.remove(boxHelper)
       helpersByEntity.box.delete(entity)
     }
 
@@ -278,7 +278,7 @@ export default async function DebugHelpersSystem(world: World) {
       const helper = new Box3Helper(boundingBox.box)
       helper.visible = false
       helpersByEntity.box.set(entity, helper)
-      Engine.instance.scene.add(helper)
+      Engine.instance.currentWorld.scene.add(helper)
     }
 
     // ===== CUSTOM ===== //
@@ -287,13 +287,13 @@ export default async function DebugHelpersSystem(world: World) {
       const arrow = getComponent(entity, DebugArrowComponent)
       const arrowHelper = new ArrowHelper(new Vector3(), new Vector3(0, 0, 0), 0.5, arrow.color)
       arrowHelper.visible = accessEngineRendererState().physicsDebugEnable.value
-      Engine.instance.scene.add(arrowHelper)
+      Engine.instance.currentWorld.scene.add(arrowHelper)
       helpersByEntity.helperArrow.set(entity, arrowHelper)
     }
 
     for (const entity of arrowHelperQuery.exit()) {
       const arrowHelper = helpersByEntity.helperArrow.get(entity) as Object3D
-      Engine.instance.scene.remove(arrowHelper)
+      Engine.instance.currentWorld.scene.remove(arrowHelper)
       helpersByEntity.helperArrow.delete(entity)
     }
 
@@ -317,7 +317,7 @@ export default async function DebugHelpersSystem(world: World) {
       helper.add(convexHelper)
       helper.add(graphHelper)
       console.log('navhelper', helper)
-      Engine.instance.scene.add(helper)
+      Engine.instance.currentWorld.scene.add(helper)
       helpersByEntity.navmesh.set(entity, helper)
     }
     for (const entity of navmeshQuery()) {
@@ -329,7 +329,7 @@ export default async function DebugHelpersSystem(world: World) {
     }
     for (const entity of navmeshQuery.exit()) {
       const helper = helpersByEntity.navmesh.get(entity) as Object3D
-      Engine.instance.scene.remove(helper)
+      Engine.instance.currentWorld.scene.remove(helper)
       helpersByEntity.navmesh.delete(entity)
     }
     // ===== Autopilot Helper ===== //

--- a/packages/engine/src/debug/systems/DebugRenderer.ts
+++ b/packages/engine/src/debug/systems/DebugRenderer.ts
@@ -66,13 +66,13 @@ export const DebugRenderer = () => {
     enabled = _enabled
     if (!_enabled) {
       _meshes.forEach((mesh) => {
-        Engine.instance.scene.remove(mesh)
+        Engine.instance.currentWorld.scene.remove(mesh)
       })
       _raycasts.forEach((mesh) => {
-        Engine.instance.scene.remove(mesh)
+        Engine.instance.currentWorld.scene.remove(mesh)
       })
       _obstacles.forEach((mesh) => {
-        Engine.instance.scene.remove(mesh)
+        Engine.instance.currentWorld.scene.remove(mesh)
       })
       _meshes.clear()
       _raycasts.clear()
@@ -93,7 +93,7 @@ export const DebugRenderer = () => {
       }
       const mesh = new Mesh(geom, _materials[5])
       setObjectLayers(mesh, ObjectLayers.PhysicsHelper)
-      Engine.instance.scene.add(mesh)
+      Engine.instance.currentWorld.scene.add(mesh)
       _obstacles.set(id, mesh)
     }
     const mesh = _obstacles.get(id)
@@ -108,7 +108,7 @@ export const DebugRenderer = () => {
     let needsUpdate = false
     if (body._debugNeedsUpdate) {
       if (mesh) {
-        Engine.instance.scene.remove(mesh)
+        Engine.instance.currentWorld.scene.remove(mesh)
         needsUpdate = true
       }
       body._debugNeedsUpdate = false
@@ -138,7 +138,7 @@ export const DebugRenderer = () => {
       }
       _meshes.set(id, mesh)
       setObjectLayers(mesh, ObjectLayers.PhysicsHelper)
-      Engine.instance.scene.add(mesh)
+      Engine.instance.currentWorld.scene.add(mesh)
     }
   }
 
@@ -147,7 +147,7 @@ export const DebugRenderer = () => {
     let needsUpdate = false
     if (shape._debugNeedsUpdate) {
       if (mesh) {
-        Engine.instance.scene.remove(mesh)
+        Engine.instance.currentWorld.scene.remove(mesh)
         needsUpdate = true
       }
       delete shape._debugNeedsUpdate
@@ -236,7 +236,7 @@ export const DebugRenderer = () => {
 
     if (mesh && mesh.geometry) {
       setObjectLayers(mesh, ObjectLayers.PhysicsHelper)
-      Engine.instance.scene.add(mesh)
+      Engine.instance.currentWorld.scene.add(mesh)
     }
 
     return mesh
@@ -249,10 +249,10 @@ export const DebugRenderer = () => {
       // @ts-ignore
       const xrCameras = EngineRenderer.instance.xrManager?.getCamera() as ArrayCamera
       if (enabled) {
-        Engine.instance.camera.layers.enable(ObjectLayers.PhysicsHelper)
+        Engine.instance.currentWorld.camera.layers.enable(ObjectLayers.PhysicsHelper)
         if (xrCameras) xrCameras.cameras.forEach((camera) => camera.layers.enable(ObjectLayers.PhysicsHelper))
       } else {
-        Engine.instance.camera.layers.disable(ObjectLayers.PhysicsHelper)
+        Engine.instance.currentWorld.camera.layers.disable(ObjectLayers.PhysicsHelper)
         if (xrCameras) xrCameras.cameras.forEach((camera) => camera.layers.disable(ObjectLayers.PhysicsHelper))
       }
     }
@@ -291,13 +291,13 @@ export const DebugRenderer = () => {
     })
     _obstacles.forEach((mesh, id) => {
       if (!world.physics.obstacles.has(id)) {
-        Engine.instance.scene.remove(mesh)
+        Engine.instance.currentWorld.scene.remove(mesh)
         _meshes.delete(id)
       }
     })
     _meshes.forEach((mesh, id) => {
       if (!world.physics.shapes.has(id)) {
-        Engine.instance.scene.remove(mesh)
+        Engine.instance.currentWorld.scene.remove(mesh)
         _meshes.delete(id)
       }
     })

--- a/packages/engine/src/ecs/classes/Engine.ts
+++ b/packages/engine/src/ecs/classes/Engine.ts
@@ -1,13 +1,11 @@
-import { AudioListener, Object3D, OrthographicCamera, PerspectiveCamera, Scene, XRFrame } from 'three'
+import { XRFrame } from 'three'
 
 import type { UserId } from '@xrengine/common/src/interfaces/UserId'
 import { createHyperStore } from '@xrengine/hyperflux'
 
 import { nowMilliseconds } from '../../common/functions/nowMilliseconds'
-import type { InputValue } from '../../input/interfaces/InputValue'
 import type { World } from '../classes/World'
 import type { SystemModuleType } from '../functions/SystemFunctions'
-import type { Entity } from './Entity'
 
 export class Engine {
   static instance: Engine
@@ -44,33 +42,6 @@ export class Engine {
    * All worlds that are currently instantiated
    */
   worlds: World[] = []
-
-  /**
-   * Reference to the three.js scene object.
-   */
-  scene: Scene = null!
-
-  /**
-   * Map of object lists by layer
-   * (automatically updated by the SceneObjectSystem)
-   */
-  objectLayerList = {} as { [layer: number]: Set<Object3D> }
-
-  /**
-   * Reference to the three.js perspective camera object.
-   */
-  camera: PerspectiveCamera | OrthographicCamera = null!
-  activeCameraEntity: Entity = null!
-  activeCameraFollowTarget: Entity | null = null
-
-  /**
-   * Reference to the audioListener.
-   * This is a virtual listner for all positional and non-positional audio.
-   */
-  audioListener: AudioListener = null!
-
-  inputState = new Map<any, InputValue>()
-  prevInputState = new Map<any, InputValue>()
 
   publicPath: string = null!
 

--- a/packages/engine/src/ecs/classes/World.ts
+++ b/packages/engine/src/ecs/classes/World.ts
@@ -284,7 +284,6 @@ export class World {
     const worldElapsedSeconds = (frameTime - this.startTime) / 1000
     this.deltaSeconds = Math.max(0, Math.min(TimerConfig.MAX_DELTA_SECONDS, worldElapsedSeconds - this.elapsedSeconds))
     this.elapsedSeconds = worldElapsedSeconds
-    console.log(worldElapsedSeconds)
 
     for (const system of this.pipelines[SystemUpdateType.UPDATE]) system.execute()
     for (const system of this.pipelines[SystemUpdateType.PRE_RENDER]) system.execute()

--- a/packages/engine/src/ecs/classes/World.ts
+++ b/packages/engine/src/ecs/classes/World.ts
@@ -4,7 +4,7 @@ import { AudioListener, Object3D, OrthographicCamera, PerspectiveCamera, Scene, 
 import { NetworkId } from '@xrengine/common/src/interfaces/NetworkId'
 import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
 import { UserId } from '@xrengine/common/src/interfaces/UserId'
-import { createHyperStore } from '@xrengine/hyperflux'
+import { createHyperStore, registerState } from '@xrengine/hyperflux'
 
 import { DEFAULT_LOD_DISTANCES } from '../../assets/constants/LoaderConstants'
 import { AvatarComponent } from '../../avatar/components/AvatarComponent'
@@ -15,6 +15,7 @@ import { InputValue } from '../../input/interfaces/InputValue'
 import { Network } from '../../networking/classes/Network'
 import { NetworkObjectComponent } from '../../networking/components/NetworkObjectComponent'
 import { NetworkClient } from '../../networking/interfaces/NetworkClient'
+import { WorldState } from '../../networking/interfaces/WorldState'
 import { Physics } from '../../physics/classes/Physics'
 import { NameComponent } from '../../scene/components/NameComponent'
 import { Object3DComponent } from '../../scene/components/Object3DComponent'
@@ -54,6 +55,8 @@ export class World {
 
     initializeEntityTree(this)
     this.scene.layers.set(ObjectLayers.Scene)
+
+    registerState(this.store, WorldState)
 
     // @todo support multiple networks per world
     Network.instance = new Network()

--- a/packages/engine/src/ecs/functions/EngineFunctions.test.ts
+++ b/packages/engine/src/ecs/functions/EngineFunctions.test.ts
@@ -29,7 +29,8 @@ describe('EngineFunctions', () => {
       const objectEntities = object3dQuery(world)
 
       // add obejcts to scene
-      for (const entity of objectEntities) Engine.instance.scene.add(getComponent(entity, Object3DComponent).value)
+      for (const entity of objectEntities)
+        Engine.instance.currentWorld.scene.add(getComponent(entity, Object3DComponent).value)
 
       assert.equal(objectEntities.length, 5)
 
@@ -61,7 +62,8 @@ describe('EngineFunctions', () => {
       const objectEntities = getEntities(world)
 
       // add obejcts to scene
-      for (const entity of objectEntities) Engine.instance.scene.add(getComponent(entity, Object3DComponent).value)
+      for (const entity of objectEntities)
+        Engine.instance.currentWorld.scene.add(getComponent(entity, Object3DComponent).value)
 
       assert.equal(objectEntities.length, 5)
 

--- a/packages/engine/src/ecs/functions/EngineFunctions.ts
+++ b/packages/engine/src/ecs/functions/EngineFunctions.ts
@@ -67,12 +67,12 @@ export function reset() {
   // }
 
   // delete all what is left on scene
-  if (Engine.instance.scene) {
-    disposeScene(Engine.instance.scene)
-    Engine.instance.scene = null!
+  if (Engine.instance.currentWorld.scene) {
+    disposeScene(Engine.instance.currentWorld.scene)
+    Engine.instance.currentWorld.scene = null!
   }
 
-  Engine.instance.camera = null!
+  Engine.instance.currentWorld.camera = null!
 
   if (EngineRenderer.instance.renderer) {
     EngineRenderer.instance.renderer.clear(true, true, true)
@@ -83,8 +83,8 @@ export function reset() {
   AssetLoader.Cache.clear()
 
   dispatchAction(Engine.instance.store, EngineActions.initializeEngine({ initialised: false }))
-  Engine.instance.inputState.clear()
-  Engine.instance.prevInputState.clear()
+  Engine.instance.currentWorld.inputState.clear()
+  Engine.instance.currentWorld.prevInputState.clear()
 }
 
 export const unloadScene = (world: World, removePersisted = false) => {
@@ -93,8 +93,8 @@ export const unloadScene = (world: World, removePersisted = false) => {
 
   dispatchAction(Engine.instance.store, EngineActions.sceneUnloaded())
 
-  Engine.instance.scene.background = new Color('black')
-  Engine.instance.scene.environment = null
+  Engine.instance.currentWorld.scene.background = new Color('black')
+  Engine.instance.currentWorld.scene.environment = null
 
   isClient && configureEffectComposer()
 
@@ -132,7 +132,7 @@ export const unloadAllEntities = (world: World, removePersisted = false) => {
     entityNodesToRemove.forEach((node) => removeEntityNodeFromParent(node, world.entityTree))
   }
 
-  Engine.instance.scene.traverse((o: any) => {
+  Engine.instance.currentWorld.scene.traverse((o: any) => {
     if (!o.entity) return
     if (!entitiesToRemove.includes(o.entity)) return
 
@@ -153,6 +153,6 @@ export const unloadAllEntities = (world: World, removePersisted = false) => {
     sceneObjectsToRemove.push(o)
   })
 
-  sceneObjectsToRemove.forEach((o) => Engine.instance.scene.remove(o))
+  sceneObjectsToRemove.forEach((o) => Engine.instance.currentWorld.scene.remove(o))
   entitiesToRemove.forEach((entity) => removeEntity(entity, true))
 }

--- a/packages/engine/src/initializeEngine.ts
+++ b/packages/engine/src/initializeEngine.ts
@@ -36,7 +36,6 @@ export const createEngine = () => {
   EngineRenderer.instance = new EngineRenderer()
   if (isClient) EngineRenderer.instance.initialize()
   registerState(Engine.instance.store, EngineState)
-  registerState(Engine.instance.currentWorld.store, WorldState)
   addActionReceptor(Engine.instance.store, EngineEventReceptor)
 }
 

--- a/packages/engine/src/initializeEngine.ts
+++ b/packages/engine/src/initializeEngine.ts
@@ -33,8 +33,6 @@ import { FontManager } from './xrui/classes/FontManager'
 export const createEngine = () => {
   Engine.instance = new Engine()
   Engine.instance.currentWorld = createWorld()
-  Engine.instance.scene = new Scene()
-  Engine.instance.scene.layers.set(ObjectLayers.Scene)
   EngineRenderer.instance = new EngineRenderer()
   if (isClient) EngineRenderer.instance.initialize()
   registerState(Engine.instance.store, EngineState)
@@ -49,14 +47,15 @@ export const createEngine = () => {
  */
 export const initializeBrowser = () => {
   Engine.instance.publicPath = location.origin
-  Engine.instance.audioListener = new AudioListener()
-  Engine.instance.audioListener.context.resume()
-  Engine.instance.camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 10000)
-  Engine.instance.camera.add(Engine.instance.audioListener)
-  Engine.instance.camera.layers.disableAll()
-  Engine.instance.camera.layers.enable(ObjectLayers.Scene)
-  Engine.instance.camera.layers.enable(ObjectLayers.Avatar)
-  Engine.instance.camera.layers.enable(ObjectLayers.UI)
+  const world = Engine.instance.currentWorld
+  world.audioListener = new AudioListener()
+  world.audioListener.context.resume()
+  world.camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 10000)
+  world.camera.add(world.audioListener)
+  world.camera.layers.disableAll()
+  world.camera.layers.enable(ObjectLayers.Scene)
+  world.camera.layers.enable(ObjectLayers.Avatar)
+  world.camera.layers.enable(ObjectLayers.UI)
 
   Engine.instance.isBot = navigator.userAgent === BotUserAgent
 

--- a/packages/engine/src/input/functions/GamepadInput.ts
+++ b/packages/engine/src/input/functions/GamepadInput.ts
@@ -64,7 +64,7 @@ export const handleGamepads = () => {
 export const handleGamepadButton = (gamepad: Gamepad, index: number) => {
   if (gamepad.buttons[index].touched === (lastButtonInput[index] === BinaryValue.ON)) return
   // Set input data
-  Engine.instance.inputState.set(gamepadMapping[gamepad.mapping || 'standard'][index], {
+  Engine.instance.currentWorld.inputState.set(gamepadMapping[gamepad.mapping || 'standard'][index], {
     type: InputType.BUTTON,
     value: [gamepad.buttons[index].touched ? BinaryValue.ON : BinaryValue.OFF],
     lifecycleState: gamepad.buttons[index].touched ? LifecycleValue.Started : LifecycleValue.Ended
@@ -94,7 +94,7 @@ export const handleGamepadAxis = (gamepad: Gamepad, inputIndex: number, mappedIn
 
   // Axis has changed, so get mutable reference to Input and set data
   if (x !== lastAxisInput[xIndex] || y !== lastAxisInput[yIndex]) {
-    Engine.instance.inputState.set(mappedInputValue, {
+    Engine.instance.currentWorld.inputState.set(mappedInputValue, {
       type: InputType.TWODIM,
       value: [x, y],
       lifecycleState: LifecycleValue.Changed
@@ -102,7 +102,7 @@ export const handleGamepadAxis = (gamepad: Gamepad, inputIndex: number, mappedIn
   }
 
   if (x === 0 && lastAxisInput[xIndex] !== 0 && y === 0 && lastAxisInput[yIndex] !== 0) {
-    Engine.instance.inputState.set(mappedInputValue, {
+    Engine.instance.currentWorld.inputState.set(mappedInputValue, {
       type: InputType.TWODIM,
       value: [0, 0],
       lifecycleState: LifecycleValue.Ended
@@ -150,7 +150,7 @@ export const handleGamepadDisconnected = (event: any): void => {
 
   for (let index = 0; index < lastButtonInput.length; index++) {
     if (lastButtonInput[index] === BinaryValue.ON) {
-      Engine.instance.inputState.set(gamepadMapping[event.gamepad.mapping || 'standard'][index], {
+      Engine.instance.currentWorld.inputState.set(gamepadMapping[event.gamepad.mapping || 'standard'][index], {
         type: InputType.BUTTON,
         value: [BinaryValue.OFF],
         lifecycleState: LifecycleValue.Changed

--- a/packages/engine/src/input/functions/WebcamInput.ts
+++ b/packages/engine/src/input/functions/WebcamInput.ts
@@ -98,7 +98,7 @@ export async function faceToInput(detection) {
       // If the detected value of the expression is more than 1/3rd-ish of total, record it
       // This should allow up to 3 expressions but usually 1-2
       const inputKey = nameToInputValue[expression]
-      Engine.instance.inputState.set(inputKey, {
+      Engine.instance.currentWorld.inputState.set(inputKey, {
         type: InputType.ONEDIM,
         value: detection.expressions[expression] < EXPRESSION_THRESHOLD ? 0 : detection.expressions[expression],
         lifecycleState: LifecycleValue.Changed
@@ -186,33 +186,33 @@ export const startLipsyncTracking = () => {
 
 export const lipToInput = (pucker, widen, open) => {
   if (pucker > 0.2)
-    Engine.instance.inputState.set(nameToInputValue['pucker'], {
+    Engine.instance.currentWorld.inputState.set(nameToInputValue['pucker'], {
       type: InputType.ONEDIM,
       value: pucker,
       lifecycleState: LifecycleValue.Changed
     })
-  else if (Engine.instance.inputState.has(nameToInputValue['pucker']))
-    Engine.instance.inputState.delete(nameToInputValue['pucker'])
+  else if (Engine.instance.currentWorld.inputState.has(nameToInputValue['pucker']))
+    Engine.instance.currentWorld.inputState.delete(nameToInputValue['pucker'])
 
   // Calculate lips widing and apply as input
   if (widen > 0.2)
-    Engine.instance.inputState.set(nameToInputValue['widen'], {
+    Engine.instance.currentWorld.inputState.set(nameToInputValue['widen'], {
       type: InputType.ONEDIM,
       value: widen,
       lifecycleState: LifecycleValue.Changed
     })
-  else if (Engine.instance.inputState.has(nameToInputValue['widen']))
-    Engine.instance.inputState.delete(nameToInputValue['widen'])
+  else if (Engine.instance.currentWorld.inputState.has(nameToInputValue['widen']))
+    Engine.instance.currentWorld.inputState.delete(nameToInputValue['widen'])
 
   // Calculate mouth opening and apply as input
   if (open > 0.2)
-    Engine.instance.inputState.set(nameToInputValue['open'], {
+    Engine.instance.currentWorld.inputState.set(nameToInputValue['open'], {
       type: InputType.ONEDIM,
       value: open,
       lifecycleState: LifecycleValue.Changed
     })
-  else if (Engine.instance.inputState.has(nameToInputValue['open']))
-    Engine.instance.inputState.delete(nameToInputValue['open'])
+  else if (Engine.instance.currentWorld.inputState.has(nameToInputValue['open']))
+    Engine.instance.currentWorld.inputState.delete(nameToInputValue['open'])
 }
 
 function getRMS(spectrum) {

--- a/packages/engine/src/input/schema/ClientInputSchema.test.ts
+++ b/packages/engine/src/input/schema/ClientInputSchema.test.ts
@@ -18,7 +18,7 @@ import {
 
 describe('clientInputSchema', () => {
   beforeEach(() => {
-    Engine.instance.inputState.clear()
+    Engine.instance.currentWorld.inputState.clear()
   })
 
   it('check useThumpstick', () => {
@@ -55,7 +55,10 @@ describe('clientInputSchema', () => {
     handleTouchMove(touchEvent as unknown as TouchEvent)
     strictEqual(prevTouchPosition[0], rNorm[0])
     strictEqual(prevTouchPosition[1], rNorm[1])
-    strictEqual(Engine.instance.inputState.get(TouchInputs.Touch1Position)?.lifecycleState, LifecycleValue.Started)
+    strictEqual(
+      Engine.instance.currentWorld.inputState.get(TouchInputs.Touch1Position)?.lifecycleState,
+      LifecycleValue.Started
+    )
 
     const touchEvent2 = {
       type: 'touchchange',
@@ -79,27 +82,32 @@ describe('clientInputSchema', () => {
 
     handleTouchMove(touchEvent2 as unknown as TouchEvent)
 
-    strictEqual(Engine.instance.inputState.get(TouchInputs.Touch1Position)?.lifecycleState, LifecycleValue.Changed)
+    strictEqual(
+      Engine.instance.currentWorld.inputState.get(TouchInputs.Touch1Position)?.lifecycleState,
+      LifecycleValue.Changed
+    )
 
-    assert(Engine.instance.inputState.size > 0)
+    assert(Engine.instance.currentWorld.inputState.size > 0)
   })
 
   it('check handleTouch', async () => {
     const touchEvent = { type: 'touchstart', targetTouches: ['1'] }
 
     handleTouch(touchEvent as unknown as TouchEvent)
-    assert(Engine.instance.inputState.get(TouchInputs.Touch)?.lifecycleState === LifecycleValue.Started)
-    assert(Engine.instance.inputState.get(TouchInputs.DoubleTouch) === undefined)
+    assert(Engine.instance.currentWorld.inputState.get(TouchInputs.Touch)?.lifecycleState === LifecycleValue.Started)
+    assert(Engine.instance.currentWorld.inputState.get(TouchInputs.DoubleTouch) === undefined)
     //double tap
     handleTouch(touchEvent as unknown as TouchEvent)
-    assert(Engine.instance.inputState.get(TouchInputs.DoubleTouch)?.lifecycleState === LifecycleValue.Started)
-    assert(Engine.instance.inputState.get(TouchInputs.Touch)?.lifecycleState === LifecycleValue.Continued)
+    assert(
+      Engine.instance.currentWorld.inputState.get(TouchInputs.DoubleTouch)?.lifecycleState === LifecycleValue.Started
+    )
+    assert(Engine.instance.currentWorld.inputState.get(TouchInputs.Touch)?.lifecycleState === LifecycleValue.Continued)
 
     const touchEvent2 = { type: 'touchend', targetTouches: ['1'] }
     handleTouch(touchEvent2 as unknown as TouchEvent)
-    assert(Engine.instance.inputState.get(TouchInputs.Touch)?.lifecycleState === LifecycleValue.Ended)
+    assert(Engine.instance.currentWorld.inputState.get(TouchInputs.Touch)?.lifecycleState === LifecycleValue.Ended)
 
-    assert(Engine.instance.inputState.size > 0)
+    assert(Engine.instance.currentWorld.inputState.size > 0)
   })
 
   it('check handleTouchDirectionalPad', () => {
@@ -117,9 +125,9 @@ describe('clientInputSchema', () => {
     const input = GamepadAxis.Left
 
     handleTouchDirectionalPad(touchEvent as unknown as CustomEvent)
-    assert(Engine.instance.inputState.get(input)?.lifecycleState === LifecycleValue.Started)
+    assert(Engine.instance.currentWorld.inputState.get(input)?.lifecycleState === LifecycleValue.Started)
     handleTouchDirectionalPad(touchEvent as unknown as CustomEvent)
-    assert(Engine.instance.inputState.get(input)?.lifecycleState === LifecycleValue.Started)
+    assert(Engine.instance.currentWorld.inputState.get(input)?.lifecycleState === LifecycleValue.Started)
     touchEvent = {
       detail: {
         stick: GamepadAxis.Left,
@@ -131,9 +139,9 @@ describe('clientInputSchema', () => {
       }
     }
     handleTouchDirectionalPad(touchEvent as unknown as CustomEvent)
-    assert(Engine.instance.inputState.get(input)?.lifecycleState === LifecycleValue.Changed)
+    assert(Engine.instance.currentWorld.inputState.get(input)?.lifecycleState === LifecycleValue.Changed)
 
-    assert(Engine.instance.inputState.size > 0)
+    assert(Engine.instance.currentWorld.inputState.size > 0)
   })
 
   it('check handleTouchGamepadButton', () => {
@@ -145,10 +153,10 @@ describe('clientInputSchema', () => {
     }
 
     handleTouchGamepadButton(touchEvent as unknown as CustomEvent)
-    assert(Engine.instance.inputState.get(GamepadButtons.A)?.lifecycleState === LifecycleValue.Started)
+    assert(Engine.instance.currentWorld.inputState.get(GamepadButtons.A)?.lifecycleState === LifecycleValue.Started)
 
     handleTouchGamepadButton(touchEvent as unknown as CustomEvent)
-    assert(Engine.instance.inputState.get(GamepadButtons.A)?.lifecycleState === LifecycleValue.Continued)
+    assert(Engine.instance.currentWorld.inputState.get(GamepadButtons.A)?.lifecycleState === LifecycleValue.Continued)
     touchEvent = {
       type: 'touchgamepadbuttonup',
       detail: {
@@ -156,8 +164,8 @@ describe('clientInputSchema', () => {
       }
     }
     handleTouchGamepadButton(touchEvent as unknown as CustomEvent)
-    assert(Engine.instance.inputState.get(GamepadButtons.A)?.lifecycleState === LifecycleValue.Ended)
-    assert(Engine.instance.inputState.size > 0)
+    assert(Engine.instance.currentWorld.inputState.get(GamepadButtons.A)?.lifecycleState === LifecycleValue.Ended)
+    assert(Engine.instance.currentWorld.inputState.size > 0)
   })
 
   it('check handleMouseMovement', () => {
@@ -167,13 +175,21 @@ describe('clientInputSchema', () => {
     }
 
     handleMouseMovement(touchEvent as unknown as MouseEvent)
-    assert(Engine.instance.inputState.get(MouseInput.MousePosition)?.lifecycleState === LifecycleValue.Started)
-    assert(Engine.instance.inputState.get(MouseInput.MouseMovement)?.lifecycleState === LifecycleValue.Started)
+    assert(
+      Engine.instance.currentWorld.inputState.get(MouseInput.MousePosition)?.lifecycleState === LifecycleValue.Started
+    )
+    assert(
+      Engine.instance.currentWorld.inputState.get(MouseInput.MouseMovement)?.lifecycleState === LifecycleValue.Started
+    )
     handleMouseMovement(touchEvent as unknown as MouseEvent)
-    assert(Engine.instance.inputState.get(MouseInput.MousePosition)?.lifecycleState === LifecycleValue.Changed)
-    assert(Engine.instance.inputState.get(MouseInput.MouseMovement)?.lifecycleState === LifecycleValue.Changed)
+    assert(
+      Engine.instance.currentWorld.inputState.get(MouseInput.MousePosition)?.lifecycleState === LifecycleValue.Changed
+    )
+    assert(
+      Engine.instance.currentWorld.inputState.get(MouseInput.MouseMovement)?.lifecycleState === LifecycleValue.Changed
+    )
 
-    assert(Engine.instance.inputState.size > 0)
+    assert(Engine.instance.currentWorld.inputState.size > 0)
   })
 
   it('check handleMouseButton', () => {
@@ -185,8 +201,13 @@ describe('clientInputSchema', () => {
     }
 
     handleMouseButton(touchEvent as unknown as MouseEvent)
-    assert(Engine.instance.inputState.get(MouseInput.MouseClickDownPosition)?.lifecycleState === LifecycleValue.Started)
-    assert(Engine.instance.inputState.get(MouseInput.LeftButton)?.lifecycleState === LifecycleValue.Started)
+    assert(
+      Engine.instance.currentWorld.inputState.get(MouseInput.MouseClickDownPosition)?.lifecycleState ===
+        LifecycleValue.Started
+    )
+    assert(
+      Engine.instance.currentWorld.inputState.get(MouseInput.LeftButton)?.lifecycleState === LifecycleValue.Started
+    )
 
     touchEvent = {
       type: 'mouseup',
@@ -195,15 +216,24 @@ describe('clientInputSchema', () => {
       clientY: 0
     }
     handleMouseButton(touchEvent as unknown as MouseEvent)
-    assert(Engine.instance.inputState.get(MouseInput.MouseClickDownPosition)?.lifecycleState === LifecycleValue.Ended)
-    assert(Engine.instance.inputState.get(MouseInput.MouseClickDownPosition)?.lifecycleState === LifecycleValue.Ended)
-    assert(Engine.instance.inputState.get(MouseInput.LeftButton)?.lifecycleState === LifecycleValue.Ended)
     assert(
-      Engine.instance.inputState.get(MouseInput.MouseClickDownTransformRotation)?.lifecycleState ===
+      Engine.instance.currentWorld.inputState.get(MouseInput.MouseClickDownPosition)?.lifecycleState ===
         LifecycleValue.Ended
     )
-    assert(Engine.instance.inputState.get(MouseInput.MouseClickDownMovement)?.lifecycleState === LifecycleValue.Ended)
-    assert(Engine.instance.inputState.size > 0)
+    assert(
+      Engine.instance.currentWorld.inputState.get(MouseInput.MouseClickDownPosition)?.lifecycleState ===
+        LifecycleValue.Ended
+    )
+    assert(Engine.instance.currentWorld.inputState.get(MouseInput.LeftButton)?.lifecycleState === LifecycleValue.Ended)
+    assert(
+      Engine.instance.currentWorld.inputState.get(MouseInput.MouseClickDownTransformRotation)?.lifecycleState ===
+        LifecycleValue.Ended
+    )
+    assert(
+      Engine.instance.currentWorld.inputState.get(MouseInput.MouseClickDownMovement)?.lifecycleState ===
+        LifecycleValue.Ended
+    )
+    assert(Engine.instance.currentWorld.inputState.size > 0)
   })
 
   it('check handleKey', () => {
@@ -213,16 +243,16 @@ describe('clientInputSchema', () => {
     }
 
     handleKey(touchEvent as unknown as KeyboardEvent)
-    assert(Engine.instance.inputState.get('KeyA')?.lifecycleState === LifecycleValue.Started)
+    assert(Engine.instance.currentWorld.inputState.get('KeyA')?.lifecycleState === LifecycleValue.Started)
     handleKey(touchEvent as unknown as KeyboardEvent)
-    assert(Engine.instance.inputState.get('KeyA')?.lifecycleState === LifecycleValue.Continued)
+    assert(Engine.instance.currentWorld.inputState.get('KeyA')?.lifecycleState === LifecycleValue.Continued)
     touchEvent = {
       type: 'keyup',
       code: 'KeyA'
     }
     handleKey(touchEvent as unknown as KeyboardEvent)
-    assert(Engine.instance.inputState.get('KeyA')?.lifecycleState === LifecycleValue.Ended)
+    assert(Engine.instance.currentWorld.inputState.get('KeyA')?.lifecycleState === LifecycleValue.Ended)
 
-    assert(Engine.instance.inputState.size > 0)
+    assert(Engine.instance.currentWorld.inputState.size > 0)
   })
 })

--- a/packages/engine/src/input/schema/ClientInputSchema.ts
+++ b/packages/engine/src/input/schema/ClientInputSchema.ts
@@ -21,10 +21,10 @@ const tapLength = 200 // 100ms between doubletaps
 
 export const usingThumbstick = () => {
   return Boolean(
-    Engine.instance.inputState.get(GamepadAxis.Left)?.value[0] ||
-      Engine.instance.inputState.get(GamepadAxis.Left)?.value[1] ||
-      Engine.instance.inputState.get(GamepadAxis.Right)?.value[0] ||
-      Engine.instance.inputState.get(GamepadAxis.Right)?.value[1]
+    Engine.instance.currentWorld.inputState.get(GamepadAxis.Left)?.value[0] ||
+      Engine.instance.currentWorld.inputState.get(GamepadAxis.Left)?.value[1] ||
+      Engine.instance.currentWorld.inputState.get(GamepadAxis.Right)?.value[0] ||
+      Engine.instance.currentWorld.inputState.get(GamepadAxis.Right)?.value[1]
   )
 }
 
@@ -43,9 +43,9 @@ export const handleTouchMove = (event: TouchEvent): void => {
 
   if (event.touches.length >= 1) {
     const mappedPositionInput = TouchInputs.Touch1Position
-    const hasData = Engine.instance.inputState.has(mappedPositionInput)
+    const hasData = Engine.instance.currentWorld.inputState.has(mappedPositionInput)
 
-    Engine.instance.inputState.set(mappedPositionInput, {
+    Engine.instance.currentWorld.inputState.set(mappedPositionInput, {
       type: InputType.TWODIM,
       value: touchPosition,
       lifecycleState: hasData ? LifecycleValue.Changed : LifecycleValue.Started
@@ -62,10 +62,10 @@ export const handleTouchMove = (event: TouchEvent): void => {
 
     prevTouchPosition = touchPosition
 
-    Engine.instance.inputState.set(mappedMovementInput, {
+    Engine.instance.currentWorld.inputState.set(mappedMovementInput, {
       type: InputType.TWODIM,
       value: touchMovement,
-      lifecycleState: Engine.instance.inputState.has(mappedMovementInput)
+      lifecycleState: Engine.instance.currentWorld.inputState.has(mappedMovementInput)
         ? LifecycleValue.Changed
         : LifecycleValue.Started
     })
@@ -78,13 +78,13 @@ export const handleTouchMove = (event: TouchEvent): void => {
     )
     const touchPosition2: [number, number] = [normalizedPosition2.x, normalizedPosition2.y]
 
-    Engine.instance.inputState.set(TouchInputs.Touch1Position, {
+    Engine.instance.currentWorld.inputState.set(TouchInputs.Touch1Position, {
       type: InputType.TWODIM,
       value: touchPosition,
       lifecycleState: LifecycleValue.Changed
     })
 
-    Engine.instance.inputState.set(TouchInputs.Touch2Position, {
+    Engine.instance.currentWorld.inputState.set(TouchInputs.Touch2Position, {
       type: InputType.TWODIM,
       value: touchPosition2,
       lifecycleState: LifecycleValue.Changed
@@ -95,9 +95,9 @@ export const handleTouchMove = (event: TouchEvent): void => {
     const usingStick = usingThumbstick()
 
     if (usingStick) {
-      if (Engine.instance.inputState.has(scaleMappedInputKey)) {
-        const [oldValue] = Engine.instance.inputState.get(scaleMappedInputKey)?.value as number[]
-        Engine.instance.inputState.set(scaleMappedInputKey, {
+      if (Engine.instance.currentWorld.inputState.has(scaleMappedInputKey)) {
+        const [oldValue] = Engine.instance.currentWorld.inputState.get(scaleMappedInputKey)?.value as number[]
+        Engine.instance.currentWorld.inputState.set(scaleMappedInputKey, {
           type: InputType.ONEDIM,
           value: [oldValue],
           lifecycleState: LifecycleValue.Ended
@@ -106,25 +106,27 @@ export const handleTouchMove = (event: TouchEvent): void => {
       return
     }
 
-    const lastTouchcontrollerPositionLeftArray = Engine.instance.prevInputState.get(TouchInputs.Touch1Position)?.value
-    const lastTouchPosition2Array = Engine.instance.prevInputState.get(TouchInputs.Touch2Position)?.value
+    const lastTouchcontrollerPositionLeftArray = Engine.instance.currentWorld.prevInputState.get(
+      TouchInputs.Touch1Position
+    )?.value
+    const lastTouchPosition2Array = Engine.instance.currentWorld.prevInputState.get(TouchInputs.Touch2Position)?.value
     if (event.type === 'touchstart' || !lastTouchcontrollerPositionLeftArray || !lastTouchPosition2Array) {
       // skip if it's just start of gesture or there are no previous data yet
       return
     }
 
     if (
-      !Engine.instance.inputState.has(TouchInputs.Touch1Position) ||
-      !Engine.instance.inputState.has(TouchInputs.Touch2Position)
+      !Engine.instance.currentWorld.inputState.has(TouchInputs.Touch1Position) ||
+      !Engine.instance.currentWorld.inputState.has(TouchInputs.Touch2Position)
     ) {
       console.warn('handleTouchScale requires POINTER1_POSITION and POINTER2_POSITION to be set and updated.')
       return
     }
     const currentTouchcontrollerPositionLeft = new Vector2().fromArray(
-      Engine.instance.inputState.get(TouchInputs.Touch1Position)?.value as number[]
+      Engine.instance.currentWorld.inputState.get(TouchInputs.Touch1Position)?.value as number[]
     )
     const currentTouchPosition2 = new Vector2().fromArray(
-      Engine.instance.inputState.get(TouchInputs.Touch2Position)?.value as number[]
+      Engine.instance.currentWorld.inputState.get(TouchInputs.Touch2Position)?.value as number[]
     )
 
     const lastTouchcontrollerPositionLeft = new Vector2().fromArray(lastTouchcontrollerPositionLeftArray as number[])
@@ -135,15 +137,15 @@ export const handleTouchMove = (event: TouchEvent): void => {
 
     const touchScaleValue = (lastDistance - currentDistance) * 0.01
     const signVal = Math.sign(touchScaleValue)
-    if (!Engine.instance.inputState.has(scaleMappedInputKey)) {
-      Engine.instance.inputState.set(scaleMappedInputKey, {
+    if (!Engine.instance.currentWorld.inputState.has(scaleMappedInputKey)) {
+      Engine.instance.currentWorld.inputState.set(scaleMappedInputKey, {
         type: InputType.ONEDIM,
         value: [signVal],
         lifecycleState: LifecycleValue.Started
       })
     } else {
-      const [oldValue] = Engine.instance.inputState.get(scaleMappedInputKey)?.value as number[]
-      Engine.instance.inputState.set(scaleMappedInputKey, {
+      const [oldValue] = Engine.instance.currentWorld.inputState.get(scaleMappedInputKey)?.value as number[]
+      Engine.instance.currentWorld.inputState.set(scaleMappedInputKey, {
         type: InputType.ONEDIM,
         value: [oldValue + signVal],
         lifecycleState: LifecycleValue.Changed
@@ -165,15 +167,15 @@ export const handleTouch = (event: TouchEvent): void => {
         const timeNow = Date.now()
         const doubleTapInput = TouchInputs.DoubleTouch
         if (timeNow - lastTap < tapLength) {
-          Engine.instance.inputState.set(doubleTapInput, {
+          Engine.instance.currentWorld.inputState.set(doubleTapInput, {
             type: InputType.BUTTON,
             value: [BinaryValue.ON],
-            lifecycleState: Engine.instance.inputState.has(doubleTapInput)
+            lifecycleState: Engine.instance.currentWorld.inputState.has(doubleTapInput)
               ? LifecycleValue.Continued
               : LifecycleValue.Started
           })
-        } else if (Engine.instance.inputState.has(doubleTapInput)) {
-          Engine.instance.inputState.set(doubleTapInput, {
+        } else if (Engine.instance.currentWorld.inputState.has(doubleTapInput)) {
+          Engine.instance.currentWorld.inputState.set(doubleTapInput, {
             type: InputType.BUTTON,
             value: [BinaryValue.OFF],
             lifecycleState: LifecycleValue.Ended
@@ -184,11 +186,11 @@ export const handleTouch = (event: TouchEvent): void => {
 
       // If the key is in the map but it's in the same state as now, let's skip it (debounce)
       if (
-        Engine.instance.inputState.has(mappedInputKey) &&
-        Engine.instance.inputState.get(mappedInputKey)?.value[0] === BinaryValue.ON
+        Engine.instance.currentWorld.inputState.has(mappedInputKey) &&
+        Engine.instance.currentWorld.inputState.get(mappedInputKey)?.value[0] === BinaryValue.ON
       ) {
-        if (Engine.instance.inputState.get(mappedInputKey)?.lifecycleState !== LifecycleValue.Continued) {
-          Engine.instance.inputState.set(mappedInputKey, {
+        if (Engine.instance.currentWorld.inputState.get(mappedInputKey)?.lifecycleState !== LifecycleValue.Continued) {
+          Engine.instance.currentWorld.inputState.set(mappedInputKey, {
             type: InputType.BUTTON,
             value: [BinaryValue.ON],
             lifecycleState: LifecycleValue.Continued
@@ -198,13 +200,13 @@ export const handleTouch = (event: TouchEvent): void => {
       }
 
       // Set type to BUTTON (up/down discrete state) and value to up or down, depending on what the value is set to
-      Engine.instance.inputState.set(mappedInputKey, {
+      Engine.instance.currentWorld.inputState.set(mappedInputKey, {
         type: InputType.BUTTON,
         value: [BinaryValue.ON],
         lifecycleState: LifecycleValue.Started
       })
     } else {
-      Engine.instance.inputState.set(mappedInputKey, {
+      Engine.instance.currentWorld.inputState.set(mappedInputKey, {
         type: InputType.BUTTON,
         value: [BinaryValue.OFF],
         lifecycleState: LifecycleValue.Ended
@@ -212,24 +214,24 @@ export const handleTouch = (event: TouchEvent): void => {
     }
     return
   }
-  if (Engine.instance.inputState.has(TouchInputs.Touch)) {
-    Engine.instance.inputState.set(TouchInputs.Touch, {
+  if (Engine.instance.currentWorld.inputState.has(TouchInputs.Touch)) {
+    Engine.instance.currentWorld.inputState.set(TouchInputs.Touch, {
       type: InputType.BUTTON,
       value: [BinaryValue.OFF],
       lifecycleState: LifecycleValue.Ended
     })
   }
 
-  if (Engine.instance.inputState.has(TouchInputs.DoubleTouch)) {
-    Engine.instance.inputState.set(TouchInputs.DoubleTouch, {
+  if (Engine.instance.currentWorld.inputState.has(TouchInputs.DoubleTouch)) {
+    Engine.instance.currentWorld.inputState.set(TouchInputs.DoubleTouch, {
       type: InputType.BUTTON,
       value: [BinaryValue.OFF],
       lifecycleState: LifecycleValue.Ended
     })
   }
 
-  if (Engine.instance.inputState.has(TouchInputs.Touch1Movement)) {
-    Engine.instance.inputState.set(TouchInputs.Touch1Movement, {
+  if (Engine.instance.currentWorld.inputState.has(TouchInputs.Touch1Movement)) {
+    Engine.instance.currentWorld.inputState.set(TouchInputs.Touch1Movement, {
       type: InputType.TWODIM,
       value: [0, 0],
       lifecycleState: LifecycleValue.Ended
@@ -253,20 +255,20 @@ export const handleTouchDirectionalPad = (event: CustomEvent): void => {
   const stickPosition: [number, number, number] = [value.x, value.y, value.angleRad]
 
   // If position not set, set it with lifecycle started
-  if (!Engine.instance.inputState.has(stick)) {
-    Engine.instance.inputState.set(stick, {
+  if (!Engine.instance.currentWorld.inputState.has(stick)) {
+    Engine.instance.currentWorld.inputState.set(stick, {
       type: InputType.TWODIM,
       value: stickPosition,
       lifecycleState: LifecycleValue.Started
     })
   } else {
     // If position set, check it's value
-    const oldStickPosition = Engine.instance.inputState.get(stick)?.value
+    const oldStickPosition = Engine.instance.currentWorld.inputState.get(stick)?.value
     // If it's not the same, set it and update the lifecycle value to changed
     if (JSON.stringify(oldStickPosition) !== JSON.stringify(stickPosition)) {
       // console.log('---changed');
       // Set type to TWODIM (two-dimensional axis) and value to a normalized -1, 1 on X and Y
-      Engine.instance.inputState.set(stick, {
+      Engine.instance.currentWorld.inputState.set(stick, {
         type: InputType.TWODIM,
         value: stickPosition,
         lifecycleState: LifecycleValue.Changed
@@ -274,7 +276,7 @@ export const handleTouchDirectionalPad = (event: CustomEvent): void => {
     } else {
       // console.log('---not changed');
       // Otherwise, remove it
-      //Engine.instance.inputState.delete(mappedKey)
+      //Engine.instance.currentWorld.inputState.delete(mappedKey)
     }
   }
 }
@@ -291,9 +293,12 @@ export function handleTouchGamepadButton(event: CustomEvent): any {
 
   if (value) {
     // If the key is in the map but it's in the same state as now, let's skip it (debounce)
-    if (Engine.instance.inputState.has(key) && Engine.instance.inputState.get(key)?.value[0] === BinaryValue.ON) {
-      if (Engine.instance.inputState.get(key)?.lifecycleState !== LifecycleValue.Continued) {
-        Engine.instance.inputState.set(key, {
+    if (
+      Engine.instance.currentWorld.inputState.has(key) &&
+      Engine.instance.currentWorld.inputState.get(key)?.value[0] === BinaryValue.ON
+    ) {
+      if (Engine.instance.currentWorld.inputState.get(key)?.lifecycleState !== LifecycleValue.Continued) {
+        Engine.instance.currentWorld.inputState.set(key, {
           type: InputType.BUTTON,
           value: [BinaryValue.ON],
           lifecycleState: LifecycleValue.Continued
@@ -302,13 +307,13 @@ export function handleTouchGamepadButton(event: CustomEvent): any {
       return
     }
     // Set type to BUTTON (up/down discrete state) and value to up or down, depending on what the value is set to
-    Engine.instance.inputState.set(key, {
+    Engine.instance.currentWorld.inputState.set(key, {
       type: InputType.BUTTON,
       value: [BinaryValue.ON],
       lifecycleState: LifecycleValue.Started
     })
   } else {
-    Engine.instance.inputState.set(key, {
+    Engine.instance.currentWorld.inputState.set(key, {
       type: InputType.BUTTON,
       value: [BinaryValue.OFF],
       lifecycleState: LifecycleValue.Ended
@@ -328,16 +333,16 @@ export const handleMouseWheel = (event: WheelEvent): void => {
   const normalizedValues = normalizeWheel(event)
   const value = normalizedValues?.spinY + Math.random() * 0.000001
 
-  if (!Engine.instance.inputState.has(MouseInput.MouseScroll)) {
-    Engine.instance.inputState.set(MouseInput.MouseScroll, {
+  if (!Engine.instance.currentWorld.inputState.has(MouseInput.MouseScroll)) {
+    Engine.instance.currentWorld.inputState.set(MouseInput.MouseScroll, {
       type: InputType.ONEDIM,
       value: [Math.sign(value)],
       lifecycleState: LifecycleValue.Started
     })
   } else {
-    const oldValue = Engine.instance.inputState.get(MouseInput.MouseScroll)?.value[0] as number
+    const oldValue = Engine.instance.currentWorld.inputState.get(MouseInput.MouseScroll)?.value[0] as number
     const newValue = oldValue === value ? value : oldValue + Math.sign(value)
-    Engine.instance.inputState.set(MouseInput.MouseScroll, {
+    Engine.instance.currentWorld.inputState.set(MouseInput.MouseScroll, {
       type: InputType.ONEDIM,
       value: [newValue],
       lifecycleState: LifecycleValue.Changed
@@ -378,42 +383,43 @@ export const handleMouseMovement = (event: MouseEvent): void => {
     window.innerHeight
   )
   const mousePosition: [number, number] = [normalizedPosition.x, normalizedPosition.y]
-  const lastMousePosition = Engine.instance.inputState.get(MouseInput.MousePosition)?.value! ?? mousePosition
+  const lastMousePosition =
+    Engine.instance.currentWorld.inputState.get(MouseInput.MousePosition)?.value! ?? mousePosition
 
-  Engine.instance.inputState.set(MouseInput.MousePosition, {
+  Engine.instance.currentWorld.inputState.set(MouseInput.MousePosition, {
     type: InputType.TWODIM,
     value: mousePosition,
-    lifecycleState: Engine.instance.inputState.has(MouseInput.MousePosition)
+    lifecycleState: Engine.instance.currentWorld.inputState.has(MouseInput.MousePosition)
       ? LifecycleValue.Changed
       : LifecycleValue.Started
   })
 
   const mouseMovement = [mousePosition[0] - lastMousePosition[0], mousePosition[1] - lastMousePosition[1]]
 
-  Engine.instance.inputState.set(MouseInput.MouseMovement, {
+  Engine.instance.currentWorld.inputState.set(MouseInput.MouseMovement, {
     type: InputType.TWODIM,
     value: mouseMovement,
-    lifecycleState: Engine.instance.inputState.has(MouseInput.MouseMovement)
+    lifecycleState: Engine.instance.currentWorld.inputState.has(MouseInput.MouseMovement)
       ? LifecycleValue.Changed
       : LifecycleValue.Started
   })
 
-  const isDragging = Engine.instance.inputState.get(MouseInput.MouseClickDownPosition)
+  const isDragging = Engine.instance.currentWorld.inputState.get(MouseInput.MouseClickDownPosition)
 
   if (isDragging && isDragging?.lifecycleState !== LifecycleValue.Ended) {
     callback = setTimeout(() => {
-      Engine.instance.inputState.set(MouseInput.MouseClickDownMovement, {
+      Engine.instance.currentWorld.inputState.set(MouseInput.MouseClickDownMovement, {
         type: InputType.TWODIM,
         value: [0, 0],
-        lifecycleState: Engine.instance.inputState.has(MouseInput.MouseClickDownMovement)
+        lifecycleState: Engine.instance.currentWorld.inputState.has(MouseInput.MouseClickDownMovement)
           ? LifecycleValue.Changed
           : LifecycleValue.Started
       })
     }, 50)
-    Engine.instance.inputState.set(MouseInput.MouseClickDownMovement, {
+    Engine.instance.currentWorld.inputState.set(MouseInput.MouseClickDownMovement, {
       type: InputType.TWODIM,
       value: mouseMovement,
-      lifecycleState: Engine.instance.inputState.has(MouseInput.MouseClickDownMovement)
+      lifecycleState: Engine.instance.currentWorld.inputState.has(MouseInput.MouseClickDownMovement)
         ? LifecycleValue.Changed
         : LifecycleValue.Started
     })
@@ -436,7 +442,7 @@ export const handleMouseButton = (event: MouseEvent): void => {
   // Set type to BUTTON (up/down discrete state) and value to up or down, as called by the DOM mouse events
   if (mousedown) {
     // Set type to BUTTON and value to up or down
-    Engine.instance.inputState.set(event.button, {
+    Engine.instance.currentWorld.inputState.set(event.button, {
       type: InputType.BUTTON,
       value: [BinaryValue.ON],
       lifecycleState: LifecycleValue.Started
@@ -444,29 +450,29 @@ export const handleMouseButton = (event: MouseEvent): void => {
 
     // TODO: this would not be set if none of buttons assigned
     // Set type to TWOD (two dimensional) and value with x: -1, 1 and y: -1, 1
-    Engine.instance.inputState.set(MouseInput.MouseClickDownPosition, {
+    Engine.instance.currentWorld.inputState.set(MouseInput.MouseClickDownPosition, {
       type: InputType.TWODIM,
       value: mousePosition,
       lifecycleState: LifecycleValue.Started
     })
   } else {
-    // Removed mouse Engine.instance.inputState data
-    Engine.instance.inputState.set(event.button, {
+    // Removed mouse Engine.instance.currentWorld.inputState data
+    Engine.instance.currentWorld.inputState.set(event.button, {
       type: InputType.BUTTON,
       value: [BinaryValue.OFF],
       lifecycleState: LifecycleValue.Ended
     })
-    Engine.instance.inputState.set(MouseInput.MouseClickDownPosition, {
+    Engine.instance.currentWorld.inputState.set(MouseInput.MouseClickDownPosition, {
       type: InputType.TWODIM,
       value: mousePosition,
       lifecycleState: LifecycleValue.Ended
     })
-    Engine.instance.inputState.set(MouseInput.MouseClickDownTransformRotation, {
+    Engine.instance.currentWorld.inputState.set(MouseInput.MouseClickDownTransformRotation, {
       type: InputType.TWODIM,
       value: mousePosition,
       lifecycleState: LifecycleValue.Ended
     })
-    Engine.instance.inputState.set(MouseInput.MouseClickDownMovement, {
+    Engine.instance.currentWorld.inputState.set(MouseInput.MouseClickDownMovement, {
       type: InputType.TWODIM,
       value: [0, 0],
       lifecycleState: LifecycleValue.Ended
@@ -488,14 +494,17 @@ export const handleKey = (event: KeyboardEvent): any => {
   if (element?.tagName === 'INPUT' || element?.tagName === 'SELECT' || element?.tagName === 'TEXTAREA') {
     return
   }
-  // const mappedKey = Engine.instance.inputState.schema.keyboardInputMap[];
+  // const mappedKey = Engine.instance.currentWorld.inputState.schema.keyboardInputMap[];
   const key = event.code
 
   if (keydown) {
     // If the key is in the map but it's in the same state as now, let's skip it (debounce)
-    if (Engine.instance.inputState.has(key) && Engine.instance.inputState.get(key)?.value[0] === BinaryValue.ON) {
-      if (Engine.instance.inputState.get(key)?.lifecycleState !== LifecycleValue.Continued) {
-        Engine.instance.inputState.set(key, {
+    if (
+      Engine.instance.currentWorld.inputState.has(key) &&
+      Engine.instance.currentWorld.inputState.get(key)?.value[0] === BinaryValue.ON
+    ) {
+      if (Engine.instance.currentWorld.inputState.get(key)?.lifecycleState !== LifecycleValue.Continued) {
+        Engine.instance.currentWorld.inputState.set(key, {
           type: InputType.BUTTON,
           value: [BinaryValue.ON],
           lifecycleState: LifecycleValue.Continued
@@ -504,13 +513,13 @@ export const handleKey = (event: KeyboardEvent): any => {
       return
     }
     // Set type to BUTTON (up/down discrete state) and value to up or down, depending on what the value is set to
-    Engine.instance.inputState.set(key, {
+    Engine.instance.currentWorld.inputState.set(key, {
       type: InputType.BUTTON,
       value: [BinaryValue.ON],
       lifecycleState: LifecycleValue.Started
     })
   } else {
-    Engine.instance.inputState.set(key, {
+    Engine.instance.currentWorld.inputState.set(key, {
       type: InputType.BUTTON,
       value: [BinaryValue.OFF],
       lifecycleState: LifecycleValue.Ended
@@ -520,9 +529,9 @@ export const handleKey = (event: KeyboardEvent): any => {
 
 export const handleWindowFocus = (event: FocusEvent) => {
   if (event.type === 'focus')
-    Engine.instance.inputState.forEach((value, key) => {
+    Engine.instance.currentWorld.inputState.forEach((value, key) => {
       if (value.type === InputType.BUTTON && value.value[0] === BinaryValue.ON) {
-        Engine.instance.inputState.set(key, {
+        Engine.instance.currentWorld.inputState.set(key, {
           type: InputType.BUTTON,
           value: [BinaryValue.OFF],
           lifecycleState: LifecycleValue.Ended
@@ -533,9 +542,9 @@ export const handleWindowFocus = (event: FocusEvent) => {
 
 export const handleVisibilityChange = (event: Event) => {
   if (document.visibilityState === 'hidden') {
-    Engine.instance.inputState.forEach((value, key) => {
+    Engine.instance.currentWorld.inputState.forEach((value, key) => {
       if (value.type === InputType.BUTTON && value.value[0] === BinaryValue.ON) {
-        Engine.instance.inputState.set(key, {
+        Engine.instance.currentWorld.inputState.set(key, {
           type: InputType.BUTTON,
           value: [BinaryValue.OFF],
           lifecycleState: LifecycleValue.Ended
@@ -563,20 +572,20 @@ export const handleContextMenu = (event: MouseEvent): void => {
 
 export const handleMouseLeave = (event: MouseEvent): void => {
   ;[MouseInput.LeftButton, MouseInput.MiddleButton, MouseInput.RightButton].forEach((button) => {
-    if (!Engine.instance.inputState.has(button)) {
+    if (!Engine.instance.currentWorld.inputState.has(button)) {
       return
     }
-    Engine.instance.inputState.set(button, {
+    Engine.instance.currentWorld.inputState.set(button, {
       type: InputType.BUTTON,
       value: [BinaryValue.OFF],
       lifecycleState: LifecycleValue.Ended
     })
   })
 
-  if (Engine.instance.inputState.has(MouseInput.MouseClickDownPosition)) {
-    const value = Engine.instance.inputState.get(MouseInput.MouseClickDownPosition)?.value as number[]
+  if (Engine.instance.currentWorld.inputState.has(MouseInput.MouseClickDownPosition)) {
+    const value = Engine.instance.currentWorld.inputState.get(MouseInput.MouseClickDownPosition)?.value as number[]
     if (value[0] !== 0 || value[1] !== 0) {
-      Engine.instance.inputState.set(MouseInput.MouseClickDownPosition, {
+      Engine.instance.currentWorld.inputState.set(MouseInput.MouseClickDownPosition, {
         type: InputType.TWODIM,
         value: [0, 0],
         lifecycleState: LifecycleValue.Ended
@@ -584,10 +593,11 @@ export const handleMouseLeave = (event: MouseEvent): void => {
     }
   }
 
-  if (Engine.instance.inputState.has(MouseInput.MouseClickDownTransformRotation)) {
-    const value = Engine.instance.inputState.get(MouseInput.MouseClickDownTransformRotation)?.value as number[]
+  if (Engine.instance.currentWorld.inputState.has(MouseInput.MouseClickDownTransformRotation)) {
+    const value = Engine.instance.currentWorld.inputState.get(MouseInput.MouseClickDownTransformRotation)
+      ?.value as number[]
     if (value[0] !== 0 || value[1] !== 0) {
-      Engine.instance.inputState.set(MouseInput.MouseClickDownTransformRotation, {
+      Engine.instance.currentWorld.inputState.set(MouseInput.MouseClickDownTransformRotation, {
         type: InputType.TWODIM,
         value: [0, 0],
         lifecycleState: LifecycleValue.Ended

--- a/packages/engine/src/input/systems/ClientInputSystem.test.ts
+++ b/packages/engine/src/input/systems/ClientInputSystem.test.ts
@@ -24,66 +24,81 @@ describe('ClientInputSystem Unit Tests', () => {
 
   describe('processEngineInputState', () => {
     it('add new input - Started state', () => {
-      Engine.instance.inputState.set(GamepadAxis.Left, {
+      Engine.instance.currentWorld.inputState.set(GamepadAxis.Left, {
         type: InputType.TWODIM,
         value: stickPosition,
         lifecycleState: LifecycleValue.Started
       })
 
-      assert.strictEqual(Engine.instance.inputState.size, 1)
+      assert.strictEqual(Engine.instance.currentWorld.inputState.size, 1)
       processEngineInputState()
-      assert.strictEqual(Engine.instance.inputState.size, 1)
+      assert.strictEqual(Engine.instance.currentWorld.inputState.size, 1)
     })
 
     it('add new input - Ended state', () => {
-      Engine.instance.inputState.set(GamepadAxis.Right, {
+      Engine.instance.currentWorld.inputState.set(GamepadAxis.Right, {
         type: InputType.TWODIM,
         value: stickPosition,
         lifecycleState: LifecycleValue.Ended
       })
-      Engine.instance.inputState.set(GamepadAxis.Left, {
+      Engine.instance.currentWorld.inputState.set(GamepadAxis.Left, {
         type: InputType.TWODIM,
         value: stickPosition,
         lifecycleState: LifecycleValue.Started
       })
 
-      assert.strictEqual(Engine.instance.inputState.size, 2)
-      assert.strictEqual(Engine.instance.inputState.get(GamepadAxis.Left)?.lifecycleState, LifecycleValue.Started)
-      assert.strictEqual(Engine.instance.inputState.get(GamepadAxis.Right)?.lifecycleState, LifecycleValue.Ended)
+      assert.strictEqual(Engine.instance.currentWorld.inputState.size, 2)
+      assert.strictEqual(
+        Engine.instance.currentWorld.inputState.get(GamepadAxis.Left)?.lifecycleState,
+        LifecycleValue.Started
+      )
+      assert.strictEqual(
+        Engine.instance.currentWorld.inputState.get(GamepadAxis.Right)?.lifecycleState,
+        LifecycleValue.Ended
+      )
     })
 
     it('Two similar state becomes unchanged', () => {
-      Engine.instance.inputState.set(GamepadAxis.Left, {
+      Engine.instance.currentWorld.inputState.set(GamepadAxis.Left, {
         type: InputType.TWODIM,
         value: stickPosition,
         lifecycleState: LifecycleValue.Started
       })
 
       processEngineInputState()
-      assert.strictEqual(Engine.instance.inputState.get(GamepadAxis.Left)?.lifecycleState, LifecycleValue.Started)
-      assert.strictEqual(Engine.instance.inputState.size, 1)
+      assert.strictEqual(
+        Engine.instance.currentWorld.inputState.get(GamepadAxis.Left)?.lifecycleState,
+        LifecycleValue.Started
+      )
+      assert.strictEqual(Engine.instance.currentWorld.inputState.size, 1)
 
-      Engine.instance.inputState.set(GamepadAxis.Left, {
+      Engine.instance.currentWorld.inputState.set(GamepadAxis.Left, {
         type: InputType.TWODIM,
         value: stickPosition,
         lifecycleState: LifecycleValue.Started
       })
       processEngineInputState()
-      assert.strictEqual(Engine.instance.inputState.get(GamepadAxis.Left)?.lifecycleState, LifecycleValue.Unchanged)
-      assert.strictEqual(Engine.instance.inputState.size, 1)
+      assert.strictEqual(
+        Engine.instance.currentWorld.inputState.get(GamepadAxis.Left)?.lifecycleState,
+        LifecycleValue.Unchanged
+      )
+      assert.strictEqual(Engine.instance.currentWorld.inputState.size, 1)
     })
 
     it('set the first input into ended', () => {
-      Engine.instance.inputState.set(GamepadAxis.Left, {
+      Engine.instance.currentWorld.inputState.set(GamepadAxis.Left, {
         type: InputType.TWODIM,
         value: stickPosition,
         lifecycleState: LifecycleValue.Ended
       })
       processEngineInputState()
-      assert.strictEqual(Engine.instance.inputState.size, 1)
-      assert.strictEqual(Engine.instance.inputState.get(GamepadAxis.Left)?.lifecycleState, LifecycleValue.Ended)
+      assert.strictEqual(Engine.instance.currentWorld.inputState.size, 1)
+      assert.strictEqual(
+        Engine.instance.currentWorld.inputState.get(GamepadAxis.Left)?.lifecycleState,
+        LifecycleValue.Ended
+      )
       processEngineInputState()
-      assert.strictEqual(Engine.instance.inputState.size, 0)
+      assert.strictEqual(Engine.instance.currentWorld.inputState.size, 0)
     })
   })
 
@@ -99,12 +114,12 @@ describe('ClientInputSystem Unit Tests', () => {
       const mapping = 'mapping'
       const input = ['KeyV', 'KeyA']
 
-      Engine.instance.inputState.set('KeyV', {
+      Engine.instance.currentWorld.inputState.set('KeyV', {
         type: InputType.BUTTON,
         value: [BinaryValue.ON],
         lifecycleState: LifecycleValue.Started
       })
-      Engine.instance.inputState.set('KeyA', {
+      Engine.instance.currentWorld.inputState.set('KeyA', {
         type: InputType.BUTTON,
         value: [BinaryValue.ON],
         lifecycleState: LifecycleValue.Started
@@ -131,12 +146,12 @@ describe('ClientInputSystem Unit Tests', () => {
       const mapping = 'mapping'
       const input = ['KeyV', 'KeyA']
 
-      Engine.instance.inputState.set('KeyV', {
+      Engine.instance.currentWorld.inputState.set('KeyV', {
         type: InputType.BUTTON,
         value: [BinaryValue.ON],
         lifecycleState: LifecycleValue.Started
       })
-      Engine.instance.inputState.set('KeyA', {
+      Engine.instance.currentWorld.inputState.set('KeyA', {
         type: InputType.BUTTON,
         value: [BinaryValue.ON],
         lifecycleState: LifecycleValue.Started

--- a/packages/engine/src/input/systems/ClientInputSystem.ts
+++ b/packages/engine/src/input/systems/ClientInputSystem.ts
@@ -15,36 +15,36 @@ import { InputAlias } from '../types/InputAlias'
 
 export const processEngineInputState = () => {
   // for continuous input, figure out if the current data and previous data is the same
-  Engine.instance.inputState.forEach((value: InputValue, key: InputAlias) => {
-    if (Engine.instance.prevInputState.has(key)) {
+  Engine.instance.currentWorld.inputState.forEach((value: InputValue, key: InputAlias) => {
+    if (Engine.instance.currentWorld.prevInputState.has(key)) {
       if (value.type === InputType.BUTTON) {
         if (
           value.lifecycleState === LifecycleValue.Started &&
-          Engine.instance.prevInputState.get(key)?.lifecycleState === LifecycleValue.Started
+          Engine.instance.currentWorld.prevInputState.get(key)?.lifecycleState === LifecycleValue.Started
         ) {
           value.lifecycleState = LifecycleValue.Continued
         }
       } else {
         if (value.lifecycleState !== LifecycleValue.Ended) {
           value.lifecycleState =
-            JSON.stringify(value.value) === JSON.stringify(Engine.instance.prevInputState.get(key)?.value)
+            JSON.stringify(value.value) === JSON.stringify(Engine.instance.currentWorld.prevInputState.get(key)?.value)
               ? LifecycleValue.Unchanged
               : LifecycleValue.Changed
         }
       }
 
       if (
-        Engine.instance.prevInputState.get(key)?.lifecycleState === LifecycleValue.Ended &&
+        Engine.instance.currentWorld.prevInputState.get(key)?.lifecycleState === LifecycleValue.Ended &&
         value.lifecycleState === LifecycleValue.Ended
       ) {
-        Engine.instance.inputState.delete(key)
+        Engine.instance.currentWorld.inputState.delete(key)
       }
     }
   })
 
-  Engine.instance.prevInputState.clear()
-  Engine.instance.inputState.forEach((value: InputValue, key: InputAlias) => {
-    Engine.instance.prevInputState.set(key, value)
+  Engine.instance.currentWorld.prevInputState.clear()
+  Engine.instance.currentWorld.inputState.forEach((value: InputValue, key: InputAlias) => {
+    Engine.instance.currentWorld.prevInputState.set(key, value)
   })
 }
 
@@ -55,7 +55,7 @@ export const processCombinationLifecycle = (
   input: InputAlias[]
 ) => {
   const prev = prevData.get(mapping)
-  const isActive = input.map((c) => Engine.instance.inputState.has(c)).filter((a) => !a).length === 0
+  const isActive = input.map((c) => Engine.instance.currentWorld.inputState.has(c)).filter((a) => !a).length === 0
   const wasActive = prev?.lifecycleState === LifecycleValue.Started || prev?.lifecycleState === LifecycleValue.Continued
 
   if (isActive) {
@@ -105,8 +105,8 @@ export const processInputComponentData = (entity: Entity) => {
     if (typeof input === 'object') {
       processCombinationLifecycle(inputComponent, prevData, mapping, input)
     } else {
-      if (Engine.instance.inputState.has(input))
-        inputComponent.data.set(mapping, JSON.parse(JSON.stringify(Engine.instance.inputState.get(input))))
+      if (Engine.instance.currentWorld.inputState.has(input))
+        inputComponent.data.set(mapping, JSON.parse(JSON.stringify(Engine.instance.currentWorld.inputState.get(input))))
     }
   }
 

--- a/packages/engine/src/interaction/functions/interactText.ts
+++ b/packages/engine/src/interaction/functions/interactText.ts
@@ -53,12 +53,14 @@ export const createInteractText = (displayText: string | undefined) => {
       if (!interactTextObject.visible) return
       interactTextObject.children[0].position.y = Math.sin(elapsedTime * 1.8) * 0.05
       if (
-        Engine.instance.activeCameraFollowTarget &&
-        hasComponent(Engine.instance.activeCameraFollowTarget, FollowCameraComponent)
+        Engine.instance.currentWorld.activeCameraFollowTarget &&
+        hasComponent(Engine.instance.currentWorld.activeCameraFollowTarget, FollowCameraComponent)
       ) {
         interactTextObject.children[0].setRotationFromAxisAngle(
           upVec,
-          MathUtils.degToRad(getComponent(Engine.instance.activeCameraFollowTarget, FollowCameraComponent).theta)
+          MathUtils.degToRad(
+            getComponent(Engine.instance.currentWorld.activeCameraFollowTarget, FollowCameraComponent).theta
+          )
         )
       } else {
         const { x, z } = getComponent(entity, TransformComponent).position

--- a/packages/engine/src/interaction/functions/interactUI.ts
+++ b/packages/engine/src/interaction/functions/interactUI.ts
@@ -71,7 +71,7 @@ export function createInteractUI(modelEntity: Entity) {
     const centeringGroup = new Group()
     boundingBoxComponent.box.getCenter(centeringGroup.position)
 
-    Engine.instance.scene.add(centeringGroup)
+    Engine.instance.currentWorld.scene.add(centeringGroup)
     centeringGroup.attach(modelObj)
     c.position.copy(centeringGroup.position)
 
@@ -223,9 +223,9 @@ export const updateInteractUI = (modelEntity: Entity, xrui: ReturnType<typeof cr
     transitionStartTime.set(modelEntity, world.elapsedSeconds)
     xrui.state.mode.set(nextMode)
     if (nextMode === 'interacting') {
-      Engine.instance.camera.attach(uiContainer)
+      Engine.instance.currentWorld.camera.attach(uiContainer)
     } else {
-      Engine.instance.scene.attach(uiContainer)
+      Engine.instance.currentWorld.scene.attach(uiContainer)
     }
     modelGroup.traverse((obj) => {
       const mesh = obj as Mesh<BufferGeometry, MeshBasicMaterial>
@@ -270,13 +270,14 @@ export const updateInteractUI = (modelEntity: Entity, xrui: ReturnType<typeof cr
   const linkMat = link.contentMesh.material as MeshBasicMaterial
 
   if (nextMode === 'inactive') {
-    const uiContainerScale = Math.max(1, Engine.instance.camera.position.distanceTo(anchoredPosition)) * 0.8
+    const uiContainerScale =
+      Math.max(1, Engine.instance.currentWorld.camera.position.distanceTo(anchoredPosition)) * 0.8
     uiContainer.position.lerp(anchoredPosition, alpha)
-    uiContainer.quaternion.slerp(_quat.setFromRotationMatrix(Engine.instance.camera.matrix), alpha)
+    uiContainer.quaternion.slerp(_quat.setFromRotationMatrix(Engine.instance.currentWorld.camera.matrix), alpha)
     uiContainer.scale.lerp(_vect.setScalar(uiContainerScale), alpha)
 
-    if (modelGroup.parent !== Engine.instance.scene) {
-      Engine.instance.scene.attach(modelGroup)
+    if (modelGroup.parent !== Engine.instance.currentWorld.scene) {
+      Engine.instance.currentWorld.scene.attach(modelGroup)
     }
 
     modelGroup.position.lerp(anchoredPosition, alpha)
@@ -306,13 +307,14 @@ export const updateInteractUI = (modelEntity: Entity, xrui: ReturnType<typeof cr
       mat.opacity = MathUtils.lerp(mat.opacity, 0, alpha)
     }
   } else if (nextMode === 'active') {
-    const uiContainerScale = Math.max(1, Engine.instance.camera.position.distanceTo(anchoredPosition)) * 0.8
+    const uiContainerScale =
+      Math.max(1, Engine.instance.currentWorld.camera.position.distanceTo(anchoredPosition)) * 0.8
     uiContainer.position.lerp(anchoredPosition, alpha)
-    uiContainer.quaternion.slerp(_quat.setFromRotationMatrix(Engine.instance.camera.matrix), alpha)
+    uiContainer.quaternion.slerp(_quat.setFromRotationMatrix(Engine.instance.currentWorld.camera.matrix), alpha)
     uiContainer.scale.lerp(_vect.setScalar(uiContainerScale), alpha)
 
-    if (modelGroup.parent !== Engine.instance.scene) {
-      Engine.instance.scene.attach(modelGroup)
+    if (modelGroup.parent !== Engine.instance.currentWorld.scene) {
+      Engine.instance.currentWorld.scene.attach(modelGroup)
     }
 
     const modelTargetPosition = _vect.copy(anchoredPosition)
@@ -368,7 +370,7 @@ export const updateInteractUI = (modelEntity: Entity, xrui: ReturnType<typeof cr
     }
 
     modelGroup.position.lerp(_vect.setScalar(0), alpha)
-    modelGroup.quaternion.slerp(_quat.copy(Engine.instance.camera.quaternion).invert(), alpha)
+    modelGroup.quaternion.slerp(_quat.copy(Engine.instance.currentWorld.camera.quaternion).invert(), alpha)
     modelGroup.scale.lerp(_vect.setScalar(modelScale), alpha)
 
     rootMat.opacity = MathUtils.lerp(rootMat.opacity, 1, alpha)

--- a/packages/engine/src/navigation/systems/AutopilotSystem.ts
+++ b/packages/engine/src/navigation/systems/AutopilotSystem.ts
@@ -69,7 +69,7 @@ export default async function AutopilotSystem(world: World) {
 
   const vec3 = new Vector3()
   function getCameraDirection() {
-    Engine.instance.camera.getWorldDirection(vec3)
+    Engine.instance.currentWorld.camera.getWorldDirection(vec3)
 
     vec3.setY(0).normalize()
     quat.setFromUnitVectors(forward, vec3)
@@ -80,7 +80,7 @@ export default async function AutopilotSystem(world: World) {
     for (const entity of navClickQuery.enter()) {
       const { coords } = getComponent(entity, AutoPilotClickRequestComponent)
       const overrideComponent = getComponent(entity, AutoPilotOverrideComponent)
-      raycaster.setFromCamera(coords, Engine.instance.camera)
+      raycaster.setFromCamera(coords, Engine.instance.currentWorld.camera)
 
       const raycasterResults: Intersection[] = []
       let _entity = -1 as Entity
@@ -179,7 +179,7 @@ export default async function AutopilotSystem(world: World) {
         if (targetFlatDistance < ARRIVED_DISTANCE) {
           if (autopilot.path.finished()) {
             // Path is finished!
-            Engine.instance.inputState.set(GAMEPAD_STICK, {
+            Engine.instance.currentWorld.inputState.set(GAMEPAD_STICK, {
               type: InputType.TWODIM,
               value: [0, 0, 0],
               lifecycleState: LifecycleValue.Changed
@@ -203,10 +203,10 @@ export default async function AutopilotSystem(world: World) {
 
           const stickPosition: NumericalType = [stickValue.z, stickValue.x, targetAngle]
           // If position not set, set it with lifecycle started
-          Engine.instance.inputState.set(GAMEPAD_STICK, {
+          Engine.instance.currentWorld.inputState.set(GAMEPAD_STICK, {
             type: InputType.TWODIM,
             value: stickPosition,
-            lifecycleState: Engine.instance.inputState.has(GAMEPAD_STICK)
+            lifecycleState: Engine.instance.currentWorld.inputState.has(GAMEPAD_STICK)
               ? LifecycleValue.Started
               : LifecycleValue.Changed
           })
@@ -218,7 +218,7 @@ export default async function AutopilotSystem(world: World) {
 
     if (autopilotQuery.exit(world).length) {
       // send one relaxed gamepad state to stop movement
-      Engine.instance.inputState.set(GAMEPAD_STICK, {
+      Engine.instance.currentWorld.inputState.set(GAMEPAD_STICK, {
         type: InputType.TWODIM,
         value: [0, 0],
         lifecycleState: LifecycleValue.Changed

--- a/packages/engine/src/physics/functions/createCollider.ts
+++ b/packages/engine/src/physics/functions/createCollider.ts
@@ -125,7 +125,7 @@ export const createShape = (entity: Entity, mesh: Mesh, shapeOptions: ShapeOptio
       //   // debugMesh.quaternion.copy(rot)
       //   // debugMesh.scale.copy(scale)
       //   // console.log(debugMesh)
-      //   // Engine.instance.scene.add(debugMesh)
+      //   // Engine.instance.currentWorld.scene.add(debugMesh)
       // }
       // yes, don't break here - use convex for cylinder
       return undefined!

--- a/packages/engine/src/renderer/EngineRendererState.ts
+++ b/packages/engine/src/renderer/EngineRendererState.ts
@@ -113,13 +113,13 @@ function updateState(): void {
   if (Engine.instance.isEditor) {
     changeRenderMode(state.renderMode.value)
 
-    if (state.nodeHelperVisibility.value) Engine.instance.camera.layers.enable(ObjectLayers.NodeHelper)
-    else Engine.instance.camera.layers.disable(ObjectLayers.NodeHelper)
+    if (state.nodeHelperVisibility.value) Engine.instance.currentWorld.camera.layers.enable(ObjectLayers.NodeHelper)
+    else Engine.instance.currentWorld.camera.layers.disable(ObjectLayers.NodeHelper)
 
     InfiniteGridHelper.instance.setGridHeight(state.gridHeight.value)
     InfiniteGridHelper.instance.visible = state.gridVisibility.value
   } else {
-    Engine.instance.camera.layers.disable(ObjectLayers.NodeHelper)
+    Engine.instance.currentWorld.camera.layers.disable(ObjectLayers.NodeHelper)
   }
 }
 

--- a/packages/engine/src/renderer/WebGLRendererSystem.ts
+++ b/packages/engine/src/renderer/WebGLRendererSystem.ts
@@ -170,7 +170,7 @@ export class EngineRenderer {
   execute(delta: number): void {
     if (this.xrManager.isPresenting) {
       this.csm?.update()
-      this.renderer.render(Engine.instance.scene, Engine.instance.camera)
+      this.renderer.render(Engine.instance.currentWorld.scene, Engine.instance.currentWorld.camera)
     } else {
       const state = accessEngineRendererState()
       const engineState = getEngineState()
@@ -185,8 +185,8 @@ export class EngineRenderer {
           const width = window.innerWidth
           const height = window.innerHeight
 
-          if ((Engine.instance.camera as PerspectiveCamera).isPerspectiveCamera) {
-            const cam = Engine.instance.camera as PerspectiveCamera
+          if ((Engine.instance.currentWorld.camera as PerspectiveCamera).isPerspectiveCamera) {
+            const cam = Engine.instance.currentWorld.camera as PerspectiveCamera
             cam.aspect = width / height
             cam.updateProjectionMatrix()
           }
@@ -202,7 +202,7 @@ export class EngineRenderer {
           this.effectComposer.render(delta)
         } else {
           this.renderer.autoClear = true
-          this.renderer.render(Engine.instance.scene, Engine.instance.camera)
+          this.renderer.render(Engine.instance.currentWorld.scene, Engine.instance.currentWorld.camera)
         }
       }
     }

--- a/packages/engine/src/renderer/functions/changeRenderMode.ts
+++ b/packages/engine/src/renderer/functions/changeRenderMode.ts
@@ -18,7 +18,7 @@ export function changeRenderMode(mode: RenderModesType): void {
   // revert any changes made by a render mode
   switch (renderMode) {
     case RenderModes.UNLIT:
-      Engine.instance.scene.traverse((obj: Light) => {
+      Engine.instance.currentWorld.scene.traverse((obj: Light) => {
         if (obj.isLight && obj.userData.editor_disabled) {
           delete obj.userData.editor_disabled
           obj.visible = true
@@ -36,7 +36,7 @@ export function changeRenderMode(mode: RenderModesType): void {
 
   switch (mode) {
     case RenderModes.UNLIT:
-      Engine.instance.scene.traverse((obj: Light) => {
+      Engine.instance.currentWorld.scene.traverse((obj: Light) => {
         if (obj.isLight && obj.visible) {
           obj.userData.editor_disabled = true
           obj.visible = false

--- a/packages/engine/src/renderer/functions/configureEffectComposer.ts
+++ b/packages/engine/src/renderer/functions/configureEffectComposer.ts
@@ -13,7 +13,7 @@ export const configureEffectComposer = (remove?: boolean): void => {
   EngineRenderer.instance.effectComposer.removeAllPasses()
 
   // we always want to have at least the render pass enabled
-  const renderPass = new RenderPass(Engine.instance.scene, Engine.instance.camera)
+  const renderPass = new RenderPass(Engine.instance.currentWorld.scene, Engine.instance.currentWorld.camera)
   EngineRenderer.instance.effectComposer.addPass(renderPass)
 
   if (remove) {
@@ -28,7 +28,7 @@ export const configureEffectComposer = (remove?: boolean): void => {
   const effects: any[] = []
   const effectKeys = EffectMap.keys()
 
-  const normalPass = new NormalPass(Engine.instance.scene, Engine.instance.camera, {
+  const normalPass = new NormalPass(Engine.instance.currentWorld.scene, Engine.instance.currentWorld.camera, {
     renderTarget: new WebGLRenderTarget(1, 1, {
       minFilter: NearestFilter,
       magFilter: NearestFilter,
@@ -51,14 +51,14 @@ export const configureEffectComposer = (remove?: boolean): void => {
     if (!effectClass) return
 
     if (key === Effects.SSAOEffect) {
-      const eff = new effectClass(Engine.instance.camera, normalPass.texture, {
+      const eff = new effectClass(Engine.instance.currentWorld.camera, normalPass.texture, {
         ...effect,
         normalDepthBuffer: depthDownsamplingPass.texture
       })
       EngineRenderer.instance.effectComposer[key] = eff
       effects.push(eff)
     } else if (key === Effects.DepthOfFieldEffect) {
-      const eff = new effectClass(Engine.instance.camera, effect)
+      const eff = new effectClass(Engine.instance.currentWorld.camera, effect)
       EngineRenderer.instance.effectComposer[key] = eff
       effects.push(eff)
     } else if (key === Effects.OutlineEffect) {
@@ -66,7 +66,11 @@ export const configureEffectComposer = (remove?: boolean): void => {
       if (Engine.instance.isEditor) {
         outlineEffect = { ...outlineEffect, hiddenEdgeColor: 0x22090a }
       }
-      const eff = new effectClass(Engine.instance.scene, Engine.instance.camera, outlineEffect)
+      const eff = new effectClass(
+        Engine.instance.currentWorld.scene,
+        Engine.instance.currentWorld.camera,
+        outlineEffect
+      )
       EngineRenderer.instance.effectComposer[key] = eff
       effects.push(eff)
     } else {
@@ -85,7 +89,9 @@ export const configureEffectComposer = (remove?: boolean): void => {
     })
 
     EngineRenderer.instance.effectComposer.addPass(depthDownsamplingPass)
-    EngineRenderer.instance.effectComposer.addPass(new EffectPass(Engine.instance.camera, ...effects, textureEffect))
+    EngineRenderer.instance.effectComposer.addPass(
+      new EffectPass(Engine.instance.currentWorld.camera, ...effects, textureEffect)
+    )
   }
 
   if (Engine.instance.isEditor) changeRenderMode(accessEngineRendererState().renderMode.value)

--- a/packages/engine/src/scene/classes/TransformGizmo.ts
+++ b/packages/engine/src/scene/classes/TransformGizmo.ts
@@ -300,7 +300,7 @@ export default class TransformGizmo extends Object3D {
     this.scaleXZPlane.visible = visible
   }
 
-  raycastAxis(target: Vector2, camera = Engine.instance.camera): Intersection<Object3D> | undefined {
+  raycastAxis(target: Vector2, camera = Engine.instance.currentWorld.camera): Intersection<Object3D> | undefined {
     if (!this.activeControls) return
 
     this.raycasterResults.length = 0
@@ -311,7 +311,10 @@ export default class TransformGizmo extends Object3D {
       .find((result) => (result.object as MeshWithAxisInfo).axisInfo !== undefined)
   }
 
-  selectAxisWithRaycaster(target: Vector2, camera = Engine.instance.camera): TransformAxisType | undefined {
+  selectAxisWithRaycaster(
+    target: Vector2,
+    camera = Engine.instance.currentWorld.camera
+  ): TransformAxisType | undefined {
     this.deselectAxis()
 
     const axisResult = this.raycastAxis(target, camera)
@@ -329,7 +332,7 @@ export default class TransformGizmo extends Object3D {
     return newAxisInfo.axis
   }
 
-  highlightHoveredAxis(target: Vector2, camera = Engine.instance.camera): void {
+  highlightHoveredAxis(target: Vector2, camera = Engine.instance.currentWorld.camera): void {
     if (!this.activeControls) return
     if (this.hoveredAxis) this.hoveredAxis.axisInfo.selectionColorTarget.opacity = 0.5
 

--- a/packages/engine/src/scene/functions/ReparentFunction.ts
+++ b/packages/engine/src/scene/functions/ReparentFunction.ts
@@ -25,7 +25,7 @@ export const reparentObject3D = (
   const parentObj3d =
     _parent.parentEntity && getComponent(_parent.entity, Object3DComponent)
       ? getComponent(_parent.entity, Object3DComponent).value
-      : Engine.instance.scene
+      : Engine.instance.currentWorld.scene
 
   if (obj3d.parent && obj3d.parent !== parentObj3d) {
     // Maintain world position when reparenting.

--- a/packages/engine/src/scene/functions/SceneLoading.ts
+++ b/packages/engine/src/scene/functions/SceneLoading.ts
@@ -165,7 +165,7 @@ export const loadSceneFromJSON = async (
   const promises = preCacheAssets(sceneData, onProgress)
 
   // todo: move these layer enable & disable to loading screen thing or something so they work with portals properly
-  if (!getEngineState().isTeleporting.value) Engine.instance.camera?.layers.disable(ObjectLayers.Scene)
+  if (!getEngineState().isTeleporting.value) Engine.instance.currentWorld.camera?.layers.disable(ObjectLayers.Scene)
 
   promises.forEach((promise) => promise.then(onComplete))
   await Promise.all(promises)
@@ -190,7 +190,7 @@ export const loadSceneFromJSON = async (
     addEntityNodeInTree(node, sceneEntity.parent ? entityMap[sceneEntity.parent] : undefined)
   })
 
-  addComponent(tree.rootNode.entity, Object3DComponent, { value: Engine.instance.scene })
+  addComponent(tree.rootNode.entity, Object3DComponent, { value: Engine.instance.currentWorld.scene })
   addComponent(tree.rootNode.entity, SceneTagComponent, {})
   getComponent(tree.rootNode.entity, EntityNodeComponent).components.push(SCENE_COMPONENT_SCENE_TAG)
 
@@ -199,7 +199,7 @@ export const loadSceneFromJSON = async (
     EngineRendererAction.setPostProcessing(getComponentCountOfType(PostprocessingComponent) > 0)
   )
 
-  if (!getEngineState().isTeleporting.value) Engine.instance.camera?.layers.enable(ObjectLayers.Scene)
+  if (!getEngineState().isTeleporting.value) Engine.instance.currentWorld.camera?.layers.enable(ObjectLayers.Scene)
 
   dispatchAction(Engine.instance.store, EngineActions.sceneLoaded()) //.delay(0.1)
 }

--- a/packages/engine/src/scene/functions/loadGLTFModel.ts
+++ b/packages/engine/src/scene/functions/loadGLTFModel.ts
@@ -142,7 +142,7 @@ export const loadNavmesh = (entity: Entity, object3d?: Object3D): void => {
     navMesh.fromPolygons(polygons)
 
     // const helper = createConvexRegionHelper(navMesh)
-    // Engine.instance.scene.add(helper)
+    // Engine.instance.currentWorld.scene.add(helper)
 
     addComponent(entity, NavMeshComponent, {
       yukaNavMesh: navMesh,

--- a/packages/engine/src/scene/functions/loaders/AudioFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/AudioFunctions.ts
@@ -102,8 +102,8 @@ export const updateAudio: ComponentUpdateFunction = (entity: Entity, properties:
     if (obj3d.userData.audioEl) obj3d.userData.audioEl.removeFromParent()
     obj3d.userData.audioEl =
       component.audioType === AudioType.Stereo
-        ? new Audio(Engine.instance.audioListener)
-        : new PositionalAudio(Engine.instance.audioListener)
+        ? new Audio(Engine.instance.currentWorld.audioListener)
+        : new PositionalAudio(Engine.instance.currentWorld.audioListener)
 
     obj3d.userData.audioEl.matrixAutoUpdate = false
     obj3d.add(obj3d.userData.audioEl)

--- a/packages/engine/src/scene/functions/loaders/CubemapBakeFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/CubemapBakeFunctions.ts
@@ -96,7 +96,7 @@ export const serializeCubemapBake: ComponentSerializeFunction = (entity) => {
 }
 
 export const prepareSceneForBake = (world = useWorld()): Scene => {
-  const scene = Engine.instance.scene.clone(false)
+  const scene = Engine.instance.currentWorld.scene.clone(false)
   const parents = {
     [world.entityTree.rootNode.entity]: scene
   } as { [key: Entity]: Object3D }

--- a/packages/engine/src/scene/functions/loaders/DirectionalLightFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/DirectionalLightFunctions.ts
@@ -136,9 +136,9 @@ export const updateDirectionalLight: ComponentUpdateFunction = (
   light.userData.cameraHelper.visible = component.showCameraHelper
 
   if (component.showCameraHelper) {
-    Engine.instance.scene.add(light.userData.cameraHelper)
+    Engine.instance.currentWorld.scene.add(light.userData.cameraHelper)
   } else {
-    Engine.instance.scene.remove(light.userData.cameraHelper)
+    Engine.instance.currentWorld.scene.remove(light.userData.cameraHelper)
   }
 
   light.userData.cameraHelper.update()

--- a/packages/engine/src/scene/functions/loaders/EnvMapFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/EnvMapFunctions.ts
@@ -65,7 +65,7 @@ export const deserializeEnvMap: ComponentDeserializeFunction = (
 
 export const updateEnvMap: ComponentUpdateFunction = (entity: Entity, properties: EnvmapComponentType) => {
   const component = getComponent(entity, EnvmapComponent)
-  const obj3d = component.forModel ? getComponent(entity, Object3DComponent)?.value : Engine.instance.scene
+  const obj3d = component.forModel ? getComponent(entity, Object3DComponent)?.value : Engine.instance.currentWorld.scene
 
   if (
     typeof properties.type !== 'undefined' ||

--- a/packages/engine/src/scene/functions/loaders/FogFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/FogFunctions.test.ts
@@ -39,9 +39,9 @@ describe('FogFunctions', () => {
     assert.equal(near, 0.1)
     assert.equal(far, 1000)
 
-    assert(Engine.instance.scene.fog instanceof Fog)
+    assert(Engine.instance.currentWorld.scene.fog instanceof Fog)
 
     // TODO: unnecessary once engine global scope is refactored
-    Engine.instance.scene = null!
+    Engine.instance.currentWorld.scene = null!
   })
 })

--- a/packages/engine/src/scene/functions/loaders/FogFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/FogFunctions.ts
@@ -37,26 +37,26 @@ export const updateFog: ComponentUpdateFunction = (entity: Entity, _properties: 
 
   switch (component.type) {
     case FogType.Linear:
-      if (Engine.instance.scene.fog instanceof Fog) {
-        Engine.instance.scene.fog.color = component.color
-        Engine.instance.scene.fog.near = component.near
-        Engine.instance.scene.fog.far = component.far
+      if (Engine.instance.currentWorld.scene.fog instanceof Fog) {
+        Engine.instance.currentWorld.scene.fog.color = component.color
+        Engine.instance.currentWorld.scene.fog.near = component.near
+        Engine.instance.currentWorld.scene.fog.far = component.far
       } else {
-        Engine.instance.scene.fog = new Fog(component.color, component.near, component.far)
+        Engine.instance.currentWorld.scene.fog = new Fog(component.color, component.near, component.far)
       }
       break
 
     case FogType.Exponential:
-      if (Engine.instance.scene.fog instanceof FogExp2) {
-        Engine.instance.scene.fog.color = component.color
-        Engine.instance.scene.fog.density = component.density
+      if (Engine.instance.currentWorld.scene.fog instanceof FogExp2) {
+        Engine.instance.currentWorld.scene.fog.color = component.color
+        Engine.instance.currentWorld.scene.fog.density = component.density
       } else {
-        Engine.instance.scene.fog = new FogExp2(component.color.getHexString(), component.density)
+        Engine.instance.currentWorld.scene.fog = new FogExp2(component.color.getHexString(), component.density)
       }
       break
 
     default:
-      Engine.instance.scene.fog = null
+      Engine.instance.currentWorld.scene.fog = null
       break
   }
 }

--- a/packages/engine/src/scene/functions/loaders/GroundPlaneFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/GroundPlaneFunctions.ts
@@ -80,10 +80,10 @@ export const updateGroundPlane: ComponentUpdateFunction = (entity: Entity, prope
       if (!navigationRaycastTarget) navigationRaycastTarget = new Group()
 
       navigationRaycastTarget.scale.setScalar(getComponent(entity, TransformComponent).scale.x)
-      Engine.instance.scene.add(navigationRaycastTarget)
+      Engine.instance.currentWorld.scene.add(navigationRaycastTarget)
       addComponent(entity, NavMeshComponent, { navTarget: navigationRaycastTarget })
     } else {
-      Engine.instance.scene.remove(navigationRaycastTarget)
+      Engine.instance.currentWorld.scene.remove(navigationRaycastTarget)
       removeComponent(entity, NavMeshComponent)
     }
   }

--- a/packages/engine/src/scene/functions/loaders/RenderSettingsFunction.ts
+++ b/packages/engine/src/scene/functions/loaders/RenderSettingsFunction.ts
@@ -105,7 +105,7 @@ export const updateShadowMap = (enable: boolean, shadowMapType?: number) => {
     EngineRenderer.instance.renderer.shadowMap.enabled = false
   }
 
-  Engine.instance.scene.traverse((node: Light) => {
+  Engine.instance.currentWorld.scene.traverse((node: Light) => {
     if (node.isLight && node.shadow) {
       node.shadow.map?.dispose()
       node.castShadow = enable
@@ -139,8 +139,8 @@ export const initializeCSM = () => {
     })
 
     EngineRenderer.instance.csm = new CSM({
-      camera: Engine.instance.camera as PerspectiveCamera,
-      parent: Engine.instance.scene,
+      camera: Engine.instance.currentWorld.camera as PerspectiveCamera,
+      parent: Engine.instance.currentWorld.scene,
       lights
     })
 
@@ -148,7 +148,7 @@ export const initializeCSM = () => {
       activeCSMLight.getWorldDirection(EngineRenderer.instance.csm.lightDirection)
     }
 
-    Engine.instance.scene.traverse((obj: Mesh) => {
+    Engine.instance.currentWorld.scene.traverse((obj: Mesh) => {
       if (typeof obj.material !== 'undefined' && obj.receiveShadow) EngineRenderer.instance.csm.setupMaterial(obj)
     })
   }

--- a/packages/engine/src/scene/functions/loaders/ScenePreviewCameraFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/ScenePreviewCameraFunctions.test.ts
@@ -72,12 +72,12 @@ describe('ScenePreviewCameraFunctions', () => {
 
     describe('Editor vs Location', () => {
       it('creates ScenePreviewCamera in Location', () => {
-        Engine.instance.activeCameraEntity = createEntity()
-        Engine.instance.camera = new PerspectiveCamera()
+        Engine.instance.currentWorld.activeCameraEntity = createEntity()
+        Engine.instance.currentWorld.camera = new PerspectiveCamera()
 
         scenePreviewCameraFunctions.deserializeScenePreviewCamera(entity, sceneComponent)
 
-        assert(Engine.instance.camera.position.equals(getComponent(entity, TransformComponent).position))
+        assert(Engine.instance.currentWorld.camera.position.equals(getComponent(entity, TransformComponent).position))
       })
 
       it('creates ScenePreviewCamera in Editor', () => {
@@ -99,11 +99,11 @@ describe('ScenePreviewCameraFunctions', () => {
 
       scenePreviewCameraFunctions.deserializeScenePreviewCamera(entity, sceneComponent)
 
-      Engine.instance.camera = new PerspectiveCamera()
-      Engine.instance.camera.position.set(1, 2, 3)
-      Engine.instance.camera.rotation.set(4, 5, 6)
-      Engine.instance.camera.scale.set(7, 8, 9)
-      Engine.instance.camera.updateMatrixWorld()
+      Engine.instance.currentWorld.camera = new PerspectiveCamera()
+      Engine.instance.currentWorld.camera.position.set(1, 2, 3)
+      Engine.instance.currentWorld.camera.rotation.set(4, 5, 6)
+      Engine.instance.currentWorld.camera.scale.set(7, 8, 9)
+      Engine.instance.currentWorld.camera.updateMatrixWorld()
 
       const parent = new Object3D()
       parent.add(getComponent(entity, Object3DComponent)?.value)

--- a/packages/engine/src/scene/functions/loaders/ScenePreviewCameraFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/ScenePreviewCameraFunctions.ts
@@ -41,9 +41,9 @@ export const deserializeScenePreviewCamera: ComponentDeserializeFunction = (enti
     setObjectLayers(camera.userData.helper, ObjectLayers.NodeHelper)
 
     addComponent(entity, Object3DComponent, { value: camera })
-  } else if (Engine.instance.activeCameraEntity) {
+  } else if (Engine.instance.currentWorld.activeCameraEntity) {
     const transformComponent = getComponent(entity, TransformComponent)
-    Engine.instance.camera.position.copy(transformComponent.position)
+    Engine.instance.currentWorld.camera.position.copy(transformComponent.position)
   }
 }
 
@@ -54,7 +54,7 @@ export const updateCameraTransform = (entity: Entity) => {
   return new Matrix4()
     .copy(obj3d.parent!.matrixWorld)
     .invert()
-    .multiply(Engine.instance.camera.matrixWorld)
+    .multiply(Engine.instance.currentWorld.camera.matrixWorld)
     .decompose(transformComponent.position, transformComponent.rotation, transformComponent.scale)
 }
 

--- a/packages/engine/src/scene/functions/loaders/SimpleMaterialFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SimpleMaterialFunctions.ts
@@ -368,9 +368,9 @@ export const useSimpleMaterial = (obj: Object3DWithEntity & Mesh<any, any>): voi
     })
 
     if (hasEnvMap) {
-      obj.material.envMap = Engine.instance.scene?.environment
+      obj.material.envMap = Engine.instance.currentWorld.scene?.environment
       obj.material.uniforms.envMap = {
-        value: Engine.instance.scene?.environment
+        value: Engine.instance.currentWorld.scene?.environment
       }
       obj.material.uniforms.envMapIntensity = { value: 1 }
       obj.material.uniforms.flipEnvMap = { value: 1 }

--- a/packages/engine/src/scene/functions/loaders/SkyboxFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/SkyboxFunctions.ts
@@ -68,7 +68,7 @@ export const updateSkybox: ComponentUpdateFunction = (entity: Entity) => {
 
   switch (component.backgroundType) {
     case SkyTypeEnum.color:
-      Engine.instance.scene.background = component.backgroundColor
+      Engine.instance.currentWorld.scene.background = component.backgroundColor
       break
 
     case SkyTypeEnum.cubemap:
@@ -76,7 +76,7 @@ export const updateSkybox: ComponentUpdateFunction = (entity: Entity) => {
         component.cubemapPath,
         (texture) => {
           texture.encoding = sRGBEncoding
-          Engine.instance.scene.background = texture
+          Engine.instance.currentWorld.scene.background = texture
           removeError(entity, 'error')
         },
         undefined,
@@ -89,7 +89,7 @@ export const updateSkybox: ComponentUpdateFunction = (entity: Entity) => {
         component.equirectangularPath,
         (texture) => {
           texture.encoding = sRGBEncoding
-          Engine.instance.scene.background = getPmremGenerator().fromEquirectangular(texture).texture
+          Engine.instance.currentWorld.scene.background = getPmremGenerator().fromEquirectangular(texture).texture
           removeError(entity, 'error')
         },
         undefined,
@@ -112,7 +112,7 @@ export const updateSkybox: ComponentUpdateFunction = (entity: Entity) => {
       component.sky.luminance = component.skyboxProps.luminance
 
       setSkyDirection(component.sky.sunPosition)
-      Engine.instance.scene.background = getPmremGenerator().fromCubemap(
+      Engine.instance.currentWorld.scene.background = getPmremGenerator().fromCubemap(
         component.sky.generateSkyboxTextureCube(EngineRenderer.instance.renderer)
       ).texture
 

--- a/packages/engine/src/scene/functions/loaders/VideoFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/VideoFunctions.ts
@@ -144,7 +144,9 @@ export const updateVideo: ComponentUpdateFunction = (entity: Entity, properties:
           mesh.material.map.image.width = mesh.material.map.image.videoWidth
           if (getComponent(entity, ImageComponent)?.projection === ImageProjection.Flat) resizeImageMesh(mesh)
 
-          const audioSource = Engine.instance.audioListener.context.createMediaElementSource(obj3d.userData.videoEl)
+          const audioSource = Engine.instance.currentWorld.audioListener.context.createMediaElementSource(
+            obj3d.userData.videoEl
+          )
           obj3d.userData.audioEl.setNodeSource(audioSource)
 
           updateAutoStartTimeForMedia(entity)

--- a/packages/engine/src/scene/functions/loaders/VolumetricFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/VolumetricFunctions.ts
@@ -146,7 +146,7 @@ export const updateVolumetric: ComponentUpdateFunction = (entity: Entity, proper
         return VolumetricCallbacks
       }
       //TODO: it is breaking the video play. need to check later
-      // const audioSource = Engine.instance.audioListener.context.createMediaElementSource(obj3d.userData.player.video)
+      // const audioSource = Engine.instance.currentWorld.audioListener.context.createMediaElementSource(obj3d.userData.player.video)
       // obj3d.userData.audioEl.setNodeSource(audioSource)
     } catch (error) {
       addError(entity, 'error', error.message)

--- a/packages/engine/src/scene/functions/setCameraProperties.ts
+++ b/packages/engine/src/scene/functions/setCameraProperties.ts
@@ -15,7 +15,7 @@ export const setCameraProperties = (entity: Entity, data: CameraPropertiesCompon
 
   console.log(data)
   if (data.projectionType === ProjectionType.Orthographic) {
-    Engine.instance.camera = new OrthographicCamera(
+    Engine.instance.currentWorld.camera = new OrthographicCamera(
       data.fov / -2,
       data.fov / 2,
       data.fov / 2,
@@ -23,12 +23,12 @@ export const setCameraProperties = (entity: Entity, data: CameraPropertiesCompon
       data.cameraNearClip,
       data.cameraFarClip
     )
-  } else if ((Engine.instance.camera as PerspectiveCamera).fov) {
-    ;(Engine.instance.camera as PerspectiveCamera).fov = data.fov ?? 50
+  } else if ((Engine.instance.currentWorld.camera as PerspectiveCamera).fov) {
+    ;(Engine.instance.currentWorld.camera as PerspectiveCamera).fov = data.fov ?? 50
   }
 
-  Engine.instance.camera.near = data.cameraNearClip
-  Engine.instance.camera.far = data.cameraFarClip
+  Engine.instance.currentWorld.camera.near = data.cameraNearClip
+  Engine.instance.currentWorld.camera.far = data.cameraFarClip
   cameraFollow.distance = data.startCameraDistance
   cameraFollow.minDistance = data.minCameraDistance
   cameraFollow.maxDistance = data.maxCameraDistance
@@ -36,7 +36,7 @@ export const setCameraProperties = (entity: Entity, data: CameraPropertiesCompon
   cameraFollow.minPhi = data.minPhi
   cameraFollow.maxPhi = data.maxPhi
   cameraFollow.locked = !data.startInFreeLook
-  Engine.instance.camera.updateProjectionMatrix()
+  Engine.instance.currentWorld.camera.updateProjectionMatrix()
   switchCameraMode(useWorld().localClientEntity, data, true)
 
   cameraFollow.raycastProps = data.raycastProps

--- a/packages/engine/src/scene/functions/setObjectLayers.ts
+++ b/packages/engine/src/scene/functions/setObjectLayers.ts
@@ -14,8 +14,9 @@ export function setObjectLayers(object: Object3D, ...layers: number[]) {
   for (const layerKey of Object.keys(ObjectLayers)) {
     const layer = ObjectLayers[layerKey]
     const hasLayer = object.layers.isEnabled(layer)
-    Engine.instance.objectLayerList[layer] = Engine.instance.objectLayerList[layer] || new Set()
-    if (hasLayer) Engine.instance.objectLayerList[layer].add(object)
-    else Engine.instance.objectLayerList[layer].delete(object)
+    Engine.instance.currentWorld.objectLayerList[layer] =
+      Engine.instance.currentWorld.objectLayerList[layer] || new Set()
+    if (hasLayer) Engine.instance.currentWorld.objectLayerList[layer].add(object)
+    else Engine.instance.currentWorld.objectLayerList[layer].delete(object)
   }
 }

--- a/packages/engine/src/scene/systems/EntityNodeEventSystem.ts
+++ b/packages/engine/src/scene/systems/EntityNodeEventSystem.ts
@@ -43,7 +43,7 @@ export default async function EntityNodeEventSystem(_: World) {
 
     for (let entity of scenePreviewCameraSelectQuery.enter()) {
       const obj3d = getComponent(entity, Object3DComponent).value
-      Engine.instance.scene.add(obj3d.userData.helper)
+      Engine.instance.currentWorld.scene.add(obj3d.userData.helper)
       obj3d.userData.helper.update()
     }
 
@@ -57,20 +57,20 @@ export default async function EntityNodeEventSystem(_: World) {
       let obj3d = getComponent(entity, Object3DComponent)?.value
 
       if (obj3d) {
-        Engine.instance.scene.remove(obj3d.userData.helper)
+        Engine.instance.currentWorld.scene.remove(obj3d.userData.helper)
       } else {
-        const obj3d = Engine.instance.scene.getObjectByName(SCENE_PREVIEW_CAMERA_HELPER)
-        if (obj3d) Engine.instance.scene.remove(obj3d)
+        const obj3d = Engine.instance.currentWorld.scene.getObjectByName(SCENE_PREVIEW_CAMERA_HELPER)
+        if (obj3d) Engine.instance.currentWorld.scene.remove(obj3d)
       }
     }
 
     /* Remove Events */
     for (const _ of skyboxQuery.exit()) {
-      Engine.instance.scene.background = new Color('black')
+      Engine.instance.currentWorld.scene.background = new Color('black')
     }
 
     for (const _ of fogQuery.exit()) {
-      Engine.instance.scene.fog = null
+      Engine.instance.currentWorld.scene.fog = null
     }
 
     if (Engine.instance.isEditor) {
@@ -84,8 +84,8 @@ export default async function EntityNodeEventSystem(_: World) {
     }
 
     for (const _ of scenePreviewCameraQuery.exit()) {
-      const obj3d = Engine.instance.scene.getObjectByName(SCENE_PREVIEW_CAMERA_HELPER)
-      if (obj3d) Engine.instance.scene.remove(obj3d)
+      const obj3d = Engine.instance.currentWorld.scene.getObjectByName(SCENE_PREVIEW_CAMERA_HELPER)
+      if (obj3d) Engine.instance.currentWorld.scene.remove(obj3d)
     }
 
     for (const entity of videoQuery.exit()) {

--- a/packages/engine/src/scene/systems/HyperspacePortalSystem.ts
+++ b/packages/engine/src/scene/systems/HyperspacePortalSystem.ts
@@ -47,15 +47,15 @@ export default async function HyperspacePortalSystem(world: World) {
 
       hyperspaceEffect.position.copy(playerObj.value.position)
       hyperspaceEffect.quaternion.copy(playerObj.value.quaternion)
-      Engine.instance.camera.zoom = 1.5
+      Engine.instance.currentWorld.camera.zoom = 1.5
 
       // set scene to render just the hyperspace effect and avatar
-      Engine.instance.scene.background = null
-      Engine.instance.camera.layers.enable(ObjectLayers.Portal)
-      Engine.instance.camera.layers.disable(ObjectLayers.Scene)
+      Engine.instance.currentWorld.scene.background = null
+      Engine.instance.currentWorld.camera.layers.enable(ObjectLayers.Portal)
+      Engine.instance.currentWorld.camera.layers.disable(ObjectLayers.Scene)
 
-      Engine.instance.scene.add(light)
-      Engine.instance.scene.add(hyperspaceEffect)
+      Engine.instance.currentWorld.scene.add(light)
+      Engine.instance.currentWorld.scene.add(hyperspaceEffect)
 
       // create receptor for joining the world to end the hyperspace effect
       matchActionOnce(Engine.instance.store, EngineActions.joinedWorld.matches, () => {
@@ -73,12 +73,12 @@ export default async function HyperspacePortalSystem(world: World) {
 
       hyperspaceEffect.removeFromParent()
 
-      Engine.instance.camera.layers.enable(ObjectLayers.Scene)
+      Engine.instance.currentWorld.camera.layers.enable(ObjectLayers.Scene)
 
       light.removeFromParent()
       light.dispose()
 
-      Engine.instance.camera.layers.disable(ObjectLayers.Portal)
+      Engine.instance.currentWorld.camera.layers.disable(ObjectLayers.Portal)
     }
 
     // run the logic for
@@ -88,9 +88,9 @@ export default async function HyperspacePortalSystem(world: World) {
       hyperspaceEffect.position.copy(playerObj.value.position)
       hyperspaceEffect.quaternion.copy(playerObj.value.quaternion)
 
-      if (Engine.instance.camera.zoom > 0.75) {
-        Engine.instance.camera.zoom -= delta
-        Engine.instance.camera.updateProjectionMatrix()
+      if (Engine.instance.currentWorld.camera.zoom > 0.75) {
+        Engine.instance.currentWorld.camera.zoom -= delta
+        Engine.instance.currentWorld.camera.updateProjectionMatrix()
       }
     }
   }

--- a/packages/engine/src/scene/systems/SceneObjectSystem.ts
+++ b/packages/engine/src/scene/systems/SceneObjectSystem.ts
@@ -99,13 +99,13 @@ export default async function SceneObjectSystem(world: World) {
         if (node.parentEntity) reparentObject3D(node, node.parentEntity, undefined, world.entityTree)
       } else {
         let found = false
-        Engine.instance.scene.traverse((obj) => {
+        Engine.instance.currentWorld.scene.traverse((obj) => {
           if (obj === obj3d) {
             found = true
           }
         })
 
-        if (!found) Engine.instance.scene.add(obj3d)
+        if (!found) Engine.instance.currentWorld.scene.add(obj3d)
       }
 
       processObject3d(entity)
@@ -146,14 +146,14 @@ export default async function SceneObjectSystem(world: World) {
 
     for (const _ of simpleMaterialsQuery.enter()) {
       Engine.instance.simpleMaterials = true
-      Engine.instance.scene.traverse((obj) => {
+      Engine.instance.currentWorld.scene.traverse((obj) => {
         useSimpleMaterial(obj as any)
       })
     }
 
     for (const _ of simpleMaterialsQuery.exit()) {
       Engine.instance.simpleMaterials = false
-      Engine.instance.scene.traverse((obj) => {
+      Engine.instance.currentWorld.scene.traverse((obj) => {
         useStandardMaterial(obj as Mesh<any, Material>)
       })
     }

--- a/packages/engine/src/xr/functions/WebXRFunctions.ts
+++ b/packages/engine/src/xr/functions/WebXRFunctions.ts
@@ -213,7 +213,7 @@ export const startWebXR = async (): Promise<void> => {
   const world = Engine.instance.currentWorld
 
   removeComponent(world.localClientEntity, FollowCameraComponent)
-  container.add(Engine.instance.camera)
+  container.add(Engine.instance.currentWorld.camera)
 
   setupXRInputSourceComponent(world.localClientEntity)
 
@@ -236,7 +236,7 @@ export const endXR = (): void => {
   // EngineRenderer.instance.xrSession?.end()
   EngineRenderer.instance.xrSession = null!
   EngineRenderer.instance.xrManager.setSession(null!)
-  Engine.instance.scene.add(Engine.instance.camera)
+  Engine.instance.currentWorld.scene.add(Engine.instance.currentWorld.camera)
 
   const world = Engine.instance.currentWorld
   addComponent(world.localClientEntity, FollowCameraComponent, FollowCameraDefaultValues)
@@ -351,14 +351,14 @@ export const getHandTransform = (
 export const getHeadTransform = (entity: Entity): { position: Vector3; rotation: Quaternion; scale: Vector3 } => {
   const xrInputSourceComponent = getComponent(entity, XRInputSourceComponent)
   if (xrInputSourceComponent) {
-    Engine.instance.camera.matrix.decompose(vec3, quat, v3)
+    Engine.instance.currentWorld.camera.matrix.decompose(vec3, quat, v3)
     return {
       position: vec3,
       rotation: quat,
       scale: uniformScale
     }
   }
-  const cameraTransform = getComponent(Engine.instance.activeCameraEntity, TransformComponent)
+  const cameraTransform = getComponent(Engine.instance.currentWorld.activeCameraEntity, TransformComponent)
   return {
     position: cameraTransform.position,
     rotation: cameraTransform.rotation,

--- a/packages/engine/src/xr/systems/XRSystem.ts
+++ b/packages/engine/src/xr/systems/XRSystem.ts
@@ -101,10 +101,10 @@ export default async function XRSystem(world: World) {
           const mapping = gamepadMapping[source.gamepad.mapping || 'xr-standard'][source.handedness]
           source.gamepad?.buttons.forEach((button, index) => {
             // TODO : support button.touched and button.value
-            const prev = Engine.instance.prevInputState.get(mapping.buttons[index])
+            const prev = Engine.instance.currentWorld.prevInputState.get(mapping.buttons[index])
             if (!prev && button.pressed == false) return
             const continued = prev?.value && button.pressed
-            Engine.instance.inputState.set(mapping.buttons[index], {
+            Engine.instance.currentWorld.inputState.set(mapping.buttons[index], {
               type: InputType.BUTTON,
               value: [button.pressed ? BinaryValue.ON : BinaryValue.OFF],
               lifecycleState: button.pressed
@@ -124,7 +124,7 @@ export default async function XRSystem(world: World) {
           if (Math.abs(inputData[1]) < 0.05) {
             inputData[1] = 0
           }
-          Engine.instance.inputState.set(mapping.axes, {
+          Engine.instance.currentWorld.inputState.set(mapping.axes, {
             type: InputType.TWODIM,
             value: inputData,
             lifecycleState: LifecycleValue.Started
@@ -142,8 +142,8 @@ export default async function XRSystem(world: World) {
     for (const entity of localXRControllerQuery()) {
       const xrInputSourceComponent = getComponent(entity, XRInputSourceComponent)
       const head = xrInputSourceComponent.head
-      head.quaternion.copy(Engine.instance.camera.quaternion)
-      head.position.copy(Engine.instance.camera.position)
+      head.quaternion.copy(Engine.instance.currentWorld.camera.quaternion)
+      head.position.copy(Engine.instance.currentWorld.camera.position)
     }
   }
 }

--- a/packages/engine/src/xrui/functions/ObjectFitFunctions.ts
+++ b/packages/engine/src/xrui/functions/ObjectFitFunctions.ts
@@ -37,7 +37,7 @@ export const ObjectFitFunctions = {
     contentWidth: number,
     contentHeight: number,
     fit: 'cover' | 'contain' | 'vertical' | 'horizontal' = 'contain',
-    camera = Engine.instance.camera as PerspectiveCamera
+    camera = Engine.instance.currentWorld.camera as PerspectiveCamera
   ) => {
     const vFOV = MathUtils.degToRad(camera.fov)
     const targetHeight = Math.tan(vFOV / 2) * Math.abs(distance) * 2

--- a/packages/engine/src/xrui/systems/XRUISystem.ts
+++ b/packages/engine/src/xrui/systems/XRUISystem.ts
@@ -143,7 +143,7 @@ export default async function XRUISystem(world: World) {
     const input = getComponent(world.localClientEntity, InputComponent)
     const screenXY = input?.data?.get(BaseInput.SCREENXY)?.value
     if (screenXY) {
-      screenRaycaster.setFromCamera({ x: screenXY[0], y: screenXY[1] }, Engine.instance.camera)
+      screenRaycaster.setFromCamera({ x: screenXY[0], y: screenXY[1] }, Engine.instance.currentWorld.camera)
     } else {
       screenRaycaster.ray.origin.set(Infinity, Infinity, Infinity)
       screenRaycaster.ray.direction.set(0, -1, 0)
@@ -173,7 +173,7 @@ export default async function XRUISystem(world: World) {
       xrui.container.update()
     }
 
-    // xrui.layoutSystem.viewFrustum.setFromPerspectiveProjectionMatrix(Engine.instance.camera.projectionMatrix)
+    // xrui.layoutSystem.viewFrustum.setFromPerspectiveProjectionMatrix(Engine.instance.currentWorld.camera.projectionMatrix)
     // EngineRenderer.instance.renderer.getSize(xrui.layoutSystem.viewResolution)
     // xrui.layoutSystem.update(world.delta, world.elapsedTime)
   }


### PR DESCRIPTION
## Summary

Moves the following from Engine scope to World scope
- scene
- objectLayerList
- camera
- audioListener
- activeCameraEntity
- activeCameraFollowTarget
- inputState
- prevInputState

## References

closes https://github.com/XRFoundation/XREngine/issues/5834


## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [ ] Unit & Integration tests passing via `npm run test`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
