### PR TITLE
Fixed issue with client creating engine twice.

### DIFF
--- a/packages/client-core/src/systems/WidgetUISystem.ts
+++ b/packages/client-core/src/systems/WidgetUISystem.ts
@@ -51,7 +51,11 @@ export default async function WidgetSystem(world: World) {
       createSettingsWidget(world)
       createSelectAvatarWidget(world)
       createUploadAvatarWidget(world)
-      createReadyPlayerWidget(world)
+      // TODO: Something in createReadyPlayerWidget is loading /location/undefined
+      // This is causing the engine to be created again, or at least to start being
+      // created again, which is not right. This will need to be fixed when this is
+      // restored.
+      // createReadyPlayerWidget(world)
     }
     const xrui = getComponent(ui.entity, XRUIComponent)
     if (xrui) ObjectFitFunctions.setUIVisible(xrui.container, show)


### PR DESCRIPTION
## Summary

Something in createReadyPlayerWidget is loading /location/undefined, which is triggering
a second creation of the engine. Disabled call to createReadyPlayerWidget for now. When
it is eventually restored, it will need to be fixed.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

