### PR TITLE
Fixed some bugs in WebRTCFunctions.ts and project retrieval

### DIFF
--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -311,6 +311,9 @@ export class Project extends Service {
   }
 
   async get(name: string, params?: Params): Promise<{ data: ProjectInterface }> {
+    if (!params) params = {}
+    if (!params.query) params.query = {}
+    if (!params.query.$limit) params.query.$limit = 1000
     const data: ProjectInterface[] = ((await super.find(params)) as any).data
     const project = data.find((e) => e.name === name)
     if (!project) return null!
@@ -329,6 +332,7 @@ export class Project extends Service {
       ...params,
       query: {
         ...params?.query,
+        $limit: params?.query?.$limit || 1000,
         $select: params?.query?.$select || ['id', 'name', 'thumbnail', 'repositoryPath', 'storageProviderPath']
       }
     }


### PR DESCRIPTION
## Summary

Despite checking that transport exists, apparently it can be undefined/null by the time
router checks are performed. This could lead to the whole media server crashing because it
was trying to read (null).internal. Added conditional check in each occurrence to prevent that.

Made handleSendTrack check if there's already a producer with the exact same appData, and close it
if so.

Added much higher default pagination on calls to project.find. We're normally using the results as
if they're the entirety of the projects in the database, so the default of 10 could easily cause
projects to not be found by that call.


## References

closes #_insert number here_


## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [x] Unit & Integration tests passing via `npm run test`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
