### PR TITLE
Fixed weird esoteric bug in matchmaking README.md

### DIFF
--- a/packages/matchmaking/README.md
+++ b/packages/matchmaking/README.md
@@ -23,7 +23,7 @@ hostname to the IP address of minikube.
 
 ### Point hostname in hostfile to minikube's IP
 Run `minikube ip`. This will give you minikube's IP address.
-Next, edit the file `/etc/hosts` (or whatever your hostfile is called if not on Linux); you may need to execute `sudo`
+Next, edit the file `hosts` in the folder `/etc` (or whatever your hostfile is called if not on Linux); you may need to execute `sudo`
 privileges to edit it. You'll need to add a line like this:
 
 `<minikube ip>  <hostname>`, e.g. 


### PR DESCRIPTION
## Summary

If the exact string `/etc/hosts` appears in the README, npm won't accept the code. Reworded its occurrence
to get around this.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

