### PR TITLE
scene service now handles cubemap in various scene operations

### DIFF
--- a/packages/server-core/src/projects/scene/scene.class.ts
+++ b/packages/server-core/src/projects/scene/scene.class.ts
@@ -119,7 +119,7 @@ export class Scene implements ServiceMethods<any> {
       counter++
     }
 
-    for(const ext of sceneAssetFiles) {
+    for (const ext of sceneAssetFiles) {
       await storageProvider.moveObject(
         `default${ext}`,
         `${newSceneName}${ext}`,
@@ -131,7 +131,7 @@ export class Scene implements ServiceMethods<any> {
 
     if (isDev) {
       const projectPathLocal = path.resolve(appRootPath.path, 'packages/projects/projects/' + projectName) + '/'
-      for(const ext of sceneAssetFiles) {
+      for (const ext of sceneAssetFiles) {
         fs.copyFileSync(
           path.resolve(appRootPath.path, `packages/projects/default-project/default${ext}`),
           path.resolve(projectPathLocal + newSceneName + ext)
@@ -152,7 +152,7 @@ export class Scene implements ServiceMethods<any> {
 
     const projectPath = `projects/${projectName}/`
 
-    for(const ext of sceneAssetFiles) {
+    for (const ext of sceneAssetFiles) {
       const oldSceneJsonName = `${oldSceneName}${ext}`
       const newSceneJsonName = `${newSceneName}${ext}`
 
@@ -161,7 +161,7 @@ export class Scene implements ServiceMethods<any> {
     }
 
     if (isDev) {
-      for(const ext of sceneAssetFiles) {
+      for (const ext of sceneAssetFiles) {
         const oldSceneJsonPath = path.resolve(
           appRootPath.path,
           `packages/projects/projects/${projectName}/${oldSceneName}${ext}`
@@ -238,7 +238,7 @@ export class Scene implements ServiceMethods<any> {
     const project = await this.app.service('project').get(projectName, params)
     if (!project.data) throw new Error(`No project named ${projectName} exists`)
 
-    for(const ext of sceneAssetFiles) {
+    for (const ext of sceneAssetFiles) {
       const assetFilePath = path.resolve(appRootPath.path, `packages/projects/projects/${projectName}/${name}${ext}`)
       if (fs.existsSync(assetFilePath)) {
         fs.rmSync(path.resolve(assetFilePath))


### PR DESCRIPTION
## Summary

_A summary of changes being made in this PR_


## References

closes #_insert number here_


## Checklist
- [ ] CI/CD checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Typescript passing via `npm run check-errors`
  - [ ] Unit & Integration tests passing via `npm run test`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
