### PR TITLE
Fix Scene Object System Simple Material Model Clash

### DIFF
--- a/packages/engine/src/scene/functions/loaders/ModelFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/ModelFunctions.ts
@@ -69,8 +69,13 @@ export const updateModel: ComponentUpdateFunction = (entity: Entity, properties:
     overrideTexture(entity)
   }
 
-  if (properties.useBasicMaterial !== undefined && properties.useBasicMaterial) {
-    addComponent(entity, SimpleMaterialTagComponent, true)
+  if (typeof properties.useBasicMaterial === 'boolean') {
+    const hasTag = hasComponent(entity, SimpleMaterialTagComponent)
+    if (properties.useBasicMaterial) {
+      if (!hasTag) addComponent(entity, SimpleMaterialTagComponent, true)
+    } else {
+      if (hasTag) removeComponent(entity, SimpleMaterialTagComponent)
+    }
   }
 }
 

--- a/packages/engine/src/scene/systems/SceneObjectSystem.ts
+++ b/packages/engine/src/scene/systems/SceneObjectSystem.ts
@@ -181,6 +181,8 @@ export default async function SceneObjectSystem(world: World) {
      * This is needed as the inverse case of the previous query to ensure objects that are created without a simple material still have the standard material logic applied
      */
     for (const entity of standardMaterialsQuery.enter()) {
+      //check for materials that have had simple material tag added this frame
+      if (hasComponent(entity, SimpleMaterialTagComponent)) continue
       const object3DComponent = getComponent(entity, Object3DComponent)
       if (object3DComponent.value === world.scene) continue
       object3DComponent.value.traverse((obj: Object3DWithEntity) => {


### PR DESCRIPTION
Added removeComponent logic to "Use Basic Materials" field on model components. 

Needed to add special case to useStandardMaterial entry query in scene object system for the first frame of scene loading, where models with the "Use Basic Materials" field set to true show up in both the useSimpleMaterial entry query and useStandardMaterial entry query