### PR TITLE
Returning existing dataProducer if a duplicate request to create one comes in.

### DIFF
--- a/packages/client-core/src/transports/SocketWebRTCClientTransport.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientTransport.ts
@@ -13,9 +13,9 @@ import { MediaStreams } from '@xrengine/engine/src/networking/systems/MediaStrea
 import { addActionReceptor, defineAction } from '@xrengine/hyperflux'
 import { Action } from '@xrengine/hyperflux/functions/ActionFunctions'
 
+import { MediaStreamService } from '../media/services/MediaStreamService'
 import { accessAuthState } from '../user/services/AuthService'
 import { gameserverHost } from '../util/config'
-import { MediaStreamService } from './../media/services/MediaStreamService'
 import { onConnectToInstance } from './SocketWebRTCClientFunctions'
 
 // import { encode, decode } from 'msgpackr'

--- a/packages/gameserver/src/SocketWebRTCServerTransport.ts
+++ b/packages/gameserver/src/SocketWebRTCServerTransport.ts
@@ -90,7 +90,7 @@ export class SocketWebRTCServerTransport implements NetworkTransport {
       ordered: false,
       label: 'outgoingProducer',
       protocol: 'raw',
-      appData: { peerID: 'outgoingProducer' }
+      appData: { peerId: 'outgoingProducer' }
     }
     this.outgoingDataProducer = await this.outgoingDataTransport.produceData(options)
 

--- a/packages/gameserver/src/WebRTCFunctions.ts
+++ b/packages/gameserver/src/WebRTCFunctions.ts
@@ -165,17 +165,30 @@ export const handleConsumeDataEvent =
 
         world.clients.get(userId)!.dataConsumers!.set(dataProducer.id, dataConsumer)
 
-        const dataProducerOut = world.clients.get(userId)!.dataProducers!.get('instance')
+        let dataProducerOut
 
-        // Data consumers are all consuming the single producer that outputs from the server's message queue
-        socket.emit(MessageTypes.WebRTCConsumeData.toString(), {
-          dataProducerId: dataProducerOut.id,
-          sctpStreamParameters: dataConsumer.sctpStreamParameters,
-          label: dataConsumer.label,
-          id: dataConsumer.id,
-          appData: dataConsumer.appData,
-          protocol: 'raw'
-        } as DataConsumerOptions)
+        await new Promise((resolve) => {
+          const dataProducerExistsInterval = setInterval(() => {
+            if (world.clients.get(userId)) {
+              dataProducerOut = world.clients.get(userId)!.dataProducers!.get('instance')
+              if (dataProducerOut) {
+                clearInterval(dataProducerExistsInterval)
+                resolve(null)
+              }
+            }
+          }, 10)
+        })
+        if (dataProducerOut.id === dataProducer.id) {
+          // Data consumers are all consuming the single producer that outputs from the server's message queue
+          socket.emit(MessageTypes.WebRTCConsumeData.toString(), {
+            dataProducerId: dataProducerOut.id,
+            sctpStreamParameters: dataConsumer.sctpStreamParameters,
+            label: dataConsumer.label,
+            id: dataConsumer.id,
+            appData: dataConsumer.appData,
+            protocol: 'raw'
+          } as DataConsumerOptions)
+        }
       } catch (err) {
         logger.error(err, `Consume data error: ${err.message}.`)
         logger.info('Transport that could not be consumed: %o', newTransport)
@@ -440,22 +453,31 @@ export async function handleWebRtcProduceData(
   }
   const { transportId, sctpStreamParameters, label, protocol, appData } = data
   logger.info(`Data channel label: "${label}", userId "${userId}".`)
-  logger.info('Data producer params: %o', data)
+  logger.info('Data producer param data: %o', data)
   const transport: any = networkTransport.mediasoupTransports[transportId]
   const options: DataProducerOptions = {
     label,
     protocol,
     sctpStreamParameters,
-    appData: { ...(appData || {}), peerID: userId, transportId }
+    appData: { ...(appData || {}), peerId: userId, transportId }
   }
-  logger.info('Data producer params: %o', options)
+  logger.info('Data producer options: %o', options)
   if (transport) {
     try {
-      const dataProducer = await transport.produceData(options)
-      networkTransport.dataProducers.set(label, dataProducer)
-      logger.info(`User ${userId} producing data.`)
       if (world.clients.has(userId)) {
+        const newProducerAppData = { ...appData, peerId: userId, transportId }
+
+        let existingProducer = [...world.clients.get(userId)!.dataProducers!.values()].find(
+          (producer) =>
+            producer.appData.peerId === newProducerAppData.peerId &&
+            producer.appData.transportId === newProducerAppData.transportId
+        )
+        if (existingProducer) return callback({ id: existingProducer.id })
+
+        const dataProducer = await transport.produceData(options)
+        networkTransport.dataProducers.set(label, dataProducer)
         world.clients.get(userId)!.dataProducers!.set(label, dataProducer)
+        logger.info(`User ${userId} producing data.`)
 
         const currentRouter = networkTransport.routers.instance.find(
           (router) => router.id === (transport as any)?.internal.routerId
@@ -572,7 +594,7 @@ export async function handleWebRtcSendTrack(networkTransport: SocketWebRTCServer
 
   try {
     const newProducerAppData = { ...appData, peerId: userId, transportId }
-    const existingProducer = await MediaStreams.instance?.producers.find(
+    const existingProducer = MediaStreams.instance?.producers.find(
       (producer) => producer.appData === newProducerAppData
     )
     if (existingProducer) await closeProducer(existingProducer)


### PR DESCRIPTION


## Summary

_A summary of changes being made in this PR_


## References

closes #_insert number here_


## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [x] Unit & Integration tests passing via `npm run test`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
