### PR TITLE
Added hack fix for nested paths in importSystem.

### DIFF
--- a/packages/projects/loadSystemInjection.ts
+++ b/packages/projects/loadSystemInjection.ts
@@ -29,33 +29,135 @@ export const importSystem = (project: string, data: SystemComponentType): System
   const entryPointExtension = entryPointSplit.pop()
   // const entryPointFileName = entryPointSplit.join('.')
   // vite MUST have the extension as part of the string, so unfortunately we have to manually try all potential file paths
+  // It also requires that each nested folder be explicitly present in the import string, since each variable is replaced
+  // by a single-depth wildcard '*'. In order to go multiple directories deep, there must be explicit slashes for each
+  // level it's going down in the string. Annoying, hence the current hackfix of returning successively longer import statements
+  // based on the depth of the file.
   // TODO: we could make our own derivate of https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars which can handle this more elegantly
   try {
+    const entryPointPathSplit = entryPointSplit[0].split('/')
+    let systemModulePromise
     switch (entryPointExtension) {
       case 'js':
+        if (entryPointPathSplit.length === 1)
+          systemModulePromise = import(`./projects/${project}/${entryPointPathSplit[0]}.js`)
+        if (entryPointPathSplit.length === 2)
+          systemModulePromise = import(`./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}.js`)
+        if (entryPointPathSplit.length === 3)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}.js`
+          )
+        if (entryPointPathSplit.length === 4)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}/${entryPointPathSplit[3]}.js`
+          )
+        if (entryPointPathSplit.length === 5)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}/${entryPointPathSplit[3]}/${entryPointPathSplit[4]}.js`
+          )
+        if (entryPointPathSplit.length === 6)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}/${entryPointPathSplit[3]}/${entryPointPathSplit[4]}/${entryPointPathSplit[5]}.js`
+          )
+        if (entryPointPathSplit.length > 6)
+          systemModulePromise = Promise.reject(
+            'Custom systems cannot be located more than five directories down from the root of the project'
+          )
         return {
-          systemModulePromise: import(`./projects/${project}/${entryPointSplit}.js`),
+          systemModulePromise: systemModulePromise,
           type: systemUpdateType,
           sceneSystem: true,
           args
         }
       case 'jsx':
+        if (entryPointPathSplit.length === 1)
+          systemModulePromise = import(`./projects/${project}/${entryPointPathSplit[0]}.jsx`)
+        if (entryPointPathSplit.length === 2)
+          systemModulePromise = import(`./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}.jsx`)
+        if (entryPointPathSplit.length === 3)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}.jsx`
+          )
+        if (entryPointPathSplit.length === 4)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}/${entryPointPathSplit[3]}.jsx`
+          )
+        if (entryPointPathSplit.length === 5)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}/${entryPointPathSplit[3]}/${entryPointPathSplit[4]}.jsx`
+          )
+        if (entryPointPathSplit.length === 6)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}/${entryPointPathSplit[3]}/${entryPointPathSplit[4]}/${entryPointPathSplit[5]}.jsx`
+          )
+        if (entryPointPathSplit.length > 6)
+          systemModulePromise = Promise.reject(
+            'Custom systems cannot be located more than five directories down from the root of the project'
+          )
         return {
-          systemModulePromise: import(`./projects/${project}/${entryPointSplit}.jsx`),
+          systemModulePromise: systemModulePromise,
           type: systemUpdateType,
           sceneSystem: true,
           args
         }
       case 'ts':
+        if (entryPointPathSplit.length === 1)
+          systemModulePromise = import(`./projects/${project}/${entryPointPathSplit[0]}.ts`)
+        if (entryPointPathSplit.length === 2)
+          systemModulePromise = import(`./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}.ts`)
+        if (entryPointPathSplit.length === 3)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}.ts`
+          )
+        if (entryPointPathSplit.length === 4)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}/${entryPointPathSplit[3]}.ts`
+          )
+        if (entryPointPathSplit.length === 5)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}/${entryPointPathSplit[3]}/${entryPointPathSplit[4]}.ts`
+          )
+        if (entryPointPathSplit.length === 6)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}/${entryPointPathSplit[3]}/${entryPointPathSplit[4]}/${entryPointPathSplit[5]}.ts`
+          )
+        if (entryPointPathSplit.length > 6)
+          systemModulePromise = Promise.reject(
+            'Custom systems cannot be located more than five directories down from the root of the project'
+          )
         return {
-          systemModulePromise: import(`./projects/${project}/${entryPointSplit}.ts`),
+          systemModulePromise: systemModulePromise,
           type: systemUpdateType,
           sceneSystem: true,
           args
         }
       case 'tsx':
+        if (entryPointPathSplit.length === 1)
+          systemModulePromise = import(`./projects/${project}/${entryPointPathSplit[0]}.tsx`)
+        if (entryPointPathSplit.length === 2)
+          systemModulePromise = import(`./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}.tsx`)
+        if (entryPointPathSplit.length === 3)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}.tsx`
+          )
+        if (entryPointPathSplit.length === 4)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}/${entryPointPathSplit[3]}.tsx`
+          )
+        if (entryPointPathSplit.length === 5)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}/${entryPointPathSplit[3]}/${entryPointPathSplit[4]}.tsx`
+          )
+        if (entryPointPathSplit.length === 6)
+          systemModulePromise = import(
+            `./projects/${project}/${entryPointPathSplit[0]}/${entryPointPathSplit[1]}/${entryPointPathSplit[2]}/${entryPointPathSplit[3]}/${entryPointPathSplit[4]}/${entryPointPathSplit[5]}.tsx`
+          )
+        if (entryPointPathSplit.length > 6)
+          systemModulePromise = Promise.reject(
+            'Custom systems cannot be located more than five directories down from the root of the project'
+          )
         return {
-          systemModulePromise: import(`./projects/${project}/${entryPointSplit}.tsx`),
+          systemModulePromise: systemModulePromise,
           type: systemUpdateType,
           sceneSystem: true,
           args


### PR DESCRIPTION
## Summary

rollup's dynamic-import-vars plugin cannot replace a variable in its path with anything more than a single
level deep '*'. The prior implementation of importSystem was using a potentially multi-level path, leading
to client-side behavior of not finding any systems that weren't in the root of the project.

Added a hack fix of handling files up to five levels deep by using a different import string based on splitting
the path on '/' and manually inserting a '/' between them in the import statement. There didn't seem to be a way
to design this to work with any depth, but five seems like more than enough and there's an error returned if
someone tries to do more.


## References

closes #_insert number here_


## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [x] Unit & Integration tests passing via `npm run test`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [x] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
