### PR TITLE
Fixed coil-settings find/get handlers, pruned some client-settings fetches

### DIFF
--- a/packages/client-core/src/admin/services/Setting/ClientSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/ClientSettingService.ts
@@ -50,8 +50,11 @@ export const useClientSettingState = () => useState(accessClientSettingState())
 export const ClientSettingService = {
   fetchClientSettings: async (inDec?: 'increment' | 'decrement') => {
     try {
+      console.log('waitingForClientAuthenticated')
       await waitForClientAuthenticated()
+      console.log('CLIENT AUTHENTICATED!')
       const clientSettings = (await API.instance.client.service('client-setting').find()) as Paginated<ClientSetting>
+      console.log('Dispatching fetchedClient')
       dispatchAction(ClientSettingActions.fetchedClient({ clientSettings }))
     } catch (err) {
       console.log(err.message)

--- a/packages/client-core/src/components/Layout/index.tsx
+++ b/packages/client-core/src/components/Layout/index.tsx
@@ -57,7 +57,6 @@ const Layout = ({ useLoadingScreenOpacity, pageTitle, children, hideVideo, hideF
   const engineState = useEngineState()
 
   useEffect(() => {
-    !clientSetting && ClientSettingService.fetchClientSettings()
     !coilSetting && AdminCoilSettingService.fetchCoil()
     const topButtonsState = localStorage.getItem('isTopButtonsShown')
     const bottomButtonsState = localStorage.getItem('isBottomButtonsShown')

--- a/packages/client/src/pages/_app.tsx
+++ b/packages/client/src/pages/_app.tsx
@@ -105,10 +105,6 @@ const App = (): any => {
   useEffect(initApp, [])
 
   useEffect(() => {
-    !clientSetting && ClientSettingService.fetchClientSettings()
-  }, [])
-
-  useEffect(() => {
     if (selfUser?.id && projectState.updateNeeded.value) ProjectService.fetchProjects()
   }, [selfUser, projectState.updateNeeded.value])
 
@@ -132,7 +128,7 @@ const App = (): any => {
       setDescription(clientSetting?.siteDescription)
       setClientThemeSettings(clientSetting?.themeSettings)
     }
-    ClientSettingService.fetchClientSettings()
+    if (clientSettingState?.updateNeeded?.value) ClientSettingService.fetchClientSettings()
   }, [clientSettingState?.updateNeeded?.value])
 
   useEffect(() => {

--- a/packages/client/src/pages/index.tsx
+++ b/packages/client/src/pages/index.tsx
@@ -16,10 +16,6 @@ export const HomePage = (): any => {
   const clientSettingState = useClientSettingState()
   const [clientSetting] = clientSettingState?.client?.value || []
 
-  useEffect(() => {
-    !clientSetting && ClientSettingService.fetchClientSettings()
-  }, [])
-
   if (ROOT_REDIRECT && ROOT_REDIRECT.length > 0 && ROOT_REDIRECT !== 'false') {
     const redirectParsed = new URL(ROOT_REDIRECT)
     if (redirectParsed.protocol == null) return <Redirect to={ROOT_REDIRECT} />

--- a/packages/client/src/route/public.tsx
+++ b/packages/client/src/route/public.tsx
@@ -65,7 +65,6 @@ function RouterComp() {
     // The client and auth settigns will not be needed on these routes
     if (!/auth\/oauth/.test(location.pathname)) {
       AuthService.doLoginAuto()
-      ClientSettingService.fetchClientSettings()
       AuthSettingsService.fetchAuthSetting()
     }
     getCustomRoutes().then((routes) => {

--- a/packages/server-core/src/setting/client-setting/client-setting.class.ts
+++ b/packages/server-core/src/setting/client-setting/client-setting.class.ts
@@ -1,4 +1,4 @@
-import { NullableId, Paginated, Params } from '@feathersjs/feathers'
+import { Id, NullableId, Paginated, Params } from '@feathersjs/feathers'
 import { SequelizeServiceOptions, Service } from 'feathers-sequelize'
 
 import { ClientSetting as ClientSettingInterface } from '@xrengine/common/src/interfaces/ClientSetting'
@@ -36,6 +36,21 @@ export class ClientSetting<T = ClientSettingDataType> extends Service<T> {
       limit: clientSettings.limit,
       skip: clientSettings.skip,
       data
+    }
+  }
+
+  async get(id: Id, params?: Params): Promise<T> {
+    const clientSettings = (await super.get(id, params)) as any
+    let appSocialLinks = JSON.parse(clientSettings.appSocialLinks)
+    let themeSettings = JSON.parse(clientSettings.themeSettings)
+
+    if (typeof appSocialLinks === 'string') appSocialLinks = JSON.parse(appSocialLinks)
+    if (typeof themeSettings === 'string') themeSettings = JSON.parse(themeSettings)
+
+    return {
+      ...clientSettings,
+      appSocialLinks: appSocialLinks,
+      themeSettings: themeSettings
     }
   }
 

--- a/packages/server-core/src/setting/coil-setting/coil-setting.class.ts
+++ b/packages/server-core/src/setting/coil-setting/coil-setting.class.ts
@@ -1,8 +1,10 @@
+import { Id, Paginated, Params } from '@feathersjs/feathers'
 import { SequelizeServiceOptions, Service } from 'feathers-sequelize'
 
 import { CoilSetting as CoilSettingDataType } from '@xrengine/common/src/interfaces/CoilSetting'
 
 import { Application } from '../../../declarations'
+import { UserDataType } from '../../user/user/user.class'
 
 export class CoilSetting<T = CoilSettingDataType> extends Service<T> {
   app: Application
@@ -10,5 +12,26 @@ export class CoilSetting<T = CoilSettingDataType> extends Service<T> {
   constructor(options: Partial<SequelizeServiceOptions>, app: Application) {
     super(options)
     this.app = app
+  }
+
+  async get(id: Id, params?: Params): Promise<T> {
+    const loggedInUser = params!.user as UserDataType
+    const settings = (await super.get(id, params)) as any
+    if (loggedInUser.userRole !== 'admin') {
+      delete settings.clientId
+      delete settings.clientSecret
+    }
+    return settings
+  }
+
+  async find(params?: Params): Promise<T[] | Paginated<T>> {
+    const loggedInUser = params!.user as UserDataType
+    const settings = (await super.find(params)) as any
+    if (loggedInUser.userRole !== 'admin')
+      settings.data.forEach((setting) => {
+        delete setting.clientId
+        delete setting.clientSecret
+      })
+    return settings
   }
 }

--- a/packages/server-core/src/setting/coil-setting/coil-setting.hooks.ts
+++ b/packages/server-core/src/setting/coil-setting/coil-setting.hooks.ts
@@ -6,13 +6,13 @@ import authenticate from '../../hooks/authenticate'
 
 export default {
   before: {
-    all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    all: [authenticate()],
     find: [],
     get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: []
+    create: [iff(isProvider('external'), restrictUserRole('admin') as any)],
+    update: [iff(isProvider('external'), restrictUserRole('admin') as any)],
+    patch: [iff(isProvider('external'), restrictUserRole('admin') as any)],
+    remove: [iff(isProvider('external'), restrictUserRole('admin') as any)]
   },
 
   after: {


### PR DESCRIPTION
## Summary

Updates to coil-settings were preventing non-admins from getting them at all, but some information in
them is needed. Removed admin restriction on FIND & GET, made custom handlers that strip out clientId
and clientSecret for non-admins before returning.

Added custom client-setting GET handler that performs the same alterations to the result that the FIND
handler does.

Removed several extraneous calls to ClientSettingService.fetchClientSettings(). Only one is needed, and
the one in _app.tsx on udpateNeeded being true should cover every page.

## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

