### PR TITLE
Rename NetworkWorldAction to WorldNetworkAction

### DIFF
--- a/packages/client-core/src/components/InstanceChat/index.tsx
+++ b/packages/client-core/src/components/InstanceChat/index.tsx
@@ -20,7 +20,7 @@ import { getComponent } from '@xrengine/engine/src/ecs/functions/ComponentFuncti
 import { createEntity } from '@xrengine/engine/src/ecs/functions/EntityFunctions'
 import { addEntityNodeInTree, createEntityNode } from '@xrengine/engine/src/ecs/functions/EntityTreeFunctions'
 import { matchActionOnce } from '@xrengine/engine/src/networking/functions/matchActionOnce'
-import { NetworkWorldAction } from '@xrengine/engine/src/networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '@xrengine/engine/src/networking/functions/WorldNetworkAction'
 import { toggleAudio } from '@xrengine/engine/src/scene/functions/loaders/AudioFunctions'
 import { updateAudio } from '@xrengine/engine/src/scene/functions/loaders/AudioFunctions'
 import { ScenePrefabs } from '@xrengine/engine/src/scene/functions/registerPrefabs'
@@ -96,7 +96,7 @@ const InstanceChat = (props: Props): any => {
     if (!composingMessage || !usersTyping) return
     const delayDebounce = setTimeout(() => {
       dispatchAction(
-        NetworkWorldAction.setUserTyping({
+        WorldNetworkAction.setUserTyping({
           typing: false
         }),
         [Engine.instance.currentWorld.worldNetwork.hostId]
@@ -163,7 +163,7 @@ const InstanceChat = (props: Props): any => {
     if (message.length > composingMessage.length) {
       if (!usersTyping) {
         dispatchAction(
-          NetworkWorldAction.setUserTyping({
+          WorldNetworkAction.setUserTyping({
             typing: true
           }),
           [Engine.instance.currentWorld.worldNetwork.hostId]
@@ -173,7 +173,7 @@ const InstanceChat = (props: Props): any => {
     if (message.length == 0 || message.length < composingMessage.length) {
       if (usersTyping) {
         dispatchAction(
-          NetworkWorldAction.setUserTyping({
+          WorldNetworkAction.setUserTyping({
             typing: false
           }),
           [Engine.instance.currentWorld.worldNetwork.hostId]
@@ -188,7 +188,7 @@ const InstanceChat = (props: Props): any => {
     if (composingMessage?.length && user.instanceId.value) {
       if (usersTyping) {
         dispatchAction(
-          NetworkWorldAction.setUserTyping({
+          WorldNetworkAction.setUserTyping({
             typing: false
           }),
           [Engine.instance.currentWorld.worldNetwork.hostId]

--- a/packages/client-core/src/components/World/LoadEngineWithScene.tsx
+++ b/packages/client-core/src/components/World/LoadEngineWithScene.tsx
@@ -12,7 +12,7 @@ import { SceneAction, useSceneState } from '@xrengine/client-core/src/world/serv
 import multiLogger from '@xrengine/common/src/logger'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { EngineActions, useEngineState } from '@xrengine/engine/src/ecs/classes/EngineState'
-import { NetworkActionReceptor } from '@xrengine/engine/src/networking/functions/NetworkActionReceptor'
+import { WorldNetworkActionReceptor } from '@xrengine/engine/src/networking/functions/WorldNetworkActionReceptor'
 import { teleportToScene } from '@xrengine/engine/src/scene/functions/teleportToScene'
 import { dispatchAction, useHookEffect } from '@xrengine/hyperflux'
 
@@ -98,7 +98,7 @@ export const LoadEngineWithScene = () => {
       }
 
       // remove all network clients but own (will be updated when new connection is established)
-      NetworkActionReceptor.removeAllNetworkClients(false, world)
+      WorldNetworkActionReceptor.removeAllNetworkClients(false, world)
 
       teleportToScene()
     }

--- a/packages/client-core/src/components/World/LocationLoadHelper.tsx
+++ b/packages/client-core/src/components/World/LocationLoadHelper.tsx
@@ -17,7 +17,7 @@ import {
   initializeRealtimeSystems,
   initializeSceneSystems
 } from '@xrengine/engine/src/initializeEngine'
-import { NetworkWorldAction } from '@xrengine/engine/src/networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '@xrengine/engine/src/networking/functions/WorldNetworkAction'
 import { updateNearbyAvatars } from '@xrengine/engine/src/networking/systems/MediaStreamSystem'
 import { EngineRenderer } from '@xrengine/engine/src/renderer/WebGLRendererSystem'
 import { loadSceneFromJSON } from '@xrengine/engine/src/scene/functions/SceneLoading'
@@ -51,11 +51,11 @@ export const initClient = async () => {
 
   addActionReceptor((action) => {
     matches(action)
-      .when(NetworkWorldAction.createClient.matches, () => {
+      .when(WorldNetworkAction.createClient.matches, () => {
         updateNearbyAvatars()
         MediaStreamService.triggerUpdateNearbyLayerUsers()
       })
-      .when(NetworkWorldAction.destroyClient.matches, () => {
+      .when(WorldNetworkAction.destroyClient.matches, () => {
         updateNearbyAvatars()
         MediaStreamService.triggerUpdateNearbyLayerUsers()
       })

--- a/packages/client-core/src/components/World/OfflineLocation.tsx
+++ b/packages/client-core/src/components/World/OfflineLocation.tsx
@@ -5,10 +5,12 @@ import { UserId } from '@xrengine/common/src/interfaces/UserId'
 import { SpawnPoints } from '@xrengine/engine/src/avatar/AvatarSpawnSystem'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { getEngineState } from '@xrengine/engine/src/ecs/classes/EngineState'
+import { Network, NetworkTypes } from '@xrengine/engine/src/networking/classes/Network'
 import { receiveJoinWorld } from '@xrengine/engine/src/networking/functions/receiveJoinWorld'
 import { useHookEffect, useState } from '@xrengine/hyperflux'
 
 import { client } from '../../feathers'
+import { SocketWebRTCClientNetwork } from '../../transports/SocketWebRTCClientNetwork'
 import GameServerWarnings from './GameServerWarnings'
 
 export const OfflineLocation = () => {
@@ -21,7 +23,9 @@ export const OfflineLocation = () => {
       const world = Engine.instance.currentWorld
       const userId = authState.authUser.identityProvider.userId.value
       Engine.instance.userId = userId
-      world.worldNetwork.hostId = Engine.instance.userId as UserId
+
+      Engine.instance.currentWorld._worldHostId = userId
+      Engine.instance.currentWorld.networks.set(userId, new Network(userId))
 
       const index = 1
       world.userIdToUserIndex.set(userId, index)

--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -8,8 +8,8 @@ import { NetworkTypes } from '@xrengine/engine/src/networking/classes/Network'
 import { PUBLIC_STUN_SERVERS } from '@xrengine/engine/src/networking/constants/STUNServers'
 import { CAM_VIDEO_SIMULCAST_ENCODINGS } from '@xrengine/engine/src/networking/constants/VideoConstants'
 import { MessageTypes } from '@xrengine/engine/src/networking/enums/MessageTypes'
-import { NetworkActionReceptor } from '@xrengine/engine/src/networking/functions/NetworkActionReceptor'
 import { receiveJoinWorld } from '@xrengine/engine/src/networking/functions/receiveJoinWorld'
+import { WorldNetworkActionReceptor } from '@xrengine/engine/src/networking/functions/WorldNetworkActionReceptor'
 import { MediaStreams } from '@xrengine/engine/src/networking/systems/MediaStreamSystem'
 import { updateNearbyAvatars } from '@xrengine/engine/src/networking/systems/MediaStreamSystem'
 import { addActionReceptor, dispatchAction, removeActionReceptor } from '@xrengine/hyperflux'
@@ -912,7 +912,7 @@ export async function leaveNetwork(network: SocketWebRTCClientNetwork, kicked?: 
       Engine.instance.currentWorld.networks.delete(Engine.instance.currentWorld.worldNetwork.hostId)
       Engine.instance.currentWorld._worldHostId = null!
       store.dispatch(LocationInstanceConnectionAction.disconnect(Engine.instance.currentWorld.worldNetwork.hostId))
-      NetworkActionReceptor.removeAllNetworkClients(false, Engine.instance.currentWorld)
+      WorldNetworkActionReceptor.removeAllNetworkClients(false, Engine.instance.currentWorld)
     }
   } catch (err) {
     console.log('Error with leave()')

--- a/packages/client-core/src/transports/SocketWebRTCClientNetwork.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientNetwork.ts
@@ -2,7 +2,6 @@ import * as mediasoupClient from 'mediasoup-client'
 import { DataProducer, Transport as MediaSoupTransport } from 'mediasoup-client/lib/types'
 import { io as ioclient, Socket } from 'socket.io-client'
 
-import { RingBuffer } from '@xrengine/engine/src/common/classes/RingBuffer'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { Network, NetworkType } from '@xrengine/engine/src/networking/classes/Network'
 import { MessageTypes } from '@xrengine/engine/src/networking/enums/MessageTypes'
@@ -10,7 +9,6 @@ import { Action } from '@xrengine/hyperflux/functions/ActionFunctions'
 
 import { accessAuthState } from '../user/services/AuthService'
 import { gameserverHost } from '../util/config'
-import { MediaStreamService } from './../media/services/MediaStreamService'
 import { onConnectToInstance } from './SocketWebRTCClientFunctions'
 
 // import { encode, decode } from 'msgpackr'
@@ -37,13 +35,6 @@ export class SocketWebRTCClientNetwork extends Network {
   sendTransport: MediaSoupTransport
   socket: Socket = null!
   request: ReturnType<typeof promisedRequest>
-
-  dataProducers = new Map<string, any>()
-  dataConsumers = new Map<string, any>()
-
-  incomingMessageQueueUnreliableIDs: RingBuffer<string> = new RingBuffer<string>(100)
-  incomingMessageQueueUnreliable: RingBuffer<any> = new RingBuffer<any>(100)
-  mediasoupOperationQueue: RingBuffer<any> = new RingBuffer<any>(1000)
 
   dataProducer: DataProducer
   heartbeat: NodeJS.Timer // is there an equivalent browser type for this?

--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -15,7 +15,7 @@ import { resolveUser, resolveWalletUser, User, UserSeed, UserSetting } from '@xr
 import { UserApiKey } from '@xrengine/common/src/interfaces/UserApiKey'
 import { UserAvatar } from '@xrengine/common/src/interfaces/UserAvatar'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
-import { NetworkWorldAction } from '@xrengine/engine/src/networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '@xrengine/engine/src/networking/functions/WorldNetworkAction'
 import { dispatchAction } from '@xrengine/hyperflux'
 
 import { NotificationService } from '../../common/services/NotificationService'
@@ -745,7 +745,7 @@ export const AuthService = {
         // dispatchAlertSuccess(dispatch, 'User Avatar updated');
         dispatch(AuthAction.userAvatarIdUpdated(res.avatarId))
         dispatchAction(
-          NetworkWorldAction.avatarDetails({
+          WorldNetworkAction.avatarDetails({
             avatarDetail: {
               avatarURL,
               thumbnailURL

--- a/packages/engine/src/avatar/AnimationSystem.ts
+++ b/packages/engine/src/avatar/AnimationSystem.ts
@@ -7,7 +7,7 @@ import { World } from '../ecs/classes/World'
 import { defineQuery, getComponent } from '../ecs/functions/ComponentFunctions'
 import { NetworkObjectComponent } from '../networking/components/NetworkObjectComponent'
 import { isEntityLocalClient } from '../networking/functions/isEntityLocalClient'
-import { NetworkWorldAction } from '../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../networking/functions/WorldNetworkAction'
 import { DesiredTransformComponent } from '../transform/components/DesiredTransformComponent'
 import { TransformComponent } from '../transform/components/TransformComponent'
 import { TweenComponent } from '../transform/components/TweenComponent'
@@ -35,7 +35,7 @@ const forward = new Vector3()
 const avatarAnimationQuery = defineQuery([AnimationComponent, AvatarAnimationComponent])
 
 export function animationActionReceptor(
-  action: ReturnType<typeof NetworkWorldAction.avatarAnimation>,
+  action: ReturnType<typeof WorldNetworkAction.avatarAnimation>,
   world = Engine.instance.currentWorld
 ) {
   const avatarEntity = world.getUserAvatarEntity(action.$from)
@@ -50,7 +50,7 @@ export function animationActionReceptor(
 }
 
 export default async function AnimationSystem(world: World) {
-  const avatarAnimationQueue = createActionQueue(NetworkWorldAction.avatarAnimation.matches)
+  const avatarAnimationQueue = createActionQueue(WorldNetworkAction.avatarAnimation.matches)
 
   await AnimationManager.instance.loadDefaultAnimations()
 

--- a/packages/engine/src/avatar/AvatarInputSchema.ts
+++ b/packages/engine/src/avatar/AvatarInputSchema.ts
@@ -44,7 +44,7 @@ import {
   unequipEntity
 } from '../interaction/functions/equippableFunctions'
 import { AutoPilotClickRequestComponent } from '../navigation/component/AutoPilotClickRequestComponent'
-import { NetworkWorldAction } from '../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../networking/functions/WorldNetworkAction'
 import { boxDynamicConfig } from '../physics/functions/physicsObjectDebugFunctions'
 import { accessEngineRendererState, EngineRendererAction } from '../renderer/EngineRendererState'
 import { Object3DComponent } from '../scene/components/Object3DComponent'
@@ -515,7 +515,7 @@ export const handlePhysicsDebugEvent = (entity: Entity, inputKey: InputAlias, in
   if (inputValue.lifecycleState !== LifecycleValue.Ended) return
   if (inputKey === PhysicsDebugInput.GENERATE_DYNAMIC_DEBUG_CUBE) {
     dispatchAction(
-      NetworkWorldAction.spawnDebugPhysicsObject({
+      WorldNetworkAction.spawnDebugPhysicsObject({
         config: boxDynamicConfig // Any custom config can be provided here
       }),
       [Engine.instance.currentWorld.worldNetwork.hostId]

--- a/packages/engine/src/avatar/AvatarSpawnSystem.ts
+++ b/packages/engine/src/avatar/AvatarSpawnSystem.ts
@@ -11,7 +11,7 @@ import { Entity } from '../ecs/classes/Entity'
 import { World } from '../ecs/classes/World'
 import { addComponent, defineQuery, getComponent, hasComponent } from '../ecs/functions/ComponentFunctions'
 import { LocalInputTagComponent } from '../input/components/LocalInputTagComponent'
-import { NetworkWorldAction } from '../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../networking/functions/WorldNetworkAction'
 import { ShadowComponent } from '../scene/components/ShadowComponent'
 import { SpawnPointComponent } from '../scene/components/SpawnPointComponent'
 import { TransformComponent } from '../transform/components/TransformComponent'
@@ -53,7 +53,7 @@ export class SpawnPoints {
 }
 
 export function avatarSpawnReceptor(
-  spawnAction: ReturnType<typeof NetworkWorldAction.spawnAvatar>,
+  spawnAction: ReturnType<typeof WorldNetworkAction.spawnAvatar>,
   world = Engine.instance.currentWorld
 ) {
   if (isClient) {
@@ -85,7 +85,7 @@ export function avatarSpawnReceptor(
 }
 
 export default async function AvatarSpawnSystem(world: World) {
-  const avatarSpawnQueue = createActionQueue(NetworkWorldAction.spawnAvatar.matches)
+  const avatarSpawnQueue = createActionQueue(WorldNetworkAction.spawnAvatar.matches)
 
   const spawnPointQuery = defineQuery([SpawnPointComponent, TransformComponent])
   return () => {

--- a/packages/engine/src/avatar/AvatarSystem.ts
+++ b/packages/engine/src/avatar/AvatarSystem.ts
@@ -15,7 +15,7 @@ import {
 } from '../ecs/functions/ComponentFunctions'
 import { AvatarControllerType } from '../input/enums/InputEnums'
 import { isEntityLocalClient } from '../networking/functions/isEntityLocalClient'
-import { NetworkWorldAction } from '../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../networking/functions/WorldNetworkAction'
 import { RaycastComponent } from '../physics/components/RaycastComponent'
 import { VelocityComponent } from '../physics/components/VelocityComponent'
 import { TransformComponent } from '../transform/components/TransformComponent'
@@ -34,7 +34,7 @@ import { loadAvatarForUser } from './functions/avatarFunctions'
 import { accessAvatarInputSettingsState } from './state/AvatarInputSettingsState'
 
 export function avatarDetailsReceptor(
-  action: ReturnType<typeof NetworkWorldAction.avatarDetails>,
+  action: ReturnType<typeof WorldNetworkAction.avatarDetails>,
   world = Engine.instance.currentWorld
 ) {
   const client = world.clients.get(action.$from)
@@ -49,7 +49,7 @@ export function avatarDetailsReceptor(
 }
 
 export function setXRModeReceptor(
-  action: ReturnType<typeof NetworkWorldAction.setXRMode>,
+  action: ReturnType<typeof WorldNetworkAction.setXRMode>,
   world = Engine.instance.currentWorld
 ) {
   const entity = world.getUserAvatarEntity(action.$from)
@@ -89,7 +89,7 @@ export function setXRModeReceptor(
 }
 
 export function xrHandsConnectedReceptor(
-  action: ReturnType<typeof NetworkWorldAction.xrHandsConnected>,
+  action: ReturnType<typeof WorldNetworkAction.xrHandsConnected>,
   world = Engine.instance.currentWorld
 ) {
   if (action.$from === Engine.instance.userId) return
@@ -110,7 +110,7 @@ export function xrHandsConnectedReceptor(
 }
 
 export function teleportObjectReceptor(
-  action: ReturnType<typeof NetworkWorldAction.teleportObject>,
+  action: ReturnType<typeof WorldNetworkAction.teleportObject>,
   world = Engine.instance.currentWorld
 ) {
   const [x, y, z, qX, qY, qZ, qW] = action.pose
@@ -126,10 +126,10 @@ export function teleportObjectReceptor(
 }
 
 export default async function AvatarSystem(world: World) {
-  const avatarDetailsQueue = createActionQueue(NetworkWorldAction.avatarDetails.matches)
-  const setXRModeQueue = createActionQueue(NetworkWorldAction.setXRMode.matches)
-  const xrHandsConnectedQueue = createActionQueue(NetworkWorldAction.xrHandsConnected.matches)
-  const teleportObjectQueue = createActionQueue(NetworkWorldAction.teleportObject.matches)
+  const avatarDetailsQueue = createActionQueue(WorldNetworkAction.avatarDetails.matches)
+  const setXRModeQueue = createActionQueue(WorldNetworkAction.setXRMode.matches)
+  const xrHandsConnectedQueue = createActionQueue(WorldNetworkAction.xrHandsConnected.matches)
+  const teleportObjectQueue = createActionQueue(WorldNetworkAction.teleportObject.matches)
 
   const raycastQuery = defineQuery([AvatarComponent, RaycastComponent])
   const xrInputQuery = defineQuery([AvatarComponent, XRInputSourceComponent, AvatarAnimationComponent])

--- a/packages/engine/src/avatar/animation/AvatarAnimationGraph.ts
+++ b/packages/engine/src/avatar/animation/AvatarAnimationGraph.ts
@@ -6,7 +6,7 @@ import { Engine } from '../../ecs/classes/Engine'
 import { Entity } from '../../ecs/classes/Entity'
 import { getComponent } from '../../ecs/functions/ComponentFunctions'
 import { isEntityLocalClient } from '../../networking/functions/isEntityLocalClient'
-import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
 import { AnimationManager } from '../AnimationManager'
 import { AvatarSettings } from '../AvatarControllerSystem'
 import { AvatarAnimationComponent } from '../components/AvatarAnimationComponent'
@@ -345,7 +345,7 @@ export function changeAvatarAnimationState(entity: Entity, newStateName: string)
   changeState(avatarAnimationComponent.animationGraph, newStateName)
   if (isEntityLocalClient(entity)) {
     const params = {}
-    dispatchAction(NetworkWorldAction.avatarAnimation({ newStateName, params }), [
+    dispatchAction(WorldNetworkAction.avatarAnimation({ newStateName, params }), [
       Engine.instance.currentWorld.worldNetwork.hostId
     ])
   }

--- a/packages/engine/src/avatar/functions/createAvatar.test.ts
+++ b/packages/engine/src/avatar/functions/createAvatar.test.ts
@@ -10,7 +10,7 @@ import { createEntity } from '../../ecs/functions/EntityFunctions'
 import { createEngine } from '../../initializeEngine'
 import { InteractorComponent } from '../../interaction/components/InteractorComponent'
 import { NetworkObjectComponent } from '../../networking/components/NetworkObjectComponent'
-import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
 import { CollisionComponent } from '../../physics/components/CollisionComponent'
 import { RaycastComponent } from '../../physics/components/RaycastComponent'
 import { VelocityComponent } from '../../physics/components/VelocityComponent'
@@ -52,7 +52,7 @@ describe('createAvatar', () => {
     const prevPhysicsColliders = Engine.instance.currentWorld.physics.controllers.size
 
     createAvatar(
-      NetworkWorldAction.spawnAvatar({
+      WorldNetworkAction.spawnAvatar({
         $from: Engine.instance.userId,
         networkId: networkObject.networkId,
         parameters: { position: new Vector3(-0.48624888685311896, 0, -0.12087574159728942), rotation: new Quaternion() }

--- a/packages/engine/src/avatar/functions/createAvatar.ts
+++ b/packages/engine/src/avatar/functions/createAvatar.ts
@@ -6,7 +6,7 @@ import { Entity } from '../../ecs/classes/Entity'
 import { addComponent, getComponent, hasComponent } from '../../ecs/functions/ComponentFunctions'
 import { InputComponent } from '../../input/components/InputComponent'
 import { InteractorComponent } from '../../interaction/components/InteractorComponent'
-import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
 import { VectorSpringSimulator } from '../../physics/classes/springs/VectorSpringSimulator'
 import { ColliderComponent } from '../../physics/components/ColliderComponent'
 import { CollisionComponent } from '../../physics/components/CollisionComponent'
@@ -33,7 +33,7 @@ export const defaultAvatarHeight = 1.8
 const capsuleHeight = defaultAvatarHeight - avatarRadius * 2
 export const defaultAvatarHalfHeight = defaultAvatarHeight / 2
 
-export const createAvatar = (spawnAction: typeof NetworkWorldAction.spawnAvatar.matches._TYPE): Entity => {
+export const createAvatar = (spawnAction: typeof WorldNetworkAction.spawnAvatar.matches._TYPE): Entity => {
   const world = Engine.instance.currentWorld
   const userId = spawnAction.$from
   const entity = world.getNetworkObject(spawnAction.$from, spawnAction.networkId)!

--- a/packages/engine/src/avatar/functions/respawnAvatar.ts
+++ b/packages/engine/src/avatar/functions/respawnAvatar.ts
@@ -4,7 +4,7 @@ import { Engine } from '../../ecs/classes/Engine'
 import { Entity } from '../../ecs/classes/Entity'
 import { getComponent } from '../../ecs/functions/ComponentFunctions'
 import { NetworkObjectComponent } from '../../networking/components/NetworkObjectComponent'
-import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
 import { SpawnPoseComponent } from '../components/SpawnPoseComponent'
 
 export const respawnAvatar = (entity: Entity) => {
@@ -12,7 +12,7 @@ export const respawnAvatar = (entity: Entity) => {
   console.log('\n\n\n\n\n\n\n\n\n\n\nRESPAWN AVATAR\n\n\n\n\n\n', position)
   const networkObject = getComponent(entity, NetworkObjectComponent)
   dispatchAction(
-    NetworkWorldAction.teleportObject({
+    WorldNetworkAction.teleportObject({
       object: {
         ownerId: Engine.instance.userId,
         networkId: networkObject.networkId

--- a/packages/engine/src/initializeEngine.ts
+++ b/packages/engine/src/initializeEngine.ts
@@ -308,7 +308,7 @@ export const initializeRealtimeSystems = async (media = true, pose = true) => {
 
   systemsToLoad.push({
     type: SystemUpdateType.FIXED_EARLY,
-    systemModulePromise: import('./networking/systems/NetworkActionSystem')
+    systemModulePromise: import('./networking/systems/WorldNetworkActionSystem')
   })
 
   if (media) {

--- a/packages/engine/src/interaction/functions/equippableFunctions.ts
+++ b/packages/engine/src/interaction/functions/equippableFunctions.ts
@@ -5,7 +5,7 @@ import { Engine } from '../../ecs/classes/Engine'
 import { Entity } from '../../ecs/classes/Entity'
 import { addComponent, getComponent, hasComponent, removeComponent } from '../../ecs/functions/ComponentFunctions'
 import { NetworkObjectComponent } from '../../networking/components/NetworkObjectComponent'
-import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
 import { EquippedComponent } from '../components/EquippedComponent'
 import { EquipperComponent } from '../components/EquipperComponent'
 import { EquippableAttachmentPoint } from '../enums/EquippedEnums'
@@ -41,7 +41,7 @@ const dispatchEquipEntity = (equippedEntity: Entity, equip: boolean): void => {
   const networkComponet = getComponent(equippedEntity, NetworkObjectComponent)
 
   dispatchAction(
-    NetworkWorldAction.setEquippedObject({
+    WorldNetworkAction.setEquippedObject({
       object: {
         ownerId: networkComponet.ownerId,
         networkId: networkComponet.networkId

--- a/packages/engine/src/interaction/systems/EquippableSystem.test.ts
+++ b/packages/engine/src/interaction/systems/EquippableSystem.test.ts
@@ -9,7 +9,7 @@ import { addComponent, hasComponent, removeComponent } from '../../ecs/functions
 import { createEntity } from '../../ecs/functions/EntityFunctions'
 import { createEngine } from '../../initializeEngine'
 import { NetworkObjectComponent } from '../../networking/components/NetworkObjectComponent'
-import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { getHandTransform } from '../../xr/functions/WebXRFunctions'
 import { EquippedComponent } from '../components/EquippedComponent'
@@ -47,7 +47,7 @@ describe.skip('EquippableSystem Integration Tests', () => {
     })
 
     createAvatar(
-      NetworkWorldAction.spawnAvatar({
+      WorldNetworkAction.spawnAvatar({
         $from: Engine.instance.userId,
         networkId: networkObject.networkId,
         parameters: { position: new Vector3(-0.48624888685311896, 0, -0.12087574159728942), rotation: new Quaternion() }

--- a/packages/engine/src/interaction/systems/EquippableSystem.ts
+++ b/packages/engine/src/interaction/systems/EquippableSystem.ts
@@ -11,7 +11,7 @@ import {
   removeComponent
 } from '../../ecs/functions/ComponentFunctions'
 import { NetworkObjectAuthorityTag } from '../../networking/components/NetworkObjectAuthorityTag'
-import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
 import { ColliderComponent } from '../../physics/components/ColliderComponent'
 import { teleportRigidbody } from '../../physics/functions/teleportRigidbody'
 import { BodyType } from '../../physics/types/PhysicsTypes'
@@ -22,7 +22,7 @@ import { EquipperComponent } from '../components/EquipperComponent'
 import { getParity } from '../functions/equippableFunctions'
 
 export function setEquippedObjectReceptor(
-  action: ReturnType<typeof NetworkWorldAction.setEquippedObject>,
+  action: ReturnType<typeof WorldNetworkAction.setEquippedObject>,
   world = Engine.instance.currentWorld
 ) {
   if (action.$from === Engine.instance.userId) return
@@ -102,7 +102,7 @@ export function equippableQueryExit(entity: Entity, world = Engine.instance.curr
  * @author Hamza Mushtaq <github.com/hamzzam>
  */
 export default async function EquippableSystem(world: World) {
-  const setEquippedObjectQueue = createActionQueue(NetworkWorldAction.setEquippedObject.matches)
+  const setEquippedObjectQueue = createActionQueue(WorldNetworkAction.setEquippedObject.matches)
 
   const equippableQuery = defineQuery([EquipperComponent])
 

--- a/packages/engine/src/networking/classes/Network.ts
+++ b/packages/engine/src/networking/classes/Network.ts
@@ -46,19 +46,19 @@ export class Network {
   close(instance?: boolean, channel?: boolean) {}
 
   /** List of data producer nodes. */
-  dataProducers: Map<string, any>
+  dataProducers = new Map<string, any>()
 
   /** List of data consumer nodes. */
-  dataConsumers: Map<string, any>
+  dataConsumers = new Map<string, any>()
 
   /** Buffer holding all incoming Messages. */
-  incomingMessageQueueUnreliableIDs: RingBuffer<string>
+  incomingMessageQueueUnreliableIDs: RingBuffer<string> = new RingBuffer<string>(100)
 
   /** Buffer holding all incoming Messages. */
-  incomingMessageQueueUnreliable: RingBuffer<any>
+  incomingMessageQueueUnreliable: RingBuffer<any> = new RingBuffer<any>(100)
 
   /** Buffer holding Mediasoup operations */
-  mediasoupOperationQueue: RingBuffer<any>
+  mediasoupOperationQueue: RingBuffer<any> = new RingBuffer<any>(1000)
 
   /**
    * The UserId of the host

--- a/packages/engine/src/networking/functions/WorldNetworkAction.ts
+++ b/packages/engine/src/networking/functions/WorldNetworkAction.ts
@@ -14,7 +14,7 @@ import { Engine } from '../../ecs/classes/Engine'
 import { matchPose } from '../../transform/TransformInterfaces'
 import { matchesAvatarProps } from '../interfaces/WorldState'
 
-export class NetworkWorldAction {
+export class WorldNetworkAction {
   static createClient = defineAction({
     type: 'network.CREATE_CLIENT',
     name: matches.string,
@@ -53,7 +53,7 @@ export class NetworkWorldAction {
   })
 
   static spawnAvatar = defineAction({
-    ...NetworkWorldAction.spawnObject.actionShape,
+    ...WorldNetworkAction.spawnObject.actionShape,
     prefab: 'avatar',
     parameters: matches.shape({
       position: matchesVector3,

--- a/packages/engine/src/networking/functions/WorldNetworkActionReceptor.test.ts
+++ b/packages/engine/src/networking/functions/WorldNetworkActionReceptor.test.ts
@@ -12,10 +12,11 @@ import { createEntity } from '../../ecs/functions/EntityFunctions'
 import { createEngine } from '../../initializeEngine'
 import { NetworkObjectAuthorityTag } from '../components/NetworkObjectAuthorityTag'
 import { NetworkObjectComponent } from '../components/NetworkObjectComponent'
+import WorldNetworkActionSystem from '../systems/WorldNetworkActionSystem'
 import { WorldNetworkAction } from './WorldNetworkAction'
 import { WorldNetworkActionReceptor } from './WorldNetworkActionReceptor'
 
-describe('NetworkActionReceptors', () => {
+describe('WorldNetworkActionReceptors', () => {
   beforeEach(() => {
     createEngine()
     createMockNetwork()
@@ -27,7 +28,7 @@ describe('NetworkActionReceptors', () => {
       const userId = 'user id' as UserId
       const userName = 'user name'
       const userIndex = 1
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: userId, name: userName, index: userIndex }),
         world
       )
@@ -47,11 +48,11 @@ describe('NetworkActionReceptors', () => {
       const userName2 = 'user name 2'
       const userIndex = 1
 
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: userId, name: userName, index: userIndex }),
         world
       )
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: userId, name: userName2, index: userIndex }),
         world
       )
@@ -66,16 +67,12 @@ describe('NetworkActionReceptors', () => {
       const userId = 'user id' as UserId
       const userName = 'user name'
       const userIndex = 1
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: userId, name: userName, index: userIndex }),
         world
       )
 
-      WorldNetworkActionReceptor.destroyClientReceptor(
-        WorldNetworkAction.destroyClient({ $from: userId }),
-        false,
-        world
-      )
+      WorldNetworkActionReceptor.receiveDestroyClient(WorldNetworkAction.destroyClient({ $from: userId }), false, world)
 
       assert(!world.clients.get(userId))
       assert(!world.userIndexToUserId.get(userIndex))
@@ -87,7 +84,7 @@ describe('NetworkActionReceptors', () => {
       const userId = 'user id' as UserId
       const userName = 'user name'
       const userIndex = 1
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: userId, name: userName, index: userIndex }),
         world
       )
@@ -106,8 +103,7 @@ describe('NetworkActionReceptors', () => {
 
       // process remove actions and execute entity removal
       Engine.instance.store.defaultDispatchDelay = 0
-      WorldNetworkActionReceptor.createNetworkActionReceptor(world)
-      WorldNetworkActionReceptor.destroyClientReceptor(WorldNetworkAction.destroyClient({ $from: userId }), true, world)
+      WorldNetworkActionReceptor.receiveDestroyClient(WorldNetworkAction.destroyClient({ $from: userId }), true, world)
 
       ActionFunctions.clearOutgoingActions()
       ActionFunctions.applyIncomingActions()
@@ -129,11 +125,11 @@ describe('NetworkActionReceptors', () => {
       Engine.instance.userId = userId
       const world = Engine.instance.currentWorld
 
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: hostUserId, name: 'host', index: 0 }),
         world
       )
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: userId, name: 'user name', index: 1 }),
         world
       )
@@ -142,7 +138,7 @@ describe('NetworkActionReceptors', () => {
       const objNetId = 3 as NetworkId
       const objPrefab = 'generic prefab'
 
-      WorldNetworkActionReceptor.spawnObjectReceptor(
+      WorldNetworkActionReceptor.receiveSpawnObject(
         WorldNetworkAction.spawnObject({
           $from: world.worldNetwork.hostId, // from  host
           prefab: objPrefab, // generic prefab
@@ -176,11 +172,11 @@ describe('NetworkActionReceptors', () => {
 
       const world = Engine.instance.currentWorld
 
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: hostId, name: 'world', index: 0 }),
         world
       )
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: userId, name: 'user name', index: 1 }),
         world
       )
@@ -189,7 +185,7 @@ describe('NetworkActionReceptors', () => {
       const objNetId = 3 as NetworkId
       const objPrefab = 'generic prefab'
 
-      WorldNetworkActionReceptor.spawnObjectReceptor(
+      WorldNetworkActionReceptor.receiveSpawnObject(
         WorldNetworkAction.spawnObject({
           $from: userId, // from  user
           prefab: objPrefab, // generic prefab
@@ -223,15 +219,15 @@ describe('NetworkActionReceptors', () => {
       Engine.instance.userId = userId
       const world = Engine.instance.currentWorld
 
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: hostUserId, name: 'world', index: 0 }),
         world
       )
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: userId, name: 'user name', index: 1 }),
         world
       )
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: userId2, name: 'second user name', index: 2 }),
         world
       )
@@ -243,7 +239,7 @@ describe('NetworkActionReceptors', () => {
       const objNetId = 3 as NetworkId
       const objPrefab = 'avatar'
 
-      WorldNetworkActionReceptor.spawnObjectReceptor(
+      WorldNetworkActionReceptor.receiveSpawnObject(
         WorldNetworkAction.spawnObject({
           $from: userId2, // from other user
           prefab: objPrefab, // generic prefab
@@ -276,7 +272,7 @@ describe('NetworkActionReceptors', () => {
       const world = Engine.instance.currentWorld
       world.localClientEntity = createEntity(world)
 
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: userId, name: 'user name', index: 1 }),
         world
       )
@@ -288,7 +284,7 @@ describe('NetworkActionReceptors', () => {
       const objNetId = 3 as NetworkId
       const objPrefab = 'avatar'
 
-      WorldNetworkActionReceptor.spawnObjectReceptor(
+      WorldNetworkActionReceptor.receiveSpawnObject(
         WorldNetworkAction.spawnObject({
           $from: userId, // from user
           prefab: objPrefab, // generic prefab
@@ -309,7 +305,7 @@ describe('NetworkActionReceptors', () => {
   describe('destroyObject', () => {})
 
   describe('transfer ownership of object', () => {
-    it('should transfer ownership of object from host to client', () => {
+    it('should transfer ownership of object from host to client', async () => {
       const hostUserId = 'world' as UserId
       const userId = 'user id' as UserId
 
@@ -319,11 +315,11 @@ describe('NetworkActionReceptors', () => {
 
       Engine.instance.store.defaultDispatchDelay = 0
 
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: hostUserId, name: 'world', index: 0 }),
         world
       )
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: userId, name: 'user name', index: 1 }),
         world
       )
@@ -332,7 +328,7 @@ describe('NetworkActionReceptors', () => {
       const objNetId = 3 as NetworkId
       const objPrefab = 'generic prefab'
 
-      WorldNetworkActionReceptor.spawnObjectReceptor(
+      WorldNetworkActionReceptor.receiveSpawnObject(
         WorldNetworkAction.spawnObject({
           $from: hostUserId, // from host
           prefab: objPrefab, // generic prefab
@@ -351,7 +347,7 @@ describe('NetworkActionReceptors', () => {
       assert.equal(networkObjectEntitiesBefore.length, 1)
       assert.equal(networkObjectOwnedEntitiesBefore.length, 1)
 
-      WorldNetworkActionReceptor.requestAuthorityOverObjectReceptor(
+      WorldNetworkActionReceptor.receiveRequestAuthorityOverObject(
         WorldNetworkAction.requestAuthorityOverObject({
           $from: userId, // from user
           object: {
@@ -363,11 +359,11 @@ describe('NetworkActionReceptors', () => {
         world
       )
 
-      const queues = WorldNetworkActionReceptor.createNetworkActionReceptor(world)
+      const system = await WorldNetworkActionSystem()
 
       ActionFunctions.clearOutgoingActions()
       ActionFunctions.applyIncomingActions()
-      queues()
+      system()
 
       const networkObjectEntitiesAfter = networkObjectQuery(world)
       const networkObjectOwnedEntitiesAfter = networkObjectOwnedQuery(world)
@@ -380,7 +376,7 @@ describe('NetworkActionReceptors', () => {
       assert.equal(hasComponent(networkObjectEntitiesAfter[0], NetworkObjectAuthorityTag), false)
     })
 
-    it('should not transfer authority of object (only host can process authority transfer)', () => {
+    it('should not transfer authority of object (only host can process authority transfer)', async () => {
       // Run as client
       const userId = 'user id' as UserId
       const userName = 'user name'
@@ -388,7 +384,7 @@ describe('NetworkActionReceptors', () => {
       Engine.instance.userId = userId
 
       const world = Engine.instance.currentWorld
-      WorldNetworkActionReceptor.createClientReceptor(
+      WorldNetworkActionReceptor.receiveCreateClient(
         WorldNetworkAction.createClient({ $from: userId, name: userName, index: userIndex }),
         world
       )
@@ -404,7 +400,7 @@ describe('NetworkActionReceptors', () => {
       const objNetId = 3 as NetworkId
       const objPrefab = 'generic prefab'
 
-      WorldNetworkActionReceptor.spawnObjectReceptor(
+      WorldNetworkActionReceptor.receiveSpawnObject(
         WorldNetworkAction.spawnObject({
           $from: world.worldNetwork.hostId, // from host
           prefab: objPrefab, // generic prefab
@@ -424,7 +420,7 @@ describe('NetworkActionReceptors', () => {
       assert.equal(networkObjectOwnedEntities.length, 0)
       assert.equal(getComponent(networkObjectEntities[0], NetworkObjectComponent).ownerId, world.worldNetwork.hostId)
 
-      WorldNetworkActionReceptor.requestAuthorityOverObjectReceptor(
+      WorldNetworkActionReceptor.receiveRequestAuthorityOverObject(
         WorldNetworkAction.requestAuthorityOverObject({
           $from: userId, // from user
           object: {
@@ -435,8 +431,6 @@ describe('NetworkActionReceptors', () => {
         }),
         world
       )
-
-      WorldNetworkActionReceptor.createNetworkActionReceptor(world)
 
       ActionFunctions.clearOutgoingActions()
       ActionFunctions.applyIncomingActions()

--- a/packages/engine/src/networking/functions/WorldNetworkActionReceptor.test.ts
+++ b/packages/engine/src/networking/functions/WorldNetworkActionReceptor.test.ts
@@ -12,8 +12,8 @@ import { createEntity } from '../../ecs/functions/EntityFunctions'
 import { createEngine } from '../../initializeEngine'
 import { NetworkObjectAuthorityTag } from '../components/NetworkObjectAuthorityTag'
 import { NetworkObjectComponent } from '../components/NetworkObjectComponent'
-import { NetworkActionReceptor } from './NetworkActionReceptor'
-import { NetworkWorldAction } from './NetworkWorldAction'
+import { WorldNetworkAction } from './WorldNetworkAction'
+import { WorldNetworkActionReceptor } from './WorldNetworkActionReceptor'
 
 describe('NetworkActionReceptors', () => {
   beforeEach(() => {
@@ -27,8 +27,8 @@ describe('NetworkActionReceptors', () => {
       const userId = 'user id' as UserId
       const userName = 'user name'
       const userIndex = 1
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: userId, name: userName, index: userIndex }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: userId, name: userName, index: userIndex }),
         world
       )
 
@@ -47,12 +47,12 @@ describe('NetworkActionReceptors', () => {
       const userName2 = 'user name 2'
       const userIndex = 1
 
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: userId, name: userName, index: userIndex }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: userId, name: userName, index: userIndex }),
         world
       )
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: userId, name: userName2, index: userIndex }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: userId, name: userName2, index: userIndex }),
         world
       )
 
@@ -66,12 +66,16 @@ describe('NetworkActionReceptors', () => {
       const userId = 'user id' as UserId
       const userName = 'user name'
       const userIndex = 1
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: userId, name: userName, index: userIndex }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: userId, name: userName, index: userIndex }),
         world
       )
 
-      NetworkActionReceptor.destroyClientReceptor(NetworkWorldAction.destroyClient({ $from: userId }), false, world)
+      WorldNetworkActionReceptor.destroyClientReceptor(
+        WorldNetworkAction.destroyClient({ $from: userId }),
+        false,
+        world
+      )
 
       assert(!world.clients.get(userId))
       assert(!world.userIndexToUserId.get(userIndex))
@@ -83,8 +87,8 @@ describe('NetworkActionReceptors', () => {
       const userId = 'user id' as UserId
       const userName = 'user name'
       const userIndex = 1
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: userId, name: userName, index: userIndex }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: userId, name: userName, index: userIndex }),
         world
       )
 
@@ -102,8 +106,8 @@ describe('NetworkActionReceptors', () => {
 
       // process remove actions and execute entity removal
       Engine.instance.store.defaultDispatchDelay = 0
-      NetworkActionReceptor.createNetworkActionReceptor(world)
-      NetworkActionReceptor.destroyClientReceptor(NetworkWorldAction.destroyClient({ $from: userId }), true, world)
+      WorldNetworkActionReceptor.createNetworkActionReceptor(world)
+      WorldNetworkActionReceptor.destroyClientReceptor(WorldNetworkAction.destroyClient({ $from: userId }), true, world)
 
       ActionFunctions.clearOutgoingActions()
       ActionFunctions.applyIncomingActions()
@@ -125,12 +129,12 @@ describe('NetworkActionReceptors', () => {
       Engine.instance.userId = userId
       const world = Engine.instance.currentWorld
 
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: hostUserId, name: 'host', index: 0 }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: hostUserId, name: 'host', index: 0 }),
         world
       )
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: userId, name: 'user name', index: 1 }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: userId, name: 'user name', index: 1 }),
         world
       )
 
@@ -138,8 +142,8 @@ describe('NetworkActionReceptors', () => {
       const objNetId = 3 as NetworkId
       const objPrefab = 'generic prefab'
 
-      NetworkActionReceptor.spawnObjectReceptor(
-        NetworkWorldAction.spawnObject({
+      WorldNetworkActionReceptor.spawnObjectReceptor(
+        WorldNetworkAction.spawnObject({
           $from: world.worldNetwork.hostId, // from  host
           prefab: objPrefab, // generic prefab
           parameters: objParams, // arbitrary
@@ -172,12 +176,12 @@ describe('NetworkActionReceptors', () => {
 
       const world = Engine.instance.currentWorld
 
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: hostId, name: 'world', index: 0 }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: hostId, name: 'world', index: 0 }),
         world
       )
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: userId, name: 'user name', index: 1 }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: userId, name: 'user name', index: 1 }),
         world
       )
 
@@ -185,8 +189,8 @@ describe('NetworkActionReceptors', () => {
       const objNetId = 3 as NetworkId
       const objPrefab = 'generic prefab'
 
-      NetworkActionReceptor.spawnObjectReceptor(
-        NetworkWorldAction.spawnObject({
+      WorldNetworkActionReceptor.spawnObjectReceptor(
+        WorldNetworkAction.spawnObject({
           $from: userId, // from  user
           prefab: objPrefab, // generic prefab
           parameters: objParams, // arbitrary
@@ -219,16 +223,16 @@ describe('NetworkActionReceptors', () => {
       Engine.instance.userId = userId
       const world = Engine.instance.currentWorld
 
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: hostUserId, name: 'world', index: 0 }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: hostUserId, name: 'world', index: 0 }),
         world
       )
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: userId, name: 'user name', index: 1 }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: userId, name: 'user name', index: 1 }),
         world
       )
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: userId2, name: 'second user name', index: 2 }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: userId2, name: 'second user name', index: 2 }),
         world
       )
 
@@ -239,8 +243,8 @@ describe('NetworkActionReceptors', () => {
       const objNetId = 3 as NetworkId
       const objPrefab = 'avatar'
 
-      NetworkActionReceptor.spawnObjectReceptor(
-        NetworkWorldAction.spawnObject({
+      WorldNetworkActionReceptor.spawnObjectReceptor(
+        WorldNetworkAction.spawnObject({
           $from: userId2, // from other user
           prefab: objPrefab, // generic prefab
           parameters: objParams, // arbitrary
@@ -272,8 +276,8 @@ describe('NetworkActionReceptors', () => {
       const world = Engine.instance.currentWorld
       world.localClientEntity = createEntity(world)
 
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: userId, name: 'user name', index: 1 }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: userId, name: 'user name', index: 1 }),
         world
       )
 
@@ -284,8 +288,8 @@ describe('NetworkActionReceptors', () => {
       const objNetId = 3 as NetworkId
       const objPrefab = 'avatar'
 
-      NetworkActionReceptor.spawnObjectReceptor(
-        NetworkWorldAction.spawnObject({
+      WorldNetworkActionReceptor.spawnObjectReceptor(
+        WorldNetworkAction.spawnObject({
           $from: userId, // from user
           prefab: objPrefab, // generic prefab
           parameters: objParams, // arbitrary
@@ -315,12 +319,12 @@ describe('NetworkActionReceptors', () => {
 
       Engine.instance.store.defaultDispatchDelay = 0
 
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: hostUserId, name: 'world', index: 0 }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: hostUserId, name: 'world', index: 0 }),
         world
       )
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: userId, name: 'user name', index: 1 }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: userId, name: 'user name', index: 1 }),
         world
       )
 
@@ -328,8 +332,8 @@ describe('NetworkActionReceptors', () => {
       const objNetId = 3 as NetworkId
       const objPrefab = 'generic prefab'
 
-      NetworkActionReceptor.spawnObjectReceptor(
-        NetworkWorldAction.spawnObject({
+      WorldNetworkActionReceptor.spawnObjectReceptor(
+        WorldNetworkAction.spawnObject({
           $from: hostUserId, // from host
           prefab: objPrefab, // generic prefab
           parameters: objParams, // arbitrary
@@ -347,8 +351,8 @@ describe('NetworkActionReceptors', () => {
       assert.equal(networkObjectEntitiesBefore.length, 1)
       assert.equal(networkObjectOwnedEntitiesBefore.length, 1)
 
-      NetworkActionReceptor.requestAuthorityOverObjectReceptor(
-        NetworkWorldAction.requestAuthorityOverObject({
+      WorldNetworkActionReceptor.requestAuthorityOverObjectReceptor(
+        WorldNetworkAction.requestAuthorityOverObject({
           $from: userId, // from user
           object: {
             ownerId: hostUserId,
@@ -359,7 +363,7 @@ describe('NetworkActionReceptors', () => {
         world
       )
 
-      const queues = NetworkActionReceptor.createNetworkActionReceptor(world)
+      const queues = WorldNetworkActionReceptor.createNetworkActionReceptor(world)
 
       ActionFunctions.clearOutgoingActions()
       ActionFunctions.applyIncomingActions()
@@ -384,8 +388,8 @@ describe('NetworkActionReceptors', () => {
       Engine.instance.userId = userId
 
       const world = Engine.instance.currentWorld
-      NetworkActionReceptor.createClientReceptor(
-        NetworkWorldAction.createClient({ $from: userId, name: userName, index: userIndex }),
+      WorldNetworkActionReceptor.createClientReceptor(
+        WorldNetworkAction.createClient({ $from: userId, name: userName, index: userIndex }),
         world
       )
 
@@ -400,8 +404,8 @@ describe('NetworkActionReceptors', () => {
       const objNetId = 3 as NetworkId
       const objPrefab = 'generic prefab'
 
-      NetworkActionReceptor.spawnObjectReceptor(
-        NetworkWorldAction.spawnObject({
+      WorldNetworkActionReceptor.spawnObjectReceptor(
+        WorldNetworkAction.spawnObject({
           $from: world.worldNetwork.hostId, // from host
           prefab: objPrefab, // generic prefab
           parameters: objParams, // arbitrary
@@ -420,8 +424,8 @@ describe('NetworkActionReceptors', () => {
       assert.equal(networkObjectOwnedEntities.length, 0)
       assert.equal(getComponent(networkObjectEntities[0], NetworkObjectComponent).ownerId, world.worldNetwork.hostId)
 
-      NetworkActionReceptor.requestAuthorityOverObjectReceptor(
-        NetworkWorldAction.requestAuthorityOverObject({
+      WorldNetworkActionReceptor.requestAuthorityOverObjectReceptor(
+        WorldNetworkAction.requestAuthorityOverObject({
           $from: userId, // from user
           object: {
             ownerId: world.worldNetwork.hostId,
@@ -432,7 +436,7 @@ describe('NetworkActionReceptors', () => {
         world
       )
 
-      NetworkActionReceptor.createNetworkActionReceptor(world)
+      WorldNetworkActionReceptor.createNetworkActionReceptor(world)
 
       ActionFunctions.clearOutgoingActions()
       ActionFunctions.applyIncomingActions()

--- a/packages/engine/src/networking/functions/receiveJoinWorld.ts
+++ b/packages/engine/src/networking/functions/receiveJoinWorld.ts
@@ -7,7 +7,7 @@ import { Action } from '@xrengine/hyperflux/functions/ActionFunctions'
 import { Engine } from '../../ecs/classes/Engine'
 import { EngineActions, getEngineState } from '../../ecs/classes/EngineState'
 import { AvatarProps } from '../interfaces/WorldState'
-import { NetworkWorldAction } from './NetworkWorldAction'
+import { WorldNetworkAction } from './WorldNetworkAction'
 
 export type JoinWorldProps = {
   highResTimeOrigin: number
@@ -47,7 +47,7 @@ export const receiveJoinWorld = (props: JoinWorldProps) => {
 
   for (const action of cachedActions) Engine.instance.store.actions.incoming.push({ ...action, $fromCache: true })
 
-  dispatchAction(NetworkWorldAction.createClient(client), [world.worldNetwork.hostId])
-  dispatchAction(NetworkWorldAction.spawnAvatar({ parameters: spawnPose }), [world.worldNetwork.hostId])
-  dispatchAction(NetworkWorldAction.avatarDetails({ avatarDetail }), [world.worldNetwork.hostId])
+  dispatchAction(WorldNetworkAction.createClient(client), [world.worldNetwork.hostId])
+  dispatchAction(WorldNetworkAction.spawnAvatar({ parameters: spawnPose }), [world.worldNetwork.hostId])
+  dispatchAction(WorldNetworkAction.avatarDetails({ avatarDetail }), [world.worldNetwork.hostId])
 }

--- a/packages/engine/src/networking/functions/validateNetworkObjects.ts
+++ b/packages/engine/src/networking/functions/validateNetworkObjects.ts
@@ -2,7 +2,7 @@ import { dispatchAction } from '@xrengine/hyperflux'
 
 import { Engine } from '../../ecs/classes/Engine'
 import { World } from '../../ecs/classes/World'
-import { NetworkWorldAction } from './NetworkWorldAction'
+import { WorldNetworkAction } from './WorldNetworkAction'
 
 export async function validateNetworkObjects(world: World): Promise<void> {
   for (const [userId, client] of world.clients) {
@@ -11,7 +11,7 @@ export async function validateNetworkObjects(world: World): Promise<void> {
     if (Date.now() - client.lastSeenTs > 30000) {
       console.log('Removing client ', userId, ' due to inactivity')
 
-      dispatchAction(NetworkWorldAction.destroyClient({ $from: userId }), [
+      dispatchAction(WorldNetworkAction.destroyClient({ $from: userId }), [
         Engine.instance.currentWorld.worldNetwork.hostId
       ])
 

--- a/packages/engine/src/networking/systems/IncomingActionSystem.test.ts
+++ b/packages/engine/src/networking/systems/IncomingActionSystem.test.ts
@@ -7,7 +7,7 @@ import ActionFunctions, { ActionRecipients } from '@xrengine/hyperflux/functions
 import { createMockNetwork } from '../../../tests/util/createMockNetwork'
 import { Engine } from '../../ecs/classes/Engine'
 import { createEngine } from '../../initializeEngine'
-import { NetworkWorldAction } from '../functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../functions/WorldNetworkAction'
 
 describe('IncomingActionSystem Unit Tests', async () => {
   beforeEach(() => {
@@ -27,7 +27,7 @@ describe('IncomingActionSystem Unit Tests', async () => {
       world.fixedTick = 0
 
       /* mock */
-      const action = NetworkWorldAction.spawnObject({
+      const action = WorldNetworkAction.spawnObject({
         $from: '0' as UserId,
         prefab: '',
         parameters: {},
@@ -41,7 +41,7 @@ describe('IncomingActionSystem Unit Tests', async () => {
 
       const recepted: typeof action[] = []
       ActionFunctions.addActionReceptor((a) =>
-        matches(a).when(NetworkWorldAction.spawnObject.matches, (a) => recepted.push(a))
+        matches(a).when(WorldNetworkAction.spawnObject.matches, (a) => recepted.push(a))
       )
 
       /* run */
@@ -62,7 +62,7 @@ describe('IncomingActionSystem Unit Tests', async () => {
       const world = Engine.instance.currentWorld
 
       /* mock */
-      const action = NetworkWorldAction.spawnObject({
+      const action = WorldNetworkAction.spawnObject({
         $from: '0' as UserId,
         prefab: '',
         parameters: {},
@@ -76,7 +76,7 @@ describe('IncomingActionSystem Unit Tests', async () => {
 
       const recepted: typeof action[] = []
       ActionFunctions.addActionReceptor((a) =>
-        matches(a).when(NetworkWorldAction.spawnObject.matches, (a) => recepted.push(a))
+        matches(a).when(WorldNetworkAction.spawnObject.matches, (a) => recepted.push(a))
       )
 
       /* run */
@@ -93,7 +93,7 @@ describe('IncomingActionSystem Unit Tests', async () => {
       world.fixedTick = 1
 
       /* mock */
-      const action = NetworkWorldAction.spawnObject({
+      const action = WorldNetworkAction.spawnObject({
         $from: '0' as UserId,
         prefab: '',
         parameters: {},
@@ -108,7 +108,7 @@ describe('IncomingActionSystem Unit Tests', async () => {
 
       const recepted: typeof action[] = []
       ActionFunctions.addActionReceptor((a) =>
-        matches(a).when(NetworkWorldAction.spawnObject.matches, (a) => recepted.push(a))
+        matches(a).when(WorldNetworkAction.spawnObject.matches, (a) => recepted.push(a))
       )
 
       /* run */

--- a/packages/engine/src/networking/systems/IncomingNetworkSystem.ts
+++ b/packages/engine/src/networking/systems/IncomingNetworkSystem.ts
@@ -1,7 +1,7 @@
 import { getEngineState } from '../../ecs/classes/EngineState'
 import { World } from '../../ecs/classes/World'
-import { NetworkActionReceptor } from '../functions/NetworkActionReceptor'
 import { validateNetworkObjects } from '../functions/validateNetworkObjects'
+import { WorldNetworkActionReceptor } from '../functions/WorldNetworkActionReceptor'
 import { createDataReader } from '../serialization/DataReader'
 
 export const applyUnreliableQueueFast = (deserialize: Function) => (world: World) => {

--- a/packages/engine/src/networking/systems/NetworkActionSystem.ts
+++ b/packages/engine/src/networking/systems/NetworkActionSystem.ts
@@ -1,9 +1,0 @@
-import { World } from '../../ecs/classes/World'
-import { WorldNetworkActionReceptor } from '../functions/WorldNetworkActionReceptor'
-
-export default async function NetworkActionSystem(world: World) {
-  const worldNetworkQueues = WorldNetworkActionReceptor.createNetworkActionReceptor(world)
-  return () => {
-    worldNetworkQueues()
-  }
-}

--- a/packages/engine/src/networking/systems/NetworkActionSystem.ts
+++ b/packages/engine/src/networking/systems/NetworkActionSystem.ts
@@ -1,9 +1,9 @@
 import { World } from '../../ecs/classes/World'
-import { NetworkActionReceptor } from '../functions/NetworkActionReceptor'
+import { WorldNetworkActionReceptor } from '../functions/WorldNetworkActionReceptor'
 
-export default async function IncomingNetworkSystem(world: World) {
-  const networkQueues = NetworkActionReceptor.createNetworkActionReceptor(world)
+export default async function NetworkActionSystem(world: World) {
+  const worldNetworkQueues = WorldNetworkActionReceptor.createNetworkActionReceptor(world)
   return () => {
-    networkQueues()
+    worldNetworkQueues()
   }
 }

--- a/packages/engine/src/networking/systems/WorldNetworkActionSystem.ts
+++ b/packages/engine/src/networking/systems/WorldNetworkActionSystem.ts
@@ -1,0 +1,35 @@
+import { createActionQueue } from '@xrengine/hyperflux'
+
+import { WorldNetworkAction } from '../functions/WorldNetworkAction'
+import { WorldNetworkActionReceptor } from '../functions/WorldNetworkActionReceptor'
+
+/**
+ * @author Gheric Speiginer <github.com/speigg>
+ * @author Josh Field <github.com/HexaField>
+ */
+export default async function WorldNetworkActionSystem() {
+  const createClientQueue = createActionQueue(WorldNetworkAction.createClient.matches)
+  const destroyClientQueue = createActionQueue(WorldNetworkAction.destroyClient.matches)
+  const spawnObjectQueue = createActionQueue(WorldNetworkAction.spawnObject.matches)
+  const spawnDebugPhysicsObjectQueue = createActionQueue(WorldNetworkAction.spawnDebugPhysicsObject.matches)
+  const destroyObjectQueue = createActionQueue(WorldNetworkAction.destroyObject.matches)
+  const requestAuthorityOverObjectQueue = createActionQueue(WorldNetworkAction.requestAuthorityOverObject.matches)
+  const transferAuthorityOfObjectQueue = createActionQueue(WorldNetworkAction.transferAuthorityOfObject.matches)
+  const setEquippedObjectQueue = createActionQueue(WorldNetworkAction.setEquippedObject.matches)
+  const setUserTypingQueue = createActionQueue(WorldNetworkAction.setUserTyping.matches)
+
+  return () => {
+    for (const action of createClientQueue()) WorldNetworkActionReceptor.receiveCreateClient(action)
+    for (const action of destroyClientQueue()) WorldNetworkActionReceptor.receiveDestroyClient(action)
+    for (const action of spawnObjectQueue()) WorldNetworkActionReceptor.receiveSpawnObject(action)
+    for (const action of spawnDebugPhysicsObjectQueue())
+      WorldNetworkActionReceptor.receiveSpawnDebugPhysicsObject(action)
+    for (const action of destroyObjectQueue()) WorldNetworkActionReceptor.receiveDestroyObject(action)
+    for (const action of requestAuthorityOverObjectQueue())
+      WorldNetworkActionReceptor.receiveRequestAuthorityOverObject(action)
+    for (const action of transferAuthorityOfObjectQueue())
+      WorldNetworkActionReceptor.receiveTransferAuthorityOfObject(action)
+    for (const action of setEquippedObjectQueue()) WorldNetworkActionReceptor.receiveSetEquippedObject(action)
+    for (const action of setUserTypingQueue()) WorldNetworkActionReceptor.receiveSetUserTyping(action)
+  }
+}

--- a/packages/engine/src/physics/functions/physicsObjectDebugFunctions.ts
+++ b/packages/engine/src/physics/functions/physicsObjectDebugFunctions.ts
@@ -6,7 +6,7 @@ import { World } from '@xrengine/engine/src/ecs/classes/World'
 import { addComponent, getComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
 import { createEntity } from '@xrengine/engine/src/ecs/functions/EntityFunctions'
 import { addEntityNodeInTree, createEntityNode } from '@xrengine/engine/src/ecs/functions/EntityTreeFunctions'
-import { NetworkWorldAction } from '@xrengine/engine/src/networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '@xrengine/engine/src/networking/functions/WorldNetworkAction'
 import { ColliderComponent } from '@xrengine/engine/src/physics/components/ColliderComponent'
 import { CollisionGroups } from '@xrengine/engine/src/physics/enums/CollisionGroups'
 import { ShapeOptions } from '@xrengine/engine/src/physics/functions/createCollider'
@@ -174,7 +174,7 @@ export const generatePhysicsObject = (
     const node = world.entityTree.entityNodeMap.get(entity)
     if (node) {
       dispatchAction(
-        NetworkWorldAction.spawnObject({
+        WorldNetworkAction.spawnObject({
           prefab: '',
           parameters: { sceneEntityId: node.uuid, position: transform.position }
         }),

--- a/packages/engine/src/physics/systems/PhysicsSystem.ts
+++ b/packages/engine/src/physics/systems/PhysicsSystem.ts
@@ -12,7 +12,7 @@ import { defineQuery, getComponent, hasComponent, removeComponent } from '../../
 import { BoundingBoxComponent } from '../../interaction/components/BoundingBoxComponent'
 import { NetworkObjectComponent } from '../../networking/components/NetworkObjectComponent'
 import { NetworkObjectDirtyTag } from '../../networking/components/NetworkObjectDirtyTag'
-import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
 import { Object3DComponent } from '../../scene/components/Object3DComponent'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { isDynamicBody, isStaticBody } from '../classes/Physics'
@@ -24,7 +24,7 @@ import { teleportRigidbody } from '../functions/teleportRigidbody'
 
 // Receptor
 export function physicsActionReceptor(
-  action: typeof NetworkWorldAction.teleportObject.matches._TYPE,
+  action: typeof WorldNetworkAction.teleportObject.matches._TYPE,
   world = Engine.instance.currentWorld
 ) {
   const [x, y, z, qX, qY, qZ, qW] = action.pose
@@ -205,7 +205,7 @@ const processCollisions = (world: World) => {
 const simulationPipeline = pipe(processRaycasts, processNetworkBodies, processBodies, processCollisions)
 
 export default async function PhysicsSystem(world: World) {
-  const teleportObjectQueue = createActionQueue(NetworkWorldAction.teleportObject.matches)
+  const teleportObjectQueue = createActionQueue(WorldNetworkAction.teleportObject.matches)
 
   await world.physics.createScene()
 

--- a/packages/engine/src/scene/functions/loadGLTFModel.ts
+++ b/packages/engine/src/scene/functions/loadGLTFModel.ts
@@ -14,7 +14,7 @@ import { addComponent, ComponentMap, getComponent, removeComponent } from '../..
 import { createEntity } from '../../ecs/functions/EntityFunctions'
 import { NavMeshComponent } from '../../navigation/component/NavMeshComponent'
 import { matchActionOnce } from '../../networking/functions/matchActionOnce'
-import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
 import { applyTransformToMeshWorld } from '../../physics/functions/parseModelColliders'
 import { TransformChildComponent } from '../../transform/components/TransformChildComponent'
 import { TransformComponent } from '../../transform/components/TransformComponent'
@@ -215,7 +215,7 @@ export const parseGLTFModel = (entity: Entity, props: ModelComponentType, obj3d:
     const node = world.entityTree.entityNodeMap.get(entity)
     if (node) {
       dispatchAction(
-        NetworkWorldAction.spawnObject({
+        WorldNetworkAction.spawnObject({
           prefab: '',
           parameters: { sceneEntityId: node.uuid }
         }),

--- a/packages/engine/src/scene/functions/loaders/CameraPropertiesFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/CameraPropertiesFunctions.ts
@@ -9,7 +9,7 @@ import { Entity } from '../../../ecs/classes/Entity'
 import { addComponent, getComponent } from '../../../ecs/functions/ComponentFunctions'
 import { useWorld } from '../../../ecs/functions/SystemHooks'
 import { matchActionOnce } from '../../../networking/functions/matchActionOnce'
-import { NetworkWorldAction } from '../../../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../../../networking/functions/WorldNetworkAction'
 import { CameraPropertiesComponent, CameraPropertiesComponentType } from '../../components/CameraPropertiesComponent'
 import { EntityNodeComponent } from '../../components/EntityNodeComponent'
 import { setCameraProperties } from '../setCameraProperties'
@@ -55,7 +55,7 @@ export const deserializeCameraProperties: ComponentDeserializeFunction = (
   getComponent(entity, EntityNodeComponent)?.components.push(SCENE_COMPONENT_CAMERA_PROPERTIES)
 
   if (isClient) {
-    matchActionOnce(NetworkWorldAction.spawnAvatar.matches, (spawnAction) => {
+    matchActionOnce(WorldNetworkAction.spawnAvatar.matches, (spawnAction) => {
       if (spawnAction.$from === Engine.instance.userId) {
         setCameraProperties(useWorld().localClientEntity, json.props)
         return true

--- a/packages/engine/src/scene/functions/teleportToScene.ts
+++ b/packages/engine/src/scene/functions/teleportToScene.ts
@@ -7,7 +7,7 @@ import { unloadScene } from '../../ecs/functions/EngineFunctions'
 import { unloadSystems } from '../../ecs/functions/SystemFunctions'
 import { useWorld } from '../../ecs/functions/SystemHooks'
 import { matchActionOnce } from '../../networking/functions/matchActionOnce'
-import { NetworkActionReceptor } from '../../networking/functions/NetworkActionReceptor'
+import { WorldNetworkActionReceptor } from '../../networking/functions/WorldNetworkActionReceptor'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { HyperspaceTagComponent } from '../components/HyperspaceTagComponent'
 
@@ -19,7 +19,7 @@ export const teleportToScene = async () => {
   addComponent(world.worldEntity, HyperspaceTagComponent, {})
 
   // remove all network clients but own (will be updated when new connection is established)
-  NetworkActionReceptor.removeAllNetworkClients(false, world)
+  WorldNetworkActionReceptor.removeAllNetworkClients(false, world)
 
   // remove this scene's injected systems
   unloadSystems(world, true)

--- a/packages/engine/src/scene/systems/HyperspacePortalSystem.ts
+++ b/packages/engine/src/scene/systems/HyperspacePortalSystem.ts
@@ -17,7 +17,7 @@ import { addComponent, defineQuery, getComponent, removeComponent } from '../../
 import { LocalInputTagComponent } from '../../input/components/LocalInputTagComponent'
 import { InteractorComponent } from '../../interaction/components/InteractorComponent'
 import { matchActionOnce } from '../../networking/functions/matchActionOnce'
-import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
 import { PortalEffect } from '../classes/PortalEffect'
 import { HyperspaceTagComponent } from '../components/HyperspaceTagComponent'
 import { Object3DComponent } from '../components/Object3DComponent'
@@ -48,7 +48,7 @@ export default async function HyperspacePortalSystem(world: World) {
       removeComponent(world.localClientEntity, InteractorComponent)
       removeComponent(world.localClientEntity, LocalInputTagComponent)
 
-      dispatchAction(NetworkWorldAction.avatarAnimation({ newStateName: AvatarStates.FALL_IDLE, params: {} }))
+      dispatchAction(WorldNetworkAction.avatarAnimation({ newStateName: AvatarStates.FALL_IDLE, params: {} }))
 
       // TODO: add BPCEM of old and new scenes and fade them in and out too
       hyperspaceEffect.fadeIn(delta)

--- a/packages/engine/src/xr/functions/WebXRFunctions.ts
+++ b/packages/engine/src/xr/functions/WebXRFunctions.ts
@@ -11,7 +11,7 @@ import { proxifyQuaternion, proxifyVector3 } from '../../common/proxies/three'
 import { Engine } from '../../ecs/classes/Engine'
 import { Entity } from '../../ecs/classes/Entity'
 import { addComponent, getComponent, hasComponent, removeComponent } from '../../ecs/functions/ComponentFunctions'
-import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
 import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { XRInputSourceComponent, XRInputSourceComponentType } from '../../xr/components/XRInputSourceComponent'
@@ -198,7 +198,7 @@ export const bindXRHandEvents = () => {
       initializeHandModel(world.localClientEntity, controller, xrInputSource.handedness)
 
       if (!eventSent) {
-        dispatchAction(NetworkWorldAction.xrHandsConnected({}), [Engine.instance.currentWorld.worldNetwork.hostId])
+        dispatchAction(WorldNetworkAction.xrHandsConnected({}), [Engine.instance.currentWorld.worldNetwork.hostId])
         eventSent = true
       }
     })
@@ -224,7 +224,7 @@ export const startWebXR = async (): Promise<void> => {
 
   const avatarInputState = accessAvatarInputSettingsState()
   dispatchAction(
-    NetworkWorldAction.setXRMode({ enabled: true, avatarInputControllerType: avatarInputState.controlType.value }),
+    WorldNetworkAction.setXRMode({ enabled: true, avatarInputControllerType: avatarInputState.controlType.value }),
     [Engine.instance.currentWorld.worldNetwork.hostId]
   )
 
@@ -248,7 +248,7 @@ export const endXR = (): void => {
   removeComponent(world.localClientEntity, XRInputSourceComponent)
   removeComponent(world.localClientEntity, XRHandsInputComponent)
 
-  dispatchAction(NetworkWorldAction.setXRMode({ enabled: false, avatarInputControllerType: '' }), [
+  dispatchAction(WorldNetworkAction.setXRMode({ enabled: false, avatarInputControllerType: '' }), [
     Engine.instance.currentWorld.worldNetwork.hostId
   ])
 }

--- a/packages/engine/src/xr/systems/XRSystem.ts
+++ b/packages/engine/src/xr/systems/XRSystem.ts
@@ -14,7 +14,7 @@ import { InputComponent } from '../../input/components/InputComponent'
 import { LocalInputTagComponent } from '../../input/components/LocalInputTagComponent'
 import { InputType } from '../../input/enums/InputType'
 import { gamepadMapping } from '../../input/functions/GamepadInput'
-import { NetworkWorldAction } from '../../networking/functions/NetworkWorldAction'
+import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
 import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { ObjectLayers } from '../../scene/constants/ObjectLayers'
 import { XRInputSourceComponent } from '../components/XRInputSourceComponent'
@@ -42,7 +42,7 @@ const startXRSession = async () => {
   }
 }
 
-export function setXRModeReceptor(action: typeof NetworkWorldAction.setXRMode.matches._TYPE) {
+export function setXRModeReceptor(action: typeof WorldNetworkAction.setXRMode.matches._TYPE) {
   // Current WebXRManager.getCamera() typedef is incorrect
   // @ts-ignore
   const cameras = EngineRenderer.instance.xrManager.getCamera() as ArrayCamera
@@ -90,7 +90,7 @@ export default async function XRSystem(world: World) {
       })
   })
 
-  const setXRModeQueue = createActionQueue(NetworkWorldAction.setXRMode.matches)
+  const setXRModeQueue = createActionQueue(WorldNetworkAction.setXRMode.matches)
 
   return () => {
     for (const action of setXRModeQueue()) setXRModeReceptor(action)

--- a/packages/engine/tests/equippables/equippables.test.ts
+++ b/packages/engine/tests/equippables/equippables.test.ts
@@ -91,7 +91,7 @@ describe('Equippables Integration Tests', () => {
     equipEntity(equipperEntity, equippableEntity, undefined)
 
     // world.receptors.push(
-    //     (a) => matches(a).when(NetworkWorldAction.setEquippedObject.matches, setEquippedObjectReceptor)
+    //     (a) => matches(a).when(WorldNetworkAction.setEquippedObject.matches, setEquippedObjectReceptor)
     // )
     ActionFunctions.clearOutgoingActions()
     ActionFunctions.applyIncomingActions()

--- a/packages/gameserver/src/NetworkFunctions.ts
+++ b/packages/gameserver/src/NetworkFunctions.ts
@@ -10,8 +10,8 @@ import checkPositionIsValid from '@xrengine/engine/src/common/functions/checkPos
 import { performance } from '@xrengine/engine/src/common/functions/performance'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { getComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
-import { NetworkWorldAction } from '@xrengine/engine/src/networking/functions/NetworkWorldAction'
 import { JoinWorldProps } from '@xrengine/engine/src/networking/functions/receiveJoinWorld'
+import { WorldNetworkAction } from '@xrengine/engine/src/networking/functions/WorldNetworkAction'
 import { AvatarProps } from '@xrengine/engine/src/networking/interfaces/WorldState'
 import { Object3DComponent } from '@xrengine/engine/src/scene/components/Object3DComponent'
 import { TransformComponent } from '@xrengine/engine/src/transform/components/TransformComponent'
@@ -248,7 +248,7 @@ function disconnectClientIfConnected(network: SocketWebRTCServerNetwork, socket:
     // client.socket?.disconnect()
     // for (const eid of world.getOwnedNetworkObjects(userId)) {
     //   const { networkId } = getComponent(eid, NetworkObjectComponent)
-    //   dispatchFrom(network.hostId, () => NetworkWorldAction.destroyObject({ $from: userId, networkId }))
+    //   dispatchFrom(network.hostId, () => WorldNetworkAction.destroyObject({ $from: userId, networkId }))
     // }
     return true
   }
@@ -320,7 +320,7 @@ export const handleJoinWorld = async (
   // send all cached and outgoing actions to joining user
   const cachedActions = [] as Required<Action>[]
   for (const action of Engine.instance.store.actions.cached[network.hostId] as Array<
-    ReturnType<typeof NetworkWorldAction.spawnAvatar>
+    ReturnType<typeof WorldNetworkAction.spawnAvatar>
   >) {
     // we may have a need to remove the check for the prefab type to enable this to work for networked objects too
     if (action.type === 'network.SPAWN_OBJECT' && action.prefab === 'avatar') {
@@ -384,7 +384,7 @@ export async function handleDisconnect(network: SocketWebRTCServerNetwork, socke
   // The new connection will overwrite the socketID for the user's client.
   // This will only clear transports if the client's socketId matches the socket that's disconnecting.
   if (socket.id === disconnectedClient?.socketId) {
-    dispatchAction(NetworkWorldAction.destroyClient({ $from: userId }), [network.hostId])
+    dispatchAction(WorldNetworkAction.destroyClient({ $from: userId }), [network.hostId])
     logger.info('Disconnecting clients for user ' + userId)
     if (disconnectedClient?.instanceRecvTransport) disconnectedClient.instanceRecvTransport.close()
     if (disconnectedClient?.instanceSendTransport) disconnectedClient.instanceSendTransport.close()
@@ -406,7 +406,7 @@ export async function handleLeaveWorld(
   for (const [, transport] of Object.entries(network.mediasoupTransports))
     if ((transport as any).appData.peerId === userId) closeTransport(network, transport)
   if (world.clients.has(userId)) {
-    dispatchAction(NetworkWorldAction.destroyClient({ $from: userId }))
+    dispatchAction(WorldNetworkAction.destroyClient({ $from: userId }))
   }
   if (callback !== undefined) callback({})
 }

--- a/packages/gameserver/src/SocketWebRTCServerNetwork.ts
+++ b/packages/gameserver/src/SocketWebRTCServerNetwork.ts
@@ -2,7 +2,6 @@ import * as https from 'https'
 import { DataProducer, Router, Transport, WebRtcTransport, Worker } from 'mediasoup/node/lib/types'
 
 import { UserId } from '@xrengine/common/src/interfaces/UserId'
-import { RingBuffer } from '@xrengine/engine/src/common/classes/RingBuffer'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { Network } from '@xrengine/engine/src/networking/classes/Network'
 import { MessageTypes } from '@xrengine/engine/src/networking/enums/MessageTypes'
@@ -16,18 +15,10 @@ import { startWebRTC } from './WebRTCFunctions'
 const logger = multiLogger.child({ component: 'gameserver:webrtc:network' })
 
 export class SocketWebRTCServerNetwork extends Network {
-  server: https.Server
   workers: Worker[] = []
   routers: Record<string, Router[]>
   transport: Transport
   app: Application
-
-  dataProducers = new Map<string, any>()
-  dataConsumers = new Map<string, any>()
-
-  incomingMessageQueueUnreliableIDs: RingBuffer<string> = new RingBuffer<string>(100)
-  incomingMessageQueueUnreliable: RingBuffer<any> = new RingBuffer<any>(100)
-  mediasoupOperationQueue: RingBuffer<any> = new RingBuffer<any>(1000)
 
   outgoingDataTransport: Transport
   outgoingDataProducer: DataProducer

--- a/packages/hyperflux/README.md
+++ b/packages/hyperflux/README.md
@@ -29,13 +29,13 @@ export default async function IncomingActionSystem(world) {
 In any case, the appropriate store must be provided when dispatching an action:
 
 ```ts
-dispatchAction( NetworkWorldAction.spawnAvatar({ parameters }))
+dispatchAction( WorldNetworkAction.spawnAvatar({ parameters }))
   ```
 
 Likewise when adding or removing receptors:
 ```ts
 addActionReceptor((a) =>
-  matches(a).when(NetworkWorldAction.spawnObject.matches, (a) => recepted.push(a))
+  matches(a).when(WorldNetworkAction.spawnObject.matches, (a) => recepted.push(a))
 )
 ```
 


### PR DESCRIPTION
## Summary

- Rename NetworkWorldAction to WorldNetworkAction
- receptors use same nomenclature
- fix offline location

## References

closes https://github.com/XRFoundation/XREngine/issues/6104

## Checklist
- [ ] CI/CD checks pass `npm run check`
  - [ ] Linter passing via `npm run lint`
  - [ ] Typescript passing via `npm run check-errors`
  - [ ] Unit & Integration tests passing via `npm run test`
  - [ ] Docker build process passing via `npm run build-client`
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Reviewers

_Reviewers for this PR_
