### PR TITLE
e2e tests launch and kill dev stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "publish-github": "lerna publish from-package --yes --no-verify-access --ignore-scripts --registry https://npm.pkg.github.com",
     "start": "npm run dev",
     "test": "cross-env TEST=true lerna run test",
-    "test-e2e": "lerna run test-e2e",
+    "test-e2e": "ts-node scripts/run_e2e_tests.ts",
     "test:projects": "cross-env TEST=true lerna run test:projects",
     "test:ci": "cpy --no-overwrite --rename=.env.local '.env.local.default' . && cross-env CI=true npm run test",
     "update-name-gh-package": "lerna run update-name-gh-package",

--- a/scripts/run_e2e_tests.ts
+++ b/scripts/run_e2e_tests.ts
@@ -1,0 +1,46 @@
+import childProcess from 'child_process'
+import killPort from 'kill-port'
+
+import config from '@xrengine/server-core/src/appconfig'
+
+// we may need an alternative to kill-port for mac & windows
+
+const killports = () => {
+  killPort(config.server.port)
+  killPort(config.instanceserver.port)
+  killPort('3032') // todo, we should put this hardcoded val into env
+  killPort(process.env.CORS_SERVER_PORT)
+  killPort(process.env.VITE_APP_PORT)
+  killPort(process.env.LOCAL_STORAGE_PROVIDER_PORT)
+}
+
+killports()
+const logOutput = (child) => {
+  child.stdout.setEncoding('utf8')
+  child.stdout.on('data', function (data) {
+    console.log(data)
+  })
+  child.stderr.setEncoding('utf8')
+  child.stderr.on('data', function (data) {
+    console.log(data)
+  })
+}
+
+const devStack = childProcess.spawn('npm', ['run', 'dev'])
+logOutput(devStack)
+const lernaE2E = childProcess.spawn('npx', ['lerna', 'run', 'test-e2e'])
+logOutput(lernaE2E)
+lernaE2E.on('exit', (exitCode) => {
+  console.log(`'lerna run test-e2e' exited with exit code`, exitCode)
+  devStack.kill(exitCode!)
+  process.exit(exitCode!)
+})
+devStack.on('exit', (exitCode) => {
+  console.log(`'npm run dev' exited with exit code`, exitCode)
+})
+process.on('exit', (exitCode) => {
+  console.log(`'npm run test-e2e' exited with exit code`, exitCode)
+  killports()
+  if (!lernaE2E.killed) lernaE2E.kill(exitCode)
+  if (!devStack.killed) devStack.kill(exitCode)
+})


### PR DESCRIPTION
## Summary

e2e tests were hard to run locally, as they needed to be run separately than the intergation tests.

included is a script that fixes this by launching and destroying the dev stack (`npm run dev`)


## References

closes https://github.com/XRFoundation/XREngine/issues/6376


## Checklist
- [ ] If this PR is still a WIP, convert to a draft 
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

