### PR TITLE
simple headless location load

### DIFF
--- a/packages/client-core/src/components/World/LoadEngineWithScene.tsx
+++ b/packages/client-core/src/components/World/LoadEngineWithScene.tsx
@@ -19,7 +19,7 @@ import { AppAction, GeneralStateList } from '../../common/services/AppService'
 import { SocketWebRTCClientTransport } from '../../transports/SocketWebRTCClientTransport'
 import { initClient, loadScene } from './LocationLoadHelper'
 
-export const LoadEngineWithScene = () => {
+export const LoadEngineWithScene = ({ headless } = { headless: false }) => {
   const history = useHistory()
   const dispatch = useDispatch()
   const engineState = useEngineState()
@@ -31,7 +31,7 @@ export const LoadEngineWithScene = () => {
    * initialise the client
    */
   useHookEffect(() => {
-    initClient().then(() => {
+    initClient({ headless }).then(() => {
       setClientReady(true)
     })
   }, [])

--- a/packages/client-core/src/components/World/LocationLoadHelper.tsx
+++ b/packages/client-core/src/components/World/LocationLoadHelper.tsx
@@ -36,13 +36,13 @@ export const retrieveLocationByName = (locationName: string) => {
   }
 }
 
-export const initClient = async () => {
+export const initClient = async ({ headless } = { headless: false }) => {
   const projects = accessProjectState().projects.value.map((project) => project.name)
   const world = Engine.instance.currentWorld
 
-  await initializeCoreSystems()
+  await initializeCoreSystems(headless)
   await initializeRealtimeSystems()
-  await initializeSceneSystems()
+  await initializeSceneSystems(headless)
   await loadEngineInjection(world, projects)
 
   // add extraneous receptors

--- a/packages/client/src/pages/location/[locationName].tsx
+++ b/packages/client/src/pages/location/[locationName].tsx
@@ -25,6 +25,7 @@ const LocationPage = () => {
   const engineState = useEngineState()
   const locationState = useLocationState()
   const offline = new URLSearchParams(search).get('offline') === 'true'
+  const headless = new URLSearchParams(search).get('headless') === 'true'
 
   const params = match.params as any
   const locationName = params.locationName ?? `${params.projectName}/${params.sceneName}`
@@ -32,7 +33,10 @@ const LocationPage = () => {
   useEffect(() => {
     dispatch(LocationAction.setLocationName(locationName))
     AuthService.listenForUserPatch()
-    Engine.instance.injectedSystems.push(...DefaultLocationSystems)
+    if (!headless) {
+      // currently: XRUILoadingSystem, AvatarUISystem
+      Engine.instance.injectedSystems.push(...DefaultLocationSystems)
+    }
   }, [])
 
   /**
@@ -48,7 +52,7 @@ const LocationPage = () => {
   return (
     <Layout useLoadingScreenOpacity pageTitle={t('location.locationName.pageTitle')}>
       {engineState.isEngineInitialized.value ? <></> : <LoadingCircle />}
-      <LoadEngineWithScene />
+      <LoadEngineWithScene headless={headless} />
       {offline ? <OfflineLocation /> : <NetworkInstanceProvisioning />}
       <LoadLocationScene />
     </Layout>

--- a/packages/engine/src/initializeEngine.ts
+++ b/packages/engine/src/initializeEngine.ts
@@ -138,7 +138,7 @@ export const initializeMediaServerSystems = async () => {
   dispatchAction(Engine.instance.store, EngineActions.initializeEngine({ initialised: true }))
 }
 
-export const initializeCoreSystems = async () => {
+export const initializeCoreSystems = async (headless = false) => {
   const systemsToLoad: SystemModuleType<any>[] = []
   systemsToLoad.push(
     {
@@ -169,7 +169,7 @@ export const initializeCoreSystems = async () => {
     }
   )
 
-  if (isClient) {
+  if (isClient && !headless) {
     systemsToLoad.push(
       {
         type: SystemUpdateType.POST_RENDER,
@@ -206,7 +206,7 @@ export const initializeCoreSystems = async () => {
  * everything needed for rendering 3d scenes
  */
 
-export const initializeSceneSystems = async () => {
+export const initializeSceneSystems = async (headless = false) => {
   const world = Engine.instance.currentWorld
   NetworkActionReceptor.createNetworkActionReceptor(world)
 
@@ -266,10 +266,6 @@ export const initializeSceneSystems = async () => {
       },
       {
         type: SystemUpdateType.PRE_RENDER,
-        systemModulePromise: import('./interaction/systems/MediaControlSystem')
-      },
-      {
-        type: SystemUpdateType.PRE_RENDER,
         systemModulePromise: import('./audio/systems/AudioSystem')
       },
       {
@@ -305,6 +301,12 @@ export const initializeSceneSystems = async () => {
         type: SystemUpdateType.PRE_RENDER
       }
     )
+    if (!headless) {
+      systemsToLoad.push({
+        type: SystemUpdateType.PRE_RENDER,
+        systemModulePromise: import('./interaction/systems/MediaControlSystem')
+      })
+    }
 
     // todo: figure out the race condition that is stopping us from moving this to SceneObjectSystem
     initializeKTX2Loader(getGLTFLoader())


### PR DESCRIPTION
## Summary

scene is loaded, synced with server, physics, etc. but without rendering/controls

todo: ability to make scene where actor will not spawn by default, (if there is no spawn point? option?)


## References




## Checklist
- [ ] CI/CD checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Typescript passing via `npm run check-errors`
  - [ ] Unit & Integration tests passing via `npm run test`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

vist https://localhost:3000/location/test?instanceId=1cd88290-d84f-11ec-a912-cfbe5be13485&**headless=true**

## Reviewers

@HexaField
