### PR TITLE
Added npm script 'update-name-gh-package' to hyperflux's package.json

### DIFF
--- a/packages/hyperflux/package.json
+++ b/packages/hyperflux/package.json
@@ -17,6 +17,7 @@
     "react-reconciler": "^0.27.0"
   },
   "scripts": {
-    "test": "mocha --config .mocharc.js"
+    "test": "mocha --config .mocharc.js",
+    "update-name-gh-package": "node scripts/update-name-gh-package.js"
   }
 }


### PR DESCRIPTION
## Summary

The publish-npm GH action expects to call a script `update-name-gh-package` in each package,
for the purposes of publishing to GitHub packages. Hyperflux was missing this script, so the
GH package publishing was failing.


## References

closes #_insert number here_


## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [x] Unit & Integration tests passing via `npm run test`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
