### PR TITLE
[Fix} Engine Timer Starts Earlier

### DIFF
--- a/packages/engine/src/initializeEngine.ts
+++ b/packages/engine/src/initializeEngine.ts
@@ -33,6 +33,7 @@ export const createEngine = () => {
   EngineRenderer.instance = new EngineRenderer()
   registerState(EngineState)
   addActionReceptor(EngineEventReceptor)
+  Engine.instance.engineTimer = Timer(executeWorlds, Engine.instance.tickRate)
 }
 
 /**
@@ -41,7 +42,6 @@ export const createEngine = () => {
  * initializes everything for the browser context
  */
 export const initializeBrowser = () => {
-  EngineRenderer.instance.initialize()
   Engine.instance.publicPath = location.origin
   const world = Engine.instance.currentWorld
   world.audioListener = new AudioListener()
@@ -75,6 +75,9 @@ export const initializeBrowser = () => {
   matchActionOnce(EngineActions.connect.matches, (action: any) => {
     Engine.instance.userId = action.id
   })
+
+  EngineRenderer.instance.initialize()
+  Engine.instance.engineTimer.start()
 }
 
 const setupInitialClickListener = () => {
@@ -93,7 +96,7 @@ const setupInitialClickListener = () => {
  * initializes everything for the node context
  */
 export const initializeNode = () => {
-  // node currently does not need to initialize anything
+  Engine.instance.engineTimer.start()
 }
 
 const executeWorlds = (elapsedTime) => {
@@ -124,9 +127,6 @@ export const initializeMediaServerSystems = async () => {
   const world = Engine.instance.currentWorld
 
   await initSystems(world, coreSystems)
-
-  Engine.instance.engineTimer = Timer(executeWorlds, Engine.instance.tickRate)
-  Engine.instance.engineTimer.start()
 
   dispatchAction(EngineActions.initializeEngine({ initialised: true }))
 }
@@ -192,9 +192,6 @@ export const initializeCoreSystems = async () => {
 
   // load injected systems which may rely on core systems
   await initSystems(world, Engine.instance.injectedSystems)
-
-  Engine.instance.engineTimer = Timer(executeWorlds, Engine.instance.tickRate)
-  Engine.instance.engineTimer.start()
 
   dispatchAction(EngineActions.initializeEngine({ initialised: true }))
 }

--- a/packages/engine/src/scene/functions/loaders/AssetComponentFunctions.test.ts
+++ b/packages/engine/src/scene/functions/loaders/AssetComponentFunctions.test.ts
@@ -61,6 +61,7 @@ describe('AssetComponentFunctions', async () => {
     sandbox = Sinon.createSandbox()
     createEngine()
     initEntity()
+    Engine.instance.engineTimer.start()
 
     Engine.instance.publicPath = ''
     await initializeCoreSystems()


### PR DESCRIPTION
## Summary

The engine timer needs to be instantiated earlier for actions to dispatch properly. As we convert the client flux services to use hyperflux, invalid states were being reached.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

