### PR TITLE
Fixed bugs in instance channel fetching and display.

### DIFF
--- a/packages/client-core/src/components/InstanceChat/index.tsx
+++ b/packages/client-core/src/components/InstanceChat/index.tsx
@@ -291,9 +291,10 @@ const InstanceChat = (props: Props): any => {
                             <div className={`${styles.selfEnd} ${styles.noMargin}`}>
                               <div className={styles.dFlex}>
                                 <div className={styles.msgWrapper}>
-                                  {isLeftOrJoinText(messages[index - 1].text) ? (
+                                  {messages[index - 1] && isLeftOrJoinText(messages[index - 1].text) ? (
                                     <h3 className={styles.sender}>{message.sender.name}</h3>
                                   ) : (
+                                    messages[index - 1] &&
                                     message.senderId !== messages[index - 1].senderId && (
                                       <h3 className={styles.sender}>{message.sender.name}</h3>
                                     )
@@ -306,9 +307,10 @@ const InstanceChat = (props: Props): any => {
                                     <p className={styles.text}>{message.text}</p>
                                   </div>
                                 </div>
-                                {index !== 0 && isLeftOrJoinText(messages[index - 1].text) ? (
+                                {index !== 0 && messages[index - 1] && isLeftOrJoinText(messages[index - 1].text) ? (
                                   <Avatar src={getAvatarURLForUser(message.senderId)} className={styles.avatar} />
                                 ) : (
+                                  messages[index - 1] &&
                                   message.senderId !== messages[index - 1].senderId && (
                                     <Avatar src={getAvatarURLForUser(message.senderId)} className={styles.avatar} />
                                   )

--- a/packages/client-core/src/social/services/ChatService.ts
+++ b/packages/client-core/src/social/services/ChatService.ts
@@ -250,6 +250,7 @@ export const ChatService = {
         }
       })) as Channel[]
       if (!channelResult.length) return setTimeout(() => ChatService.getInstanceChannel(), 2000)
+      if (channelResult[0].messages.length === 0) return setTimeout(() => ChatService.getInstanceChannel(), 500)
       dispatch(ChatAction.loadedChannel(channelResult[0], 'instance'))
     } catch (err) {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })


### PR DESCRIPTION
## Summary

Sometimes, the client recognizes a connection to an instance server has been made
before the initial 'joined' message has been created, and so when the instance channel
is fetched, there are no messages. Added a check for number of messages that triggers
a refetch in 500 ms until there are messages to display.

Added some checks to InstanceChat/index.tsx that messages[index -1] exists before trying
to call isLeftOrJoinText on that; the above bug brought to light a bug here where that
call would throw an error since there was no prior message to call on.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft 
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewers


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

