### PR TITLE
Moved notification receptor to service

### DIFF
--- a/packages/client-core/src/common/services/NotificationService.ts
+++ b/packages/client-core/src/common/services/NotificationService.ts
@@ -1,6 +1,8 @@
-import { VariantType } from 'notistack'
+import { createState } from '@speigg/hookstate'
+import { OptionsObject, SnackbarMessage, SnackbarProvider, VariantType } from 'notistack'
+import { useState } from 'react'
 
-import { useDispatch } from '../../store'
+import { store, useDispatch } from '../../store'
 import { defaultAction } from '../components/NotificationActions'
 
 export type NotificationOptions = {
@@ -12,7 +14,37 @@ export const NotificationActions = {
   default: defaultAction
 }
 
+//State
+const state = createState({
+  enqueueSnackbar: {} as SnackbarProvider
+})
+
+store.receptors.push((action: NotificationActionType): void => {
+  state.batch((s) => {
+    switch (action.type) {
+      case 'SET_NOTISTACK':
+        return s.merge({
+          enqueueSnackbar: action.payload
+        })
+      case 'ENQUEUE_NOTIFICATION': {
+        s.enqueueSnackbar.value.enqueueSnackbar(action.message, {
+          variant: action.options.variant,
+          action: NotificationActions[action.options.actionType ?? 'default']
+        })
+      }
+    }
+  }, action.type)
+})
+
+export const accessSettingsState = () => state
+
+export const useSettingsState = () => useState(state) as any as typeof state
+
 export const NotificationService = {
+  setNotiStack: async (callback: SnackbarProvider) => {
+    const dispatch = useDispatch()
+    dispatch(NotificationAction.setNotiStack(callback))
+  },
   dispatchNotify(message: string, options: NotificationOptions) {
     const dispatch = useDispatch()
     dispatch(NotificationAction.notify(message, options))
@@ -20,6 +52,12 @@ export const NotificationService = {
 }
 
 export const NotificationAction = {
+  setNotiStack: (payload: SnackbarProvider) => {
+    return {
+      type: 'SET_NOTISTACK' as const,
+      payload
+    }
+  },
   notify: (message: string, options: NotificationOptions) => {
     return {
       type: 'ENQUEUE_NOTIFICATION' as const,

--- a/packages/client-core/src/common/services/NotificationService.ts
+++ b/packages/client-core/src/common/services/NotificationService.ts
@@ -1,5 +1,5 @@
 import { createState } from '@speigg/hookstate'
-import { OptionsObject, SnackbarMessage, SnackbarProvider, VariantType } from 'notistack'
+import { SnackbarProvider, VariantType } from 'notistack'
 import { useState } from 'react'
 
 import { store, useDispatch } from '../../store'
@@ -36,9 +36,9 @@ store.receptors.push((action: NotificationActionType): void => {
   }, action.type)
 })
 
-export const accessSettingsState = () => state
+export const getNotificationState = () => state
 
-export const useSettingsState = () => useState(state) as any as typeof state
+export const useNotificationState = () => useState(state) as any as typeof state
 
 export const NotificationService = {
   setNotiStack: async (callback: SnackbarProvider) => {

--- a/packages/client/src/pages/_app.tsx
+++ b/packages/client/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import {
 import { initGA, logPageView } from '@xrengine/client-core/src/common/components/analytics'
 import { defaultAction } from '@xrengine/client-core/src/common/components/NotificationActions'
 import { ProjectService, useProjectState } from '@xrengine/client-core/src/common/services/ProjectService'
-import { store, useDispatch } from '@xrengine/client-core/src/store'
+import { useDispatch } from '@xrengine/client-core/src/store'
 import { theme } from '@xrengine/client-core/src/theme'
 import { useAuthState } from '@xrengine/client-core/src/user/services/AuthService'
 import GlobalStyle from '@xrengine/client-core/src/util/GlobalStyle'
@@ -23,10 +23,7 @@ import RouterComp from '../route/public'
 
 import './styles.scss'
 
-import {
-  NotificationActions,
-  NotificationActionType
-} from '@xrengine/client-core/src/common/services/NotificationService'
+import { NotificationService } from '@xrengine/client-core/src/common/services/NotificationService'
 
 declare module '@mui/styles/defaultTheme' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -68,25 +65,8 @@ const App = (): any => {
   }, [])
 
   useEffect(() => {
-    const receptor = (action: NotificationActionType): any => {
-      switch (action.type) {
-        case 'ENQUEUE_NOTIFICATION': {
-          notistackRef.current?.enqueueSnackbar(action.message, {
-            variant: action.options.variant,
-            action: NotificationActions[action.options.actionType ?? 'default']
-          })
-        }
-        default:
-          break
-      }
-    }
-    store.receptors.push(receptor)
-
-    return () => {
-      const index = store.receptors.indexOf(receptor)
-      if (index >= 0) {
-        store.receptors.splice(index)
-      }
+    if (notistackRef.current) {
+      NotificationService.setNotiStack(notistackRef.current)
     }
   }, [notistackRef])
 


### PR DESCRIPTION
## Summary

Moved notification receptor from app component to service.


## References

Requested by Josh due to some issue


## Checklist
- [ ] CI/CD checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Typescript passing via `npm run check-errors`
  - [ ] Unit & Integration tests passing via `npm run test`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
