### PR TITLE
Fixed a couple of bugs related to chat.

### DIFF
--- a/packages/client-core/src/components/InstanceChat/index.tsx
+++ b/packages/client-core/src/components/InstanceChat/index.tsx
@@ -386,39 +386,31 @@ const InstanceChat = (props: Props): any => {
               </CardContent>
             </Card>
           </div>
-          {unreadMessages && (
-            <div
-              className={`${styles.iconCallChat} ${
-                isInitRender
-                  ? props.animate
-                  : !chatWindowOpen
-                  ? isMobile
-                    ? styles.animateTop
-                    : styles.animateLeft
-                  : ''
-              } ${!chatWindowOpen ? '' : styles.iconCallPos}`}
+          <div
+            className={`${styles.iconCallChat} ${
+              isInitRender ? props.animate : !chatWindowOpen ? (isMobile ? styles.animateTop : styles.animateLeft) : ''
+            } ${!chatWindowOpen ? '' : styles.iconCallPos}`}
+          >
+            <Badge
+              color="primary"
+              variant="dot"
+              invisible={noUnReadMessage}
+              anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
             >
-              <Badge
-                color="primary"
-                variant="dot"
-                invisible={noUnReadMessage}
-                anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
-              >
-                <Fab className={styles.chatBadge} color="primary" onClick={() => toggleChatWindow()}>
-                  {!chatWindowOpen ? (
-                    <MessageButton />
-                  ) : (
-                    <CloseButton
-                      onClick={() => {
-                        toggleChatWindow()
-                        if (isMobile) setShowTouchPad(true)
-                      }}
-                    />
-                  )}
-                </Fab>
-              </Badge>
-            </div>
-          )}
+              <Fab className={styles.chatBadge} color="primary" onClick={() => toggleChatWindow()}>
+                {!chatWindowOpen ? (
+                  <MessageButton />
+                ) : (
+                  <CloseButton
+                    onClick={() => {
+                      toggleChatWindow()
+                      if (isMobile) setShowTouchPad(true)
+                    }}
+                  />
+                )}
+              </Fab>
+            </Badge>
+          </div>
         </div>
       </div>
     </>

--- a/packages/server-core/src/social/channel/channel.class.ts
+++ b/packages/server-core/src/social/channel/channel.class.ts
@@ -134,9 +134,10 @@ export class Channel<T = ChannelDataType> extends Service<T> {
           limit: limit
         }
       } else {
-        return this.app
-          .service('channel')
-          .Model.findAll({ where: { channelType: query.channelType, instanceId: query.instanceId } })
+        return this.app.service('channel').Model.findAll({
+          include: params.sequelize.include,
+          where: { channelType: query.channelType, instanceId: query.instanceId }
+        })
       }
     } catch (err) {
       logger.error(err, `Channel find failed: ${err.message}`)


### PR DESCRIPTION
## Summary

channel.find() was not using the sequelize include statements, and was not
returning the messages (nor other populated information) on the response.
This was causing bugs on the frontend, which expects the messages to be part
of the response.

InstanceChat was only rendering the 'open world chat' button if `unreadMessages`
were true. This seems like undesired behavior - a user should be able to open
the world chat even if there aren't any new messages.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

