### PR TITLE
Better handling of trailing slash on cubemap texture URL.

### DIFF
--- a/packages/engine/src/scene/constants/Util.ts
+++ b/packages/engine/src/scene/constants/Util.ts
@@ -26,6 +26,7 @@ export const loadCubeMapTexture = (
   onProgress?: (event: ProgressEvent<EventTarget>) => void,
   onError?: (event: ErrorEvent) => void
 ): void => {
+  if (path[path.length - 1] === '/') path = path.slice(0, path.length - 1)
   cubeTextureLoader.setPath(path).load(
     [posx, negx, posy, negy, posz, negz],
     (texture) => {


### PR DESCRIPTION
## Summary

Cubemap texture urls have a leading slash in engine/src/scene/constants/Utils.ts.
When path has a trailing slash, loadCubeMapTexture was mashing them together in its,
call to cubeTextureLoader.load(), resulting in an incorrect double slash in the url.
loadCubeMapTexture now strips the trailing slash from the path.


## References

closes #_insert number here_


## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [x] Unit & Integration tests passing via `npm run test`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
