### PR TITLE
Fixed issues with S3 getCachedObject function.

### DIFF
--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -90,7 +90,7 @@ export class S3Provider implements StorageProviderInterface {
 
   async getCachedObject(key: string): Promise<StorageObjectInterface> {
     const data = await fetch(getCachedURL(key, this.cacheDomain))
-    return { Body: (await data.arrayBuffer()) as Buffer, ContentType: (await data.blob()).type }
+    return { Body: Buffer.from(await data.arrayBuffer()), ContentType: (await data.headers.get('content-type')) || '' }
   }
 
   getObjectContentType = async (key: string): Promise<any> => {


### PR DESCRIPTION
## Summary

node-fetch won't let you call both .arrayBuffer() and .blob() on the same data.
Getting content-type manually instead of calling .blob().

Need to convert ArrayBuffer to Buffer for file writes to work.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

