### PR TITLE
combine spectate and join world, clean up various connection things

### DIFF
--- a/packages/client-core/src/common/services/LocationInstanceConnectionService.ts
+++ b/packages/client-core/src/common/services/LocationInstanceConnectionService.ts
@@ -121,11 +121,10 @@ export const LocationInstanceConnectionService = {
     const transport = Engine.instance.currentWorld.worldNetwork as SocketWebRTCClientNetwork
     logger.info({ socket: !!transport.socket, transport }, 'Connect To World Server')
     if (transport.socket) {
-      await leaveNetwork(transport, false)
+      leaveNetwork(transport, false)
     }
     const { ipAddress, port, locationId } = accessLocationInstanceConnectionState().instances.value[instanceId]
     await transport.initialize({ port, ipAddress, locationId })
-    transport.left = false
   },
   useAPIListeners: () => {
     useEffect(() => {

--- a/packages/client-core/src/common/services/MediaInstanceConnectionService.ts
+++ b/packages/client-core/src/common/services/MediaInstanceConnectionService.ts
@@ -119,7 +119,7 @@ export const MediaInstanceConnectionService = {
     logger.info({ socket: !!network.socket, network }, 'Connect To Media Server.')
     if (network.socket) {
       await endVideoChat(network, { endConsumers: true })
-      await leaveNetwork(network, false)
+      leaveNetwork(network, false)
     }
 
     const locationState = accessLocationState()
@@ -139,7 +139,6 @@ export const MediaInstanceConnectionService = {
     )
 
     await network.initialize({ port, ipAddress, channelId })
-    network.left = false
   },
   resetServer: (instanceId: string) => {
     dispatchAction(MediaInstanceConnectionAction.disconnect({ instanceId }))

--- a/packages/client-core/src/components/MediaIconsBox/index.tsx
+++ b/packages/client-core/src/components/MediaIconsBox/index.tsx
@@ -115,7 +115,7 @@ const MediaIconsBox = (props: Props) => {
     ) {
       await endVideoChat(mediaNetwork, {})
       if (mediaNetwork.socket?.connected === true) {
-        await leaveNetwork(mediaNetwork, false)
+        leaveNetwork(mediaNetwork, false)
         await MediaInstanceConnectionService.provisionServer(instanceChannel.id)
       }
     }

--- a/packages/client-core/src/components/World/InstanceServerWarnings.tsx
+++ b/packages/client-core/src/components/World/InstanceServerWarnings.tsx
@@ -150,7 +150,7 @@ const InstanceServerWarnings = () => {
         const transport = Engine.instance.currentWorld.networks.get(
           Engine.instance.currentWorld.worldNetwork?.hostId
         ) as SocketWebRTCClientNetwork
-        if (transport.left || engineState.isTeleporting.value || transport.reconnecting) return
+        if (engineState.isTeleporting.value || transport.reconnecting) return
 
         setModalValues({
           open: true,
@@ -167,7 +167,7 @@ const InstanceServerWarnings = () => {
       case WarningModalTypes.CHANNEL_DISCONNECTED: {
         if (!Engine.instance.userId) return
         const transport = Engine.instance.currentWorld.mediaNetwork as SocketWebRTCClientNetwork
-        if (transport.left || transport.reconnecting) return
+        if (transport.reconnecting) return
 
         const channels = chatState.channels.channels.value
         const instanceChannel = Object.values(channels).find(
@@ -186,10 +186,7 @@ const InstanceServerWarnings = () => {
       }
 
       case WarningModalTypes.INSTANCE_WEBGL_DISCONNECTED: {
-        const transport = Engine.instance.currentWorld.networks.get(
-          Engine.instance.currentWorld.worldNetwork?.hostId
-        ) as SocketWebRTCClientNetwork
-        if (transport.left || engineState.isTeleporting.value) return
+        if (engineState.isTeleporting.value) return
 
         setModalValues({
           open: true,

--- a/packages/client-core/src/components/World/LoadEngineWithScene.tsx
+++ b/packages/client-core/src/components/World/LoadEngineWithScene.tsx
@@ -72,7 +72,7 @@ export const LoadEngineWithScene = () => {
     }
   }, [engineState.joinedWorld])
 
-  useHookEffect(async () => {
+  useHookEffect(() => {
     if (engineState.isTeleporting.value) {
       // TODO: this needs to be implemented on the server too
       // Use teleportAvatar function from moveAvatar.ts when required
@@ -93,16 +93,9 @@ export const LoadEngineWithScene = () => {
       history.push('/location/' + world.activePortal.location)
       LocationService.getLocationByName(world.activePortal.location)
 
-      // shut down connection with existing IS
-      await leaveNetwork(world.worldNetwork as SocketWebRTCClientNetwork)
-
-      if (world.mediaNetwork) {
-        const isInstanceMediaConnection =
-          accessMediaInstanceConnectionState().instances[world.mediaNetwork.hostId].channelType.value === 'instance'
-        if (isInstanceMediaConnection) {
-          await leaveNetwork(world.mediaNetwork as SocketWebRTCClientNetwork)
-        }
-      }
+      // shut down connection with existing world instance server
+      // leaving a world instance server will check if we are in a location media instance and shut that down too
+      leaveNetwork(world.worldNetwork as SocketWebRTCClientNetwork)
 
       teleportToScene()
     }

--- a/packages/client-core/src/components/World/NetworkInstanceProvisioning.tsx
+++ b/packages/client-core/src/components/World/NetworkInstanceProvisioning.tsx
@@ -20,7 +20,7 @@ import { matches } from '@xrengine/engine/src/common/functions/MatchesUtils'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { useEngineState } from '@xrengine/engine/src/ecs/classes/EngineState'
 import { MessageTypes } from '@xrengine/engine/src/networking/enums/MessageTypes'
-import { receiveJoinWorld, receiveSpectateWorld } from '@xrengine/engine/src/networking/functions/receiveJoinWorld'
+import { JoinWorldRequestData, receiveJoinWorld } from '@xrengine/engine/src/networking/functions/receiveJoinWorld'
 import { addActionReceptor, dispatchAction, removeActionReceptor, useHookEffect } from '@xrengine/hyperflux'
 
 import { UserServiceReceptor } from '../../user/services/UserService'
@@ -121,22 +121,18 @@ export const NetworkInstanceProvisioning = () => {
   ])
 
   useHookEffect(() => {
-    if (!engineState.connectedWorld.value || !engineState.sceneLoaded.value) return
+    if (!engineState.connectedWorld.value || !engineState.sceneLoaded.value || engineState.joinedWorld.value) return
 
-    const spectateUser = getSearchParamFromURL('spectate')
-    if (spectateUser) {
-      const transportRequestData = { spectateUser }
-      Engine.instance.currentWorld.worldNetwork
-        .request(MessageTypes.SpectateWorld.toString(), transportRequestData)
-        .then(receiveSpectateWorld)
-    } else {
-      const transportRequestData = {
-        inviteCode: getSearchParamFromURL('inviteCode')!
-      }
-      Engine.instance.currentWorld.worldNetwork
-        .request(MessageTypes.JoinWorld.toString(), transportRequestData)
-        .then(receiveJoinWorld)
-    }
+    const transportRequestData = {
+      inviteCode: getSearchParamFromURL('inviteCode')!,
+      spectateUserId: Engine.instance.isEditor ? 'none' : getSearchParamFromURL('spectate')
+    } as JoinWorldRequestData
+
+    console.log('[NetworkInstanceProvisioning]: Request Join World', { transportRequestData })
+
+    Engine.instance.currentWorld.worldNetwork
+      .request(MessageTypes.JoinWorld.toString(), transportRequestData)
+      .then(receiveJoinWorld)
   }, [engineState.connectedWorld, appState.onBoardingStep])
 
   // media server provisioning

--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -1,14 +1,5 @@
-import { Consumer, Transport as MediaSoupTransport, Producer } from 'mediasoup-client/lib/types'
-import {
-  BufferGeometry,
-  LinearFilter,
-  Mesh,
-  MeshBasicMaterial,
-  MeshLambertMaterial,
-  PlaneGeometry,
-  sRGBEncoding,
-  VideoTexture
-} from 'three'
+import { Transport as MediaSoupTransport } from 'mediasoup-client/lib/types'
+import { Mesh, MeshBasicMaterial, PlaneGeometry, sRGBEncoding, VideoTexture } from 'three'
 
 import { MediaStreams } from '@xrengine/client-core/src/transports/MediaStreams'
 import { ChannelType } from '@xrengine/common/src/interfaces/Channel'
@@ -22,7 +13,6 @@ import { NetworkTypes } from '@xrengine/engine/src/networking/classes/Network'
 import { PUBLIC_STUN_SERVERS } from '@xrengine/engine/src/networking/constants/STUNServers'
 import { CAM_VIDEO_SIMULCAST_ENCODINGS } from '@xrengine/engine/src/networking/constants/VideoConstants'
 import { MessageTypes } from '@xrengine/engine/src/networking/enums/MessageTypes'
-import { receiveJoinWorld } from '@xrengine/engine/src/networking/functions/receiveJoinWorld'
 import { WorldNetworkActionReceptor } from '@xrengine/engine/src/networking/functions/WorldNetworkActionReceptor'
 import { Object3DComponent } from '@xrengine/engine/src/scene/components/Object3DComponent'
 import { ScreenshareTargetComponent } from '@xrengine/engine/src/scene/components/ScreenshareTargetComponent'
@@ -39,7 +29,6 @@ import { NetworkConnectionService } from '../common/services/NetworkConnectionSe
 import { MediaStreamAction, MediaStreamService } from '../media/services/MediaStreamService'
 import { accessAuthState } from '../user/services/AuthService'
 import { UserService } from '../user/services/UserService'
-import { getSearchParamFromURL } from '../util/getSearchParamFromURL'
 import { SocketWebRTCClientNetwork } from './SocketWebRTCClientNetwork'
 import { updateNearbyAvatars } from './UpdateNearbyUsersSystem'
 
@@ -80,12 +69,7 @@ export async function onConnectToInstance(network: SocketWebRTCClientNetwork) {
 
   if (!success) return console.error('Unable to connect with credentials')
 
-  const connectToWorldResponse = await Promise.race([
-    await network.request(MessageTypes.ConnectToWorld.toString()),
-    new Promise((resolve, reject) => {
-      setTimeout(() => !connectToWorldResponse && reject(new Error('Connect timed out')), 10000)
-    })
-  ])
+  const connectToWorldResponse = await network.request(MessageTypes.ConnectToWorld.toString())
 
   if (!connectToWorldResponse || !connectToWorldResponse.routerRtpCapabilities) {
     dispatchAction(NetworkConnectionService.actions.worldInstanceReconnected())
@@ -94,9 +78,7 @@ export async function onConnectToInstance(network: SocketWebRTCClientNetwork) {
     return
   }
 
-  const { routerRtpCapabilities } = connectToWorldResponse
-
-  if (network.mediasoupDevice.loaded !== true) await network.mediasoupDevice.load({ routerRtpCapabilities })
+  if (network.mediasoupDevice.loaded !== true) await network.mediasoupDevice.load(connectToWorldResponse)
 
   if (isWorldConnection) await onConnectToWorldInstance(network)
   else await onConnectToMediaInstance(network)
@@ -137,6 +119,13 @@ export async function onConnectToWorldInstance(network: SocketWebRTCClientNetwor
     })
   }
 
+  function kickHandler(message) {
+    // console.log("TODO: SNACKBAR HERE");
+    leaveNetwork(network, true)
+    dispatchAction(NetworkConnectionService.actions.worldInstanceKicked({ message }))
+    console.log('Client has been kicked from the world')
+  }
+
   async function reconnectHandler() {
     dispatchAction(NetworkConnectionService.actions.worldInstanceReconnected())
     network.reconnecting = false
@@ -153,6 +142,7 @@ export async function onConnectToWorldInstance(network: SocketWebRTCClientNetwor
 
     // Get information for how to consume data from server and init a data consumer
     network.socket.off(MessageTypes.WebRTCConsumeData.toString(), consumeDataHandler)
+    network.socket.off(MessageTypes.Kick.toString(), kickHandler)
   }
 
   network.socket.on('disconnect', disconnectHandler)
@@ -162,6 +152,8 @@ export async function onConnectToWorldInstance(network: SocketWebRTCClientNetwor
 
   // Get information for how to consume data from server and init a data consumer
   network.socket.on(MessageTypes.WebRTCConsumeData.toString(), consumeDataHandler)
+
+  network.socket.on(MessageTypes.Kick.toString(), kickHandler)
 
   await Promise.all([initSendTransport(network), initReceiveTransport(network)])
   await createDataProducer(network, 'instance')
@@ -173,14 +165,6 @@ export async function onConnectToWorldInstance(network: SocketWebRTCClientNetwor
   window.addEventListener('unload', async () => {
     // TODO: Handle this as a full disconnect
     network.socket.emit(MessageTypes.LeaveWorld.toString())
-  })
-
-  network.socket.on(MessageTypes.Kick.toString(), async (message) => {
-    // console.log("TODO: SNACKBAR HERE");
-    await endVideoChat(network, { endConsumers: true })
-    await leaveNetwork(network, true)
-    dispatchAction(NetworkConnectionService.actions.worldInstanceKicked({ message }))
-    console.log('Client has been kicked from the world')
   })
 }
 
@@ -454,7 +438,7 @@ export async function createTransport(network: SocketWebRTCClientNetwork, direct
   // any time a transport transitions to closed,
   // failed, or disconnected, leave the  and reset
   transport.on('connectionstatechange', async (state: string) => {
-    if (!network.leaving && (state === 'closed' || state === 'failed' || state === 'disconnected')) {
+    if (state === 'closed' || state === 'failed' || state === 'disconnected') {
       dispatchAction(
         network.type === NetworkTypes.world
           ? NetworkConnectionService.actions.worldInstanceDisconnected()
@@ -483,7 +467,7 @@ export async function createTransport(network: SocketWebRTCClientNetwork, direct
       }, 5000)
       // await request(MessageTypes.WebRTCTransportClose.toString(), {transportId: transport.id});
     }
-    // if (network.leaving !== true && state === 'connected' && transport.direction === 'recv') {
+    // if (state === 'connected' && transport.direction === 'recv') {
     //   console.log('requesting current producers for', channelType, channelId)
     //   await request(MessageTypes.WebRTCRequestCurrentProducers.toString(), {
     //     channelType: channelType,
@@ -880,29 +864,14 @@ export async function closeConsumer(network: SocketWebRTCClientNetwork, consumer
   })
 }
 
-export async function leaveNetwork(network: SocketWebRTCClientNetwork, kicked?: boolean) {
+export function leaveNetwork(network: SocketWebRTCClientNetwork, kicked?: boolean) {
   try {
-    network.leaving = true
-    const socket = network.socket
-    if (!kicked && socket?.connected) {
-      // close everything on the server-side (transports, producers, consumers)
-      const result = await Promise.race([
-        await network.request(MessageTypes.LeaveWorld.toString()),
-        new Promise((resolve, reject) => {
-          setTimeout(() => reject(new Error('Connect timed out')), 10000)
-        })
-      ])
-      if (result?.error) console.error(result.error)
-      dispatchAction(EngineActions.leaveWorld())
-    }
-
-    network.leaving = false
-    network.left = true
-
-    //Leaving the world should close all transports from the server side.
-    //This will also destroy all the associated producers and consumers.
-    //All we need to do on the client is null all references.
+    // Leaving a network should close all transports from the server side.
+    // This will also destroy all the associated producers and consumers.
+    // All we need to do on the client is null all references.
     network.close()
+
+    const world = Engine.instance.currentWorld
 
     if (network.type === NetworkTypes.media) {
       if (MediaStreams.instance.audioStream) {
@@ -921,21 +890,27 @@ export async function leaveNetwork(network: SocketWebRTCClientNetwork, kicked?: 
       MediaStreams.instance.audioStream = null!
       MediaStreams.instance.localScreen = null
       network.consumers = []
-      Engine.instance.currentWorld.networks.delete(network.hostId)
-      Engine.instance.currentWorld._mediaHostId = null!
+      world.networks.delete(network.hostId)
+      world._mediaHostId = null!
       dispatchAction(MediaInstanceConnectionAction.disconnect({ instanceId: network.hostId }))
     } else {
-      WorldNetworkActionReceptor.removeAllNetworkPeers(false, Engine.instance.currentWorld, network)
-      Engine.instance.currentWorld.networks.delete(network.hostId)
-      Engine.instance.currentWorld._worldHostId = null!
+      WorldNetworkActionReceptor.removeAllNetworkPeers(false, world, network)
+      world.networks.delete(network.hostId)
+      world._worldHostId = null!
       dispatchAction(LocationInstanceConnectionAction.disconnect({ instanceId: network.hostId }))
       dispatchAction(EngineActions.connectToWorld({ connectedWorld: false }))
+      // if world has a media server connection
+      if (world.mediaNetwork) {
+        const mediaState = accessMediaInstanceConnectionState().instances[world.mediaNetwork.hostId].value
+        if (mediaState.channelType === 'instance' && mediaState.connected) {
+          leaveNetwork(world.mediaNetwork as SocketWebRTCClientNetwork)
+        }
+      }
     }
     removeTopic(network.hostId)
   } catch (err) {
     console.log('Error with leave()')
     console.log(err)
-    network.leaving = false
   }
 }
 

--- a/packages/client-core/src/transports/SocketWebRTCClientNetwork.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientNetwork.ts
@@ -28,8 +28,6 @@ export class SocketWebRTCClientNetwork extends Network {
   }
 
   mediasoupDevice = new mediasoupClient.Device(Engine.instance.isBot ? { handlerName: 'Chrome74' } : undefined)
-  leaving = false
-  left = false
   reconnecting = false
   recvTransport: MediaSoupTransport
   sendTransport: MediaSoupTransport

--- a/packages/editor/src/components/realtime/useEditorNetworkInstanceProvisioning.tsx
+++ b/packages/editor/src/components/realtime/useEditorNetworkInstanceProvisioning.tsx
@@ -1,5 +1,3 @@
-import { MathUtils } from 'three'
-
 import {
   LocationInstanceConnectionService,
   useLocationInstanceConnectionState
@@ -7,7 +5,7 @@ import {
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { useEngineState } from '@xrengine/engine/src/ecs/classes/EngineState'
 import { MessageTypes } from '@xrengine/engine/src/networking/enums/MessageTypes'
-import { receiveSpectateWorld } from '@xrengine/engine/src/networking/functions/receiveJoinWorld'
+import { receiveJoinWorld } from '@xrengine/engine/src/networking/functions/receiveJoinWorld'
 import { useHookEffect } from '@xrengine/hyperflux'
 
 export const useEditorNetworkInstanceProvisioning = () => {
@@ -34,11 +32,13 @@ export const useEditorNetworkInstanceProvisioning = () => {
   ])
 
   useHookEffect(() => {
-    const transportRequestData = {}
+    const transportRequestData = {
+      spectateUserId: 'none'
+    }
     if (engineState.connectedWorld.value && engineState.sceneLoaded.value) {
       Engine.instance.currentWorld.worldNetwork
-        .request(MessageTypes.SpectateWorld.toString(), transportRequestData)
-        .then(receiveSpectateWorld)
+        .request(MessageTypes.JoinWorld.toString(), transportRequestData)
+        .then(receiveJoinWorld)
     }
   }, [engineState.connectedWorld, engineState.sceneLoaded])
 }

--- a/packages/engine/src/networking/enums/MessageTypes.ts
+++ b/packages/engine/src/networking/enums/MessageTypes.ts
@@ -6,7 +6,6 @@ export enum MessageTypes {
   Initialization = 3,
   JoinWorld = 4,
   LeaveWorld = 5,
-  SpectateWorld = 6,
   WebRTCTransportCreate = 7,
   WebRTCTransportConnect = 8,
   WebRTCTransportClose = 9,

--- a/packages/engine/src/scene/systems/HyperspacePortalSystem.ts
+++ b/packages/engine/src/scene/systems/HyperspacePortalSystem.ts
@@ -44,7 +44,7 @@ export default async function HyperspacePortalSystem(world: World) {
     // to trigger the hyperspace effect, add the hyperspace tag to the world entity
     for (const entity of hyperspaceTagComponent.enter()) {
       if (!EngineRenderer.instance.xrSession)
-        switchCameraMode(world.localClientEntity, { cameraMode: CameraMode.ShoulderCam }, true)
+        switchCameraMode(Engine.instance.currentWorld.cameraEntity, { cameraMode: CameraMode.ShoulderCam }, true)
 
       removeComponent(world.localClientEntity, AvatarControllerComponent)
       removeComponent(world.localClientEntity, InteractorComponent)

--- a/packages/instanceserver/src/NetworkFunctions.ts
+++ b/packages/instanceserver/src/NetworkFunctions.ts
@@ -1,6 +1,7 @@
 import AWS from 'aws-sdk'
 import { DataConsumer, DataProducer } from 'mediasoup/node/lib/types'
 import { Socket } from 'socket.io'
+import type { Quaternion } from 'three'
 
 import { UserInterface } from '@xrengine/common/src/dbmodels/UserInterface'
 import { Instance } from '@xrengine/common/src/interfaces/Instance'
@@ -12,7 +13,7 @@ import { performance } from '@xrengine/engine/src/common/functions/performance'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { getComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
 import { MessageTypes } from '@xrengine/engine/src/networking/enums/MessageTypes'
-import { JoinWorldProps } from '@xrengine/engine/src/networking/functions/receiveJoinWorld'
+import { JoinWorldProps, JoinWorldRequestData } from '@xrengine/engine/src/networking/functions/receiveJoinWorld'
 import { WorldNetworkAction } from '@xrengine/engine/src/networking/functions/WorldNetworkAction'
 import { AvatarProps } from '@xrengine/engine/src/networking/interfaces/WorldState'
 import { Object3DComponent } from '@xrengine/engine/src/scene/components/Object3DComponent'
@@ -227,16 +228,16 @@ export function getUserIdFromSocketId(network: SocketWebRTCServerNetwork, socket
 export async function handleConnectToWorld(
   network: SocketWebRTCServerNetwork,
   socket: Socket,
-  data,
-  callback,
+  data: any,
+  callback: Function,
   userId: UserId,
-  user: UserInterface
+  user: User
 ) {
   logger.info('Connect to world from ' + userId)
 
-  if (disconnectClientIfConnected(network, socket, userId)) return callback()
+  const avatarDetail = (await network.app.service('avatar').get(user.avatarId!)) as AvatarProps
 
-  const avatarDetail = (await network.app.service('avatar').get(user.avatarId)) as AvatarProps
+  if (disconnectClientIfConnected(network, socket, userId)) return callback()
 
   // Create a new client object
   // and add to the dictionary
@@ -265,7 +266,6 @@ export async function handleConnectToWorld(
   network.userIdToUserIndex.set(userId, userIndex)
   network.userIndexToUserId.set(userIndex, userId)
 
-  // Return initial world state to client to set things up
   callback({
     routerRtpCapabilities: network.routers.instance[0].rtpCapabilities
   })
@@ -319,86 +319,8 @@ const getCachedActions = (network: SocketWebRTCServerNetwork, joinedUserId: User
   return cachedActions
 }
 
-/**
- * For a user viewing an instance from the editor, or a non-participant viewer
- * @param network
- * @param socket
- * @param data
- * @param callback
- * @param joinedUserId
- * @param user
- */
-
-export const handleSpectateWorld = async (
-  network: SocketWebRTCServerNetwork,
-  socket: Socket,
-  data,
-  callback: Function,
-  joinedUserId: UserId,
-  user: User
-) => {
-  logger.info('Spectate World Request Received: %o', { joinedUserId, data, user })
-
+const getUserSpawnFromInvite = async (network: SocketWebRTCServerNetwork, user: User, inviteCode: string) => {
   const world = Engine.instance.currentWorld
-
-  // disallow join world request if already spawned
-  if (world.getUserAvatarEntity(joinedUserId) !== undefined) return callback(null!)
-
-  const cachedActions = getCachedActions(network, joinedUserId)
-  const client = network.peers.get(joinedUserId)!
-  client.spectating = true
-  let spectateUser = data['spectateUser']
-
-  if (spectateUser) {
-    const handleInvalidUser = () => {
-      spectateUser = ''
-      logger.warn('The user to spectate in no longer on this instance.')
-    }
-
-    const result = (await network.app.service('user').find({
-      query: {
-        id: spectateUser
-      },
-      isInternal: true
-    })) as any
-
-    let users = result.data as User[]
-    if (users.length > 0) {
-      const inviterUser = users[0]
-      if (inviterUser.instanceId !== user.instanceId) {
-        handleInvalidUser()
-      }
-    } else {
-      handleInvalidUser()
-    }
-  }
-
-  callback({
-    highResTimeOrigin: performance.timeOrigin,
-    worldStartTime: world.startTime,
-    client: { name: user.name, index: client.index },
-    cachedActions,
-    spectateUser
-  })
-}
-
-export const handleJoinWorld = async (
-  network: SocketWebRTCServerNetwork,
-  socket: Socket,
-  data,
-  callback: (args: JoinWorldProps) => void,
-  joinedUserId: UserId,
-  user: User
-) => {
-  logger.info('Join World Request Received: %o', { joinedUserId, data, user })
-
-  const world = Engine.instance.currentWorld
-
-  // disallow join world request if already spawned
-  if (world.getUserAvatarEntity(joinedUserId) !== undefined) return callback(null!)
-
-  let spawnPose = SpawnPoints.instance.getRandomSpawnPoint()
-  const inviteCode = data['inviteCode']
 
   if (inviteCode) {
     const result = (await network.app.service('user').find({
@@ -423,9 +345,9 @@ export const handleJoinWorld = async (
         const validSpawnablePosition = checkPositionIsValid(inviterUserObject3d.value.position, false)
 
         if (validSpawnablePosition) {
-          spawnPose = {
+          return {
             position: inviterUserObject3d.value.position,
-            rotation: inviterUserTransform.rotation
+            rotation: inviterUserTransform.rotation as Quaternion
           }
         }
       } else {
@@ -434,23 +356,45 @@ export const handleJoinWorld = async (
     }
   }
 
-  logger.info('User successfully joined world: %o', { joinedUserId, data, spawnPose })
-  const client = network.peers.get(joinedUserId)!
+  return SpawnPoints.instance.getRandomSpawnPoint()
+}
 
-  if (!client) return callback(null! as any)
+export async function handleJoinWorld(
+  network: SocketWebRTCServerNetwork,
+  socket: Socket,
+  data: JoinWorldRequestData,
+  callback: (args: JoinWorldProps) => void,
+  userId: UserId,
+  user: User
+) {
+  logger.info('Join World Request Received: %o', { userId, data, user })
+
+  const world = Engine.instance.currentWorld
+
+  let spawnPose
+  let spectateUserId
+
+  if (!network.app.isChannelInstance && data.spectateUserId !== 'string') {
+    spawnPose = await getUserSpawnFromInvite(network, user, data.inviteCode!)
+  }
+
+  const client = network.peers.get(userId)!
 
   clearCachedActionsForDisconnectedUsers(network)
-  clearCachedActionsForUser(network, joinedUserId)
+  clearCachedActionsForUser(network, userId)
 
-  const cachedActions = getCachedActions(network, joinedUserId)
+  const cachedActions = getCachedActions(network, userId)
+
+  logger.info('User successfully joined world: %o', { userId, data, spawnPose, spectateUserId, cachedActions })
 
   callback({
     highResTimeOrigin: performance.timeOrigin,
     worldStartTime: world.startTime,
     client: { name: user.name, index: client.index },
     cachedActions,
-    avatarDetail: world.users.get(joinedUserId)!.avatarDetail!,
-    avatarSpawnPose: spawnPose
+    avatarDetail: world.users.get(userId)!.avatarDetail!,
+    avatarSpawnPose: spawnPose,
+    spectateUserId
   })
 }
 

--- a/packages/instanceserver/src/SocketFunctions.ts
+++ b/packages/instanceserver/src/SocketFunctions.ts
@@ -12,8 +12,7 @@ import {
   handleHeartbeat,
   handleIncomingActions,
   handleJoinWorld,
-  handleLeaveWorld,
-  handleSpectateWorld
+  handleLeaveWorld
 } from './NetworkFunctions'
 import { SocketWebRTCServerNetwork } from './SocketWebRTCServerNetwork'
 import {
@@ -96,10 +95,6 @@ export const setupSocketFunctions = (network: SocketWebRTCServerNetwork, socket:
 
     socket.on(MessageTypes.JoinWorld.toString(), async (data, callback) =>
       handleJoinWorld(network, socket, data, callback, userId, user)
-    )
-
-    socket.on(MessageTypes.SpectateWorld.toString(), async (data, callback) =>
-      handleSpectateWorld(network, socket, data, callback, userId, user)
     )
 
     socket.on(MessageTypes.ActionData.toString(), (data) => handleIncomingActions(network, socket, data))


### PR DESCRIPTION
## Summary

- [x] fixes duplicate avatar bug
- [x] combines join world and spectate world into single handler pipeline
- [x] leaveNetwork is synchronous for simplicity
- [x] removes unused .left and .leaving `SocketWebRTCClientNetwork` properties for a future better implemetation


## References

closes https://github.com/XRFoundation/XREngine/issues/6518

## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

