### PR TITLE
Fixed bug in updating project from private repo

### DIFF
--- a/packages/server-core/src/projects/githubapp/githubapp-helper.ts
+++ b/packages/server-core/src/projects/githubapp/githubapp-helper.ts
@@ -63,6 +63,7 @@ export const getGitHubAppRepos = async () => {
 
 export const getAuthenticatedRepo = async (repositoryPath) => {
   try {
+    if (!/.git$/.test(repositoryPath)) repositoryPath = repositoryPath + '.git'
     const repos = await getGitHubAppRepos()
     const filtered = repos.filter((repo) => repo.repositoryPath == repositoryPath)
     if (filtered && filtered[0]) {


### PR DESCRIPTION
## Summary

Some private projects did not have '.git' at the end of their saved
repositoryPath, which resulted in no exact match to private repos
and therefore errors when trying to fetch from the repo using a
non-signed URL. Added a check that appends '.git', to the end of
repositoryPath if it isn't present.


## References

closes #_insert number here_


## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [x] Unit & Integration tests passing via `npm run test`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
