### PR TITLE
updated log level & removed pino multistream package

### DIFF
--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -85,7 +85,6 @@
     "octokit": "1.7.1",
     "pino": "^7.2.0",
     "pino-elasticsearch": "^6.2.0",
-    "pino-multi-stream": "^6.0.0",
     "pino-pretty": "^7.6.1",
     "pug": "^3.0.0",
     "request": "2.88.2",

--- a/packages/server-core/src/logger.ts
+++ b/packages/server-core/src/logger.ts
@@ -2,7 +2,7 @@ import pino from 'pino'
 import pinoElastic from 'pino-elasticsearch'
 import pretty from 'pino-pretty'
 
-let node = process.env.ELASTIC_HOST || 'http://localhost:9200'
+const node = process.env.ELASTIC_HOST || 'http://localhost:9200'
 
 const streamToPretty = pretty({
   colorize: true
@@ -16,13 +16,13 @@ const streamToElastic = pinoElastic({
   'flush-bytes': 1000
 })
 
-var streams = [
-    streamToPretty,
-    streamToElastic
-]
+const streams = [streamToPretty, streamToElastic]
 
-var logger = pino({
-  level: 'debug'
-}, pino.multistream(streams))
+const logger = pino(
+  {
+    level: 'debug'
+  },
+  pino.multistream(streams)
+)
 
 export default logger

--- a/packages/server-core/src/logger.ts
+++ b/packages/server-core/src/logger.ts
@@ -1,6 +1,5 @@
 import pino from 'pino'
 import pinoElastic from 'pino-elasticsearch'
-import pinoMs from 'pino-multi-stream'
 import pretty from 'pino-pretty'
 
 let node = process.env.ELASTIC_HOST || 'http://localhost:9200'
@@ -17,10 +16,13 @@ const streamToElastic = pinoElastic({
   'flush-bytes': 1000
 })
 
-const pinoOptions = {}
+var streams = [
+    streamToPretty,
+    streamToElastic
+]
 
-const logger = pino(pinoOptions, pinoMs.multistream([{ stream: streamToPretty }, { stream: streamToElastic }])).child({
-  component: 'server-core'
-})
+var logger = pino({
+  level: 'debug'
+}, pino.multistream(streams))
 
 export default logger


### PR DESCRIPTION
## Summary

Removed pino-multistream package
Using pino native for multistream
Updated log levels


## References




## Checklist
- [x] CI/CD checks pass `npm run check`
  - [x] Linter passing via `npm run lint`
  - [x] Typescript passing via `npm run check-errors`
  - [x] Unit & Integration tests passing via `npm run test`
  - [x] Docker build process passing via `npm run build-client`
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [x] Changes reviewed by at least 2 approved reviewers


## QA Steps



## Reviewers

_Reviewers for this PR_
