### PR TITLE
Refactor auth-related duplicate code.

### DIFF
--- a/packages/client-core/src/admin/components/Setting/Authentication.tsx
+++ b/packages/client-core/src/admin/components/Setting/Authentication.tsx
@@ -5,24 +5,12 @@ import { useTranslation } from 'react-i18next'
 import { Box, Button, Grid, Typography } from '@mui/material'
 import IconButton from '@mui/material/IconButton'
 
+import { initialAuthState } from '../../../common/initialAuthState'
 import { useAuthState } from '../../../user/services/AuthService'
 import InputSwitch from '../../common/InputSwitch'
 import InputText from '../../common/InputText'
 import { AuthSettingsService, useAuthSettingState } from '../../services/Setting/AuthSettingService'
 import styles from '../../styles/settings.module.scss'
-
-const initialState = {
-  jwt: true,
-  local: false,
-  discord: false,
-  facebook: false,
-  github: false,
-  google: false,
-  linkedin: false,
-  twitter: false,
-  smsMagicLink: false,
-  emailMagicLink: false
-}
 
 const OAUTH_TYPES = {
   DISCORD: 'discord',
@@ -38,8 +26,8 @@ const Account = () => {
   const authSettingState = useAuthSettingState()
   const [authSetting] = authSettingState?.authSettings?.value || []
   const id = authSetting?.id
-  const [state, setState] = useState(initialState)
-  const [holdAuth, setHoldAuth] = useState(initialState)
+  const [state, setState] = useState(initialAuthState)
+  const [holdAuth, setHoldAuth] = useState(initialAuthState)
   const [keySecret, setKeySecret] = useState({
     discord: authSetting?.oauth.discord,
     github: authSetting?.oauth.github,
@@ -100,7 +88,7 @@ const Account = () => {
 
   useEffect(() => {
     if (authSetting) {
-      let temp = { ...initialState }
+      let temp = { ...initialAuthState }
       authSetting?.authStrategies?.forEach((el) => {
         Object.entries(el).forEach(([strategyName, strategy]) => {
           temp[strategyName] = strategy
@@ -139,7 +127,7 @@ const Account = () => {
   }
 
   const handleCancel = () => {
-    let temp = { ...initialState }
+    let temp = { ...initialAuthState }
     authSetting?.authStrategies?.forEach((el) => {
       Object.entries(el).forEach(([strategyName, strategy]) => {
         temp[strategyName] = strategy

--- a/packages/client-core/src/common/initialAuthState.ts
+++ b/packages/client-core/src/common/initialAuthState.ts
@@ -1,0 +1,21 @@
+export const initialAuthState = {
+  jwt: true,
+  local: false,
+  discord: false,
+  facebook: false,
+  github: false,
+  google: false,
+  linkedin: false,
+  twitter: false,
+  smsMagicLink: false,
+  emailMagicLink: false
+}
+
+export const initialOAuthConnectedState = {
+  discord: false,
+  facebook: false,
+  github: false,
+  google: false,
+  linkedin: false,
+  twitter: false
+}

--- a/packages/client-core/src/systems/ui/ProfileDetailView/index.tsx
+++ b/packages/client-core/src/systems/ui/ProfileDetailView/index.tsx
@@ -73,7 +73,8 @@ const ProfileDetailView = () => {
     const settings = { ...userSettings, themeMode: event.target.checked ? 'dark' : 'light' }
     userSettings && AuthService.updateUserSettings(userSettings.id as string, settings)
   }
-
+  // If you're editing lines 75-191, be sure to make the same changes to the non-XRUI version over at
+  // packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx#114-230
   let type = ''
   const addMoreSocial =
     (authState?.discord && !oauthConnectedState.discord) ||

--- a/packages/client-core/src/systems/ui/ProfileDetailView/index.tsx
+++ b/packages/client-core/src/systems/ui/ProfileDetailView/index.tsx
@@ -21,32 +21,11 @@ import { FacebookIcon } from '../../../common/components/Icons/FacebookIcon'
 import { GoogleIcon } from '../../../common/components/Icons/GoogleIcon'
 import { LinkedInIcon } from '../../../common/components/Icons/LinkedInIcon'
 import { TwitterIcon } from '../../../common/components/Icons/TwitterIcon'
+import { initialAuthState, initialOAuthConnectedState } from '../../../common/initialAuthState'
 import { NotificationService } from '../../../common/services/NotificationService'
 import { getAvatarURLForUser } from '../../../user/components/UserMenu/util'
 import { AuthService, useAuthState } from '../../../user/services/AuthService'
 import styleString from './index.scss'
-
-const initialAuthState = {
-  jwt: true,
-  local: false,
-  discord: false,
-  facebook: false,
-  github: false,
-  google: false,
-  linkedin: false,
-  twitter: false,
-  smsMagicLink: false,
-  emailMagicLink: false
-}
-
-const initialOAuthConnectedState = {
-  discord: false,
-  facebook: false,
-  github: false,
-  google: false,
-  linkedin: false,
-  twitter: false
-}
 
 export function createProfileDetailView() {
   return createXRUI(ProfileDetailView, createProfileDetailState())

--- a/packages/client-core/src/user/components/Auth/Login.tsx
+++ b/packages/client-core/src/user/components/Auth/Login.tsx
@@ -7,24 +7,11 @@ import SocialIcon from '@mui/icons-material/Public'
 import Tab from '@mui/material/Tab'
 import Tabs from '@mui/material/Tabs'
 
-import { AuthSettingsService } from '../../../admin/services/Setting/AuthSettingService'
 import { useAuthSettingState } from '../../../admin/services/Setting/AuthSettingService'
+import { initialAuthState } from '../../../common/initialAuthState'
 import MagicLinkEmail from './MagicLinkEmail'
 import PasswordLogin from './PasswordLogin'
 import SocialLogin from './SocialLogin'
-
-const initialState = {
-  jwt: true,
-  local: false,
-  discord: false,
-  facebook: false,
-  github: false,
-  google: false,
-  linkedin: false,
-  twitter: false,
-  smsMagicLink: false,
-  emailMagicLink: false
-}
 
 interface Props {
   children: JSX.Element
@@ -39,11 +26,11 @@ const TabPanel = ({ children, value, index }: Props): JSX.Element => {
 const SignIn = (): JSX.Element => {
   const authSettingState = useAuthSettingState()
   const [authSetting] = authSettingState?.authSettings?.value || []
-  const [state, setState] = useState(initialState)
+  const [state, setState] = useState(initialAuthState)
 
   useEffect(() => {
     if (authSetting) {
-      let temp = { ...initialState }
+      let temp = { ...initialAuthState }
       authSetting?.authStrategies?.forEach((el) => {
         Object.entries(el).forEach(([strategyName, strategy]) => {
           temp[strategyName] = strategy

--- a/packages/client-core/src/user/components/Auth/MagicLinkEmail.tsx
+++ b/packages/client-core/src/user/components/Auth/MagicLinkEmail.tsx
@@ -10,23 +10,11 @@ import Grid from '@mui/material/Grid'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 
-import { AuthSettingsService } from '../../../admin/services/Setting/AuthSettingService'
 import { useAuthSettingState } from '../../../admin/services/Setting/AuthSettingService'
+import { initialAuthState } from '../../../common/initialAuthState'
 import { AuthService } from '../../services/AuthService'
 import { useAuthState } from '../../services/AuthService'
 import styles from './index.module.scss'
-
-const initialState = {
-  jwt: true,
-  local: false,
-  facebook: false,
-  github: false,
-  google: false,
-  linkedin: false,
-  twitter: false,
-  smsMagicLink: false,
-  emailMagicLink: false
-}
 
 interface Props {
   type?: 'email' | 'sms' | undefined
@@ -49,11 +37,11 @@ const MagicLinkEmail = ({ type, isAddConnection }: Props): JSX.Element => {
   const { t } = useTranslation()
   const authSettingState = useAuthSettingState()
   const [authSetting] = authSettingState?.authSettings?.value || []
-  const [authState, setAuthState] = useState(initialState)
+  const [authState, setAuthState] = useState(initialAuthState)
 
   useEffect(() => {
     if (authSetting) {
-      let temp = { ...initialState }
+      let temp = { ...initialAuthState }
       authSetting?.authStrategies?.forEach((el) => {
         Object.entries(el).forEach(([strategyName, strategy]) => {
           temp[strategyName] = strategy

--- a/packages/client-core/src/user/components/Login/index.tsx
+++ b/packages/client-core/src/user/components/Login/index.tsx
@@ -11,24 +11,13 @@ import Fab from '@mui/material/Fab'
 import Typography from '@mui/material/Typography'
 
 import { AuthSettingsService, useAuthSettingState } from '../../../admin/services/Setting/AuthSettingService'
+import { initialAuthState } from '../../../common/initialAuthState'
 import ForgotPassword from '../../../user/components/Auth/ForgotPassword'
 import PasswordLoginApp from '../../../user/components/Auth/PasswordLoginApp'
 import RegisterApp from '../../../user/components/Auth/RegisterApp'
 import ResetPassword from '../../../user/components/Auth/ResetPassword'
 import { AuthService } from '../../services/AuthService'
 import styles from './index.module.scss'
-
-const initialState = {
-  jwt: true,
-  local: false,
-  facebook: false,
-  github: false,
-  google: false,
-  linkedin: false,
-  twitter: false,
-  smsMagicLink: false,
-  emailMagicLink: false
-}
 
 interface Props {
   //auth?: any
@@ -38,6 +27,7 @@ interface Props {
   logo: string
   isAddConnection?: boolean
 }
+
 const FlatSignIn = (props: Props) => {
   const [view, setView] = useState('login')
 
@@ -46,7 +36,7 @@ const FlatSignIn = (props: Props) => {
 
   const authSettingState = useAuthSettingState()
   const [authSetting] = authSettingState?.authSettings?.value || []
-  const [authState, setAuthState] = useState(initialState)
+  const [authState, setAuthState] = useState(initialAuthState)
 
   const enableUserPassword = authState?.local
   const enableGoogleSocial = authState?.google
@@ -60,7 +50,7 @@ const FlatSignIn = (props: Props) => {
 
   useEffect(() => {
     if (authSetting) {
-      let temp = { ...initialState }
+      let temp = { ...initialAuthState }
       authSetting?.authStrategies?.forEach((el) => {
         Object.entries(el).forEach(([strategyName, strategy]) => {
           temp[strategyName] = strategy

--- a/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
@@ -30,6 +30,7 @@ import { FacebookIcon } from '../../../../common/components/Icons/FacebookIcon'
 import { GoogleIcon } from '../../../../common/components/Icons/GoogleIcon'
 import { LinkedInIcon } from '../../../../common/components/Icons/LinkedInIcon'
 import { TwitterIcon } from '../../../../common/components/Icons/TwitterIcon'
+import { initialAuthState, initialOAuthConnectedState } from '../../../../common/initialAuthState'
 import { NotificationService } from '../../../../common/services/NotificationService'
 import { AuthService, useAuthState } from '../../../services/AuthService'
 import { userHasAccess } from '../../../userHasAccess'
@@ -42,28 +43,6 @@ interface Props {
   isPopover?: boolean
   changeActiveMenu?: (type: string | null) => void
   onClose?: () => void
-}
-
-const initialAuthState = {
-  jwt: true,
-  local: false,
-  discord: false,
-  facebook: false,
-  github: false,
-  google: false,
-  linkedin: false,
-  twitter: false,
-  smsMagicLink: false,
-  emailMagicLink: false
-}
-
-const initialOAuthConnectedState = {
-  discord: false,
-  facebook: false,
-  github: false,
-  google: false,
-  linkedin: false,
-  twitter: false
 }
 
 const ProfileMenu = ({ className, hideLogin, isPopover, changeActiveMenu, onClose }: Props): JSX.Element => {

--- a/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
@@ -115,7 +115,8 @@ const ProfileMenu = ({ className, hideLogin, isPopover, changeActiveMenu, onClos
     const settings = { ...userSettings, themeModes: { ...themeModes, [name]: value } }
     userSettings && AuthService.updateUserSettings(userSettings.id as string, settings)
   }
-
+  // If you're editing lines 114-230, be sure to make the same changes to the XRUI version over at
+  // packages/client-core/src/systems/ui/ProfileDetailView/index.tsx#75-191
   let type = ''
   const addMoreSocial =
     (authState?.discord && !oauthConnectedState.discord) ||

--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -9,6 +9,7 @@ import { useEffect } from 'react'
 import { v1 } from 'uuid'
 
 import { validateEmail, validatePhoneNumber } from '@xrengine/common/src/config'
+import { AuthStrategies } from '@xrengine/common/src/interfaces/AuthStrategies'
 import { AuthUser, AuthUserSeed, resolveAuthUser } from '@xrengine/common/src/interfaces/AuthUser'
 import { AvatarProps } from '@xrengine/common/src/interfaces/AvatarInterface'
 import { IdentityProvider, IdentityProviderSeed } from '@xrengine/common/src/interfaces/IdentityProvider'
@@ -37,18 +38,6 @@ import { uploadToFeathersService } from '../../util/upload'
 import { userPatched } from '../functions/userPatched'
 
 const TIMEOUT_INTERVAL = 50 //ms per interval of waiting for authToken to be updated
-
-type AuthStrategies = {
-  jwt: Boolean
-  local: Boolean
-  facebook: Boolean
-  github: Boolean
-  google: Boolean
-  linkedin: Boolean
-  twitter: Boolean
-  smsMagicLink: Boolean
-  emailMagicLink: Boolean
-}
 
 //State
 const AuthState = defineState({

--- a/packages/common/src/interfaces/AdminAuthSetting.ts
+++ b/packages/common/src/interfaces/AdminAuthSetting.ts
@@ -1,3 +1,5 @@
+import { AuthStrategies } from './AuthStrategies'
+
 export interface AdminAuthSetting {
   id: string
   service: string
@@ -11,16 +13,6 @@ export interface AdminAuthSetting {
   oauth: Oauth
   createdAt: string
   updatedAt: string
-}
-
-interface AuthStrategies {
-  jwt?: boolean
-  local?: boolean
-  facebook?: boolean
-  github?: boolean
-  google?: boolean
-  linkedin?: boolean
-  twitter?: boolean
 }
 
 interface Local {

--- a/packages/common/src/interfaces/AuthStrategies.ts
+++ b/packages/common/src/interfaces/AuthStrategies.ts
@@ -1,0 +1,11 @@
+export interface AuthStrategies {
+  jwt?: boolean
+  local?: boolean
+  facebook?: boolean
+  github?: boolean
+  google?: boolean
+  linkedin?: boolean
+  twitter?: boolean
+  emailMagicLink: boolean
+  smsMagicLink: boolean
+}


### PR DESCRIPTION
## Summary

Refactoring of auth-related duplicated code:

* Moves `initialAuthState` and `initialOAuthConnectedState` constants to their own file (they were being re-declared)
* Move the duplicate `AuthStrategies` type declaration to instead re-use the `AuthStrategies` interface export.
* Add duplicate code heads-up to `packages/client-core/src/systems/ui/ProfileDetailView/index.tsx#75-191` and `packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx#114-230`

## References

Yak shaving dependency to PR https://github.com/XRFoundation/XREngine/pull/6412



