### PR TITLE
Add host userId and index to related maps on server provision.

### DIFF
--- a/packages/client-core/src/common/services/LocationInstanceConnectionService.ts
+++ b/packages/client-core/src/common/services/LocationInstanceConnectionService.ts
@@ -39,6 +39,11 @@ store.receptors.push((action: LocationInstanceConnectionActionType): any => {
     switch (action.type) {
       case 'LOCATION_INSTANCE_SERVER_PROVISIONED':
         Engine.instance.currentWorld._worldHostId = action.instanceId as UserId
+
+        const userIndex = Engine.instance.currentWorld.userIndexCount++
+        Engine.instance.currentWorld.userIdToUserIndex.set(action.instanceId as UserId, userIndex)
+        Engine.instance.currentWorld.userIndexToUserId.set(userIndex, action.instanceId as UserId)
+
         Engine.instance.currentWorld.networks.set(
           action.instanceId,
           new SocketWebRTCClientNetwork(action.instanceId, NetworkTypes.world)

--- a/packages/engine/src/networking/systems/WorldNetworkActionSystem.ts
+++ b/packages/engine/src/networking/systems/WorldNetworkActionSystem.ts
@@ -21,9 +21,9 @@ export default async function WorldNetworkActionSystem() {
   return () => {
     for (const action of createClientQueue()) WorldNetworkActionReceptor.receiveCreateClient(action)
     for (const action of destroyClientQueue()) WorldNetworkActionReceptor.receiveDestroyClient(action)
-    for (const action of spawnObjectQueue()) WorldNetworkActionReceptor.receiveSpawnObject(action)
     for (const action of spawnDebugPhysicsObjectQueue())
       WorldNetworkActionReceptor.receiveSpawnDebugPhysicsObject(action)
+    for (const action of spawnObjectQueue()) WorldNetworkActionReceptor.receiveSpawnObject(action)
     for (const action of destroyObjectQueue()) WorldNetworkActionReceptor.receiveDestroyObject(action)
     for (const action of requestAuthorityOverObjectQueue())
       WorldNetworkActionReceptor.receiveRequestAuthorityOverObject(action)


### PR DESCRIPTION
## Summary

The issue arose when we changed the logic of how we register clients & stopped sending the list of clients (which used to include the host id) in response of _handleJoinWorld_ 
Now all clients are registered as a result of network actions.
But a network action for registering the host as a client is never dispatched. And therefore host is missing in the _world.userIndexToUserId_ maps due to which packets containing state for host owned objects are never processed by the clients. 

@speigg suggested to do this on _LOCATION_INSTANCE_SERVER_PROVISIONED_  since that is when the hostId is known.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

