### PR TITLE
Fetching avatars before scene is loaded to avoid timing issues.

### DIFF
--- a/packages/client-core/src/components/World/LoadEngineWithScene.tsx
+++ b/packages/client-core/src/components/World/LoadEngineWithScene.tsx
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router'
 import { LocationInstanceConnectionServiceReceptor } from '@xrengine/client-core/src/common/services/LocationInstanceConnectionService'
 import { LocationService } from '@xrengine/client-core/src/social/services/LocationService'
 import { leaveNetwork } from '@xrengine/client-core/src/transports/SocketWebRTCClientFunctions'
-import { useAuthState } from '@xrengine/client-core/src/user/services/AuthService'
+import { AuthService, useAuthState } from '@xrengine/client-core/src/user/services/AuthService'
 import {
   SceneActions,
   SceneServiceReceptor,
@@ -55,6 +55,7 @@ export const LoadEngineWithScene = () => {
   useHookEffect(() => {
     const sceneData = sceneState.currentScene.value
     if (clientReady && sceneData) {
+      AuthService.fetchAvatarList()
       dispatchAction(AppAction.setAppOnBoardingStep({ onBoardingStep: GeneralStateList.SCENE_LOADING }))
       loadScene(sceneData).then(() => {
         dispatchAction(AppAction.setAppOnBoardingStep({ onBoardingStep: GeneralStateList.SCENE_LOADED }))


### PR DESCRIPTION
## Summary

Avatars are currently only being fetched in a few modals, but they are needed to render
the scene. Added avatar fetch to LoadEngineWithScene to try to ensure they are available.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

