### PR TITLE
Add client logging API endpoint.

### DIFF
--- a/.env.local.default
+++ b/.env.local.default
@@ -22,6 +22,7 @@ APP_HOST=localhost:3000
 APP_PORT=3000
 
 # Vite variables - Exposed to client side
+VITE_FORCE_CLIENT_LOG_AGGREGATE=false
 VITE_GA_TRACKING_ID=
 VITE_SENTRY_DSN=
 VITE_APP_HOST=localhost

--- a/packages/client-core/src/admin/components/Project/GithubRepoDrawer.tsx
+++ b/packages/client-core/src/admin/components/Project/GithubRepoDrawer.tsx
@@ -44,7 +44,6 @@ const GithubRepoDrawer = ({ open, project, onClose }: Props) => {
       setProcessing(false)
       onClose()
     } catch (err) {
-      console.error(err)
       NotificationService.dispatchNotify(err.message, { variant: 'error' })
       setProcessing(false)
       throw err
@@ -59,7 +58,6 @@ const GithubRepoDrawer = ({ open, project, onClose }: Props) => {
       setProcessing(false)
       onClose()
     } catch (err) {
-      console.error(err)
       NotificationService.dispatchNotify(err.message, { variant: 'error' })
       setProcessing(false)
       throw err

--- a/packages/client-core/src/admin/components/Project/ProjectTable.tsx
+++ b/packages/client-core/src/admin/components/Project/ProjectTable.tsx
@@ -80,7 +80,7 @@ const ProjectTable = ({ className }: Props) => {
           await ProjectService.removeProject(projectToRemove.id)
           handleCloseConfirmation()
         } else {
-          throw Error('Failed to find the project')
+          throw new Error('Failed to find the project')
         }
       }
     } catch (err) {

--- a/packages/client-core/src/admin/services/Setting/ClientSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/ClientSettingService.ts
@@ -1,12 +1,15 @@
 import { Paginated } from '@feathersjs/feathers'
 
 import { ClientSetting, PatchClientSetting } from '@xrengine/common/src/interfaces/ClientSetting'
+import multiLogger from '@xrengine/common/src/logger'
 import { matches, Validator } from '@xrengine/engine/src/common/functions/MatchesUtils'
 import { defineAction, defineState, dispatchAction, getState, useState } from '@xrengine/hyperflux'
 
 import { API } from '../../../API'
 import { NotificationService } from '../../../common/services/NotificationService'
 import waitForClientAuthenticated from '../../../util/wait-for-client-authenticated'
+
+const logger = multiLogger.child({ component: 'client-core:ClientSettingService' })
 
 const AdminClientSettingsState = defineState({
   name: 'AdminClientSettingsState',
@@ -50,14 +53,14 @@ export const useClientSettingState = () => useState(accessClientSettingState())
 export const ClientSettingService = {
   fetchClientSettings: async (inDec?: 'increment' | 'decrement') => {
     try {
-      console.log('waitingForClientAuthenticated')
+      logger.info('waitingForClientAuthenticated')
       await waitForClientAuthenticated()
-      console.log('CLIENT AUTHENTICATED!')
+      logger.info('CLIENT AUTHENTICATED!')
       const clientSettings = (await API.instance.client.service('client-setting').find()) as Paginated<ClientSetting>
-      console.log('Dispatching fetchedClient')
+      logger.info('Dispatching fetchedClient')
       dispatchAction(ClientSettingActions.fetchedClient({ clientSettings }))
     } catch (err) {
-      console.log(err.message)
+      logger.error(err)
       NotificationService.dispatchNotify(err.message, { variant: 'error' })
     }
   },
@@ -66,7 +69,7 @@ export const ClientSettingService = {
       await API.instance.client.service('client-setting').patch(id, data)
       dispatchAction(ClientSettingActions.clientSettingPatched())
     } catch (err) {
-      console.log(err)
+      logger.error(err)
       NotificationService.dispatchNotify(err.message, { variant: 'error' })
     }
   }

--- a/packages/client-core/src/common/services/NotificationService.ts
+++ b/packages/client-core/src/common/services/NotificationService.ts
@@ -1,9 +1,12 @@
 import { VariantType } from 'notistack'
 
+import multiLogger from '@xrengine/common/src/logger'
 import { matches, Validator } from '@xrengine/engine/src/common/functions/MatchesUtils'
 import { defineAction, dispatchAction } from '@xrengine/hyperflux'
 
 import { defaultAction } from '../components/NotificationActions'
+
+const logger = multiLogger.child({ component: 'client-core:Notification' })
 
 export type NotificationOptions = {
   variant: VariantType
@@ -16,6 +19,9 @@ export const NotificationActions = {
 
 export const NotificationService = {
   dispatchNotify(message: string, options: NotificationOptions) {
+    if (options?.variant === 'error') {
+      logger.error(new Error(message))
+    }
     dispatchAction(NotificationAction.notify({ message, options }))
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,6 +16,9 @@
   "repository": "http://github.com/XRFoundation/XREngine",
   "author": "XREngine",
   "license": "MIT",
+  "dependencies": {
+    "cross-fetch": "^3.1.5"
+  },
   "devDependencies": {
     "@rollup/plugin-alias": "3.1.9",
     "@rollup/plugin-json": "4.1.0",

--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -1,3 +1,23 @@
+/**
+ * An isomorphic logger with a built-in transport, meant to make
+ * error aggregation easier on the client side.
+ *
+ * All log events (info, warn, error, etc) are:
+ *  1. Printed to the console (likely browser console), and (optionally)
+ *  2. Sent to the server-side /api/log endpoint, where the pino logger
+ *     instance (see packages/server-core/src/logger.ts) sends them to Elastic etc.
+ *     Note: The sending/aggregation to Elastic only happens when APP_ENV !== 'development'.
+ *
+ */
+import fetch from 'cross-fetch'
+
+const hostDefined = !!globalThis.process.env['VITE_SERVER_HOST']
+// TODO: Hate to dupe the two config vars below, would prefer to load them from @xrengine/client-core/src/utils/config
+export const localBuildOrDev = process.env.APP_ENV === 'development' || process.env['VITE_LOCAL_BUILD'] === 'true'
+export const serverHost = localBuildOrDev
+  ? `https://${globalThis.process.env['VITE_SERVER_HOST']}:${globalThis.process.env['VITE_SERVER_PORT']}`
+  : `https://${globalThis.process.env['VITE_SERVER_HOST']}`
+
 const baseComponent = 'client-core'
 /**
  * A logger class (similar to the one provided by Pino.js) to replace
@@ -20,17 +40,134 @@ const multiLogger = {
    * // will result in:
    * // [client-core:authentication] Logging in...
    *
-   * @param childConfig
+   * @param opts {object}
+   * @param opts.component {string}
    */
   child: (opts: any) => {
-    return {
-      debug: console.debug.bind(console, `[${opts.component}]`),
-      info: console.log.bind(console, `[${opts.component}]`),
-      warn: console.warn.bind(console, `[${opts.component}]`),
-      error: console.error.bind(console, `[${opts.component}]`),
-      fatal: console.error.bind(console, `[${opts.component}]`)
+    if (localBuildOrDev && !process.env.VITE_FORCE_CLIENT_LOG_AGGREGATE) {
+      // Locally, this will provide correct file & line numbers in browser console
+      return {
+        debug: console.debug.bind(console, `[${opts.component}]`),
+        info: console.log.bind(console, `[${opts.component}]`),
+        warn: console.warn.bind(console, `[${opts.component}]`),
+        error: console.error.bind(console, `[${opts.component}]`),
+        fatal: console.error.bind(console, `[${opts.component}]`)
+      }
+    } else {
+      // For non-local builds, this send() is used
+      const send = (level) => {
+        const url = new URL('/api/log', serverHost)
+
+        return (...args) => {
+          const consoleMethods = {
+            debug: console.debug.bind(console, `[${opts.component}]`),
+            info: console.log.bind(console, `[${opts.component}]`),
+            warn: console.warn.bind(console, `[${opts.component}]`),
+            error: console.error.bind(console, `[${opts.component}]`),
+            fatal: console.error.bind(console, `[${opts.component}]`)
+          }
+
+          // @ts-ignore
+          const logParams = encodeLogParams(...args)
+
+          // In addition to sending to logging endpoint,  output to console
+          consoleMethods[level]({ component: opts.component, level, ...logParams })
+
+          // Send to backend /api/log endpoint for aggregation
+          if (hostDefined) {
+            fetch(url, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                level,
+                component: opts.component,
+                ...logParams
+              })
+            })
+          }
+        }
+      }
+
+      return {
+        debug: send('debug'),
+        info: send('info'),
+        warn: send('warn'),
+        error: send('error'),
+        fatal: send('fatal')
+      }
     }
   }
+}
+
+/**
+ * Support a limited subset of Pino's log parameters
+ * @see https://getpino.io/#/docs/api?id=logging-method-parameters
+ *
+ * Limitations:
+ * - Pino supports multiple interpolation values, but we're only going to use one in our code.
+ * - Only supports %o interpolation (for %s or %d, just use native `${}`).
+ *
+ * Usage:
+ * encodeLogParams(new TypeError('Error message'))
+ * -> { msg: 'TypeError: Error message', stack }
+ *
+ * encodeLogParams('Message') -> { msg: 'Message' }
+ *
+ * encodeLogParams({ merge: 'object' }) -> { merge: 'object' }
+ *
+ * encodeLogParams({ merge: 'object' }, 'Message') -> { merge: 'object', msg: 'Message' }
+ *
+ * encodeLogParms('Message %o', { interpolation: 'value' })
+ * -> { msg: 'Message {"interpolation": "value"}' }
+ *
+ * encodeLogParms({ merge: 'object' }, 'Message %o', { interpolation: 'value' })
+ * -> { merge: 'object', msg: 'Message {"interpolation": "value"}' }
+ *
+ */
+function encodeLogParams(first, second, third) {
+  if (Array.isArray(first)) {
+    first = first[0]
+  }
+  let mergeObject: any = {}
+  let message: string
+
+  if (first instanceof Error) {
+    message = stringifyError(first)
+  } else if (typeof first === 'string') {
+    message = interpolate(first, second)
+  } else {
+    mergeObject = first
+    message = interpolate(second, third)
+  }
+
+  return { ...mergeObject, msg: message }
+}
+
+/**
+ * Note: Only supports %o interpolation (for %s or %d, just use native `${}`).
+ * @param message {string}
+ * @param interpolationObject {object}
+ */
+function interpolate(message, interpolationObject): string {
+  if (!interpolationObject || !message?.includes('%o')) {
+    return message
+  }
+
+  return message?.replace('%o', JSON.stringify(interpolationObject))
+}
+
+function stringifyError(error) {
+  let cause, stack
+
+  const trace = { stack: '' }
+  Error.captureStackTrace?.(trace) // In Firefox captureStackTrace is undefined
+  stack = trace.stack
+
+  if (error.cause) {
+    cause = stringifyError(error)
+  }
+
+  return JSON.stringify({ error: error.name, message: error.message, stack, cause })
 }
 
 export default multiLogger

--- a/packages/editor/src/classes/History.ts
+++ b/packages/editor/src/classes/History.ts
@@ -2,6 +2,7 @@
  * @author dforrer / https://github.com/dforrer
  * Developed as part of a project at University of Applied Sciences and Arts Northwestern Switzerland (www.fhnw.ch)
  */
+import multiLogger from '@xrengine/common/src/logger'
 import { Entity } from '@xrengine/engine/src/ecs/classes/Entity'
 import { MappedComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
 import { getEntityNodeArrayFromEntities } from '@xrengine/engine/src/ecs/functions/EntityTreeFunctions'
@@ -14,6 +15,8 @@ import EditorCommands, {
   CommandParamsType
 } from '../constants/EditorCommands'
 import { accessSelectionState } from '../services/SelectionServices'
+
+const logger = multiLogger.child({ component: 'editor:History' })
 
 const ALLOWED_TIME_FOR_MERGER = 1000
 
@@ -69,14 +72,18 @@ export function executeCommandWithHistory(command: CommandParamsType): void {
   ) {
     commandFunctions.update?.(lastCmd, command)
 
-    if (EditorHistory.debug) console.log(`update:`, commandFunctions.toString(lastCmd))
+    if (EditorHistory.debug) {
+      logger.info(`update: ${commandFunctions.toString(lastCmd)}`)
+    }
   } else {
     // the command is not updatable and is added as a new part of the history
     EditorHistory.undos.push(command)
     command.id = ++EditorHistory.idCounter
     commandFunctions.execute(command)
 
-    if (EditorHistory.debug) console.log(`execute:`, commandFunctions.toString(command))
+    if (EditorHistory.debug) {
+      logger.info(`execute: ${commandFunctions.toString(command)}`)
+    }
   }
 
   EditorHistory.lastCmdTime = new Date()
@@ -165,7 +172,7 @@ export function revertHistory(checkpointId: Entity): void {
   if (typeof lastCmd.id === 'undefined') return
 
   if (lastCmd && checkpointId > lastCmd.id) {
-    console.warn('Tried to revert back to an undo action with an id greater than the last action')
+    logger.warn('Tried to revert back to an undo action with an id greater than the last action')
     return
   }
 
@@ -177,7 +184,9 @@ export function revertHistory(checkpointId: Entity): void {
     commandFunctions.undo(cmd)
     EditorHistory.redos.push(cmd)
 
-    if (EditorHistory.debug) console.log(`revert: ${commandFunctions.toString(cmd)}`)
+    if (EditorHistory.debug) {
+      logger.info(`revert: ${commandFunctions.toString(cmd)}`)
+    }
     cmd = EditorHistory.undos.pop()!
   }
 }
@@ -193,7 +202,9 @@ export function undoCommand(): CommandParamsType | undefined {
   CommandFuncs[cmd.type].undo(cmd)
   EditorHistory.redos.push(cmd)
 
-  if (EditorHistory.debug) console.log(`undo: ${CommandFuncs[cmd.type].toString(cmd)}`)
+  if (EditorHistory.debug) {
+    logger.info(`undo: ${CommandFuncs[cmd.type].toString(cmd)}`)
+  }
 
   return cmd
 }
@@ -209,7 +220,9 @@ export function redoCommand(): CommandParamsType | undefined {
   CommandFuncs[cmd.type].undo(cmd)
   EditorHistory.undos.push(cmd)
 
-  if (EditorHistory.debug) console.log(`redo: ${CommandFuncs[cmd.type].toString(cmd)}`)
+  if (EditorHistory.debug) {
+    logger.info(`redo: ${CommandFuncs[cmd.type].toString(cmd)}`)
+  }
 
   return cmd
 }

--- a/packages/editor/src/commands/ScaleCommand.ts
+++ b/packages/editor/src/commands/ScaleCommand.ts
@@ -1,5 +1,6 @@
 import { Matrix4, Vector3 } from 'three'
 
+import multiLogger from '@xrengine/common/src/logger'
 import { getComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
 import { Object3DComponent } from '@xrengine/engine/src/scene/components/Object3DComponent'
 import { TransformSpace } from '@xrengine/engine/src/scene/constants/transformConstants'
@@ -12,6 +13,8 @@ import { serializeObject3DArray, serializeVector3 } from '../functions/debug'
 import { getSpaceMatrix } from '../functions/getSpaceMatrix'
 import { EditorAction } from '../services/EditorServices'
 import { SelectionAction } from '../services/SelectionServices'
+
+const logger = multiLogger.child({ component: 'editor:ScaleCommand' })
 
 export type ScaleCommandUndoParams = {
   scales: Vector3[]
@@ -96,7 +99,7 @@ function updateScale(command: ScaleCommandParams, isUndo: boolean): void {
       const scale = scales[i] ?? scales[0]
 
       if (space === TransformSpace.World && (scale.x !== scale.y || scale.x !== scale.z || scale.y !== scale.z)) {
-        console.warn('Scaling an object in world space with a non-uniform scale is not supported')
+        logger.warn('Scaling an object in world space with a non-uniform scale is not supported')
       }
 
       getComponent(node.entity, TransformComponent).scale.multiply(scale)

--- a/packages/editor/src/components/EditorContainer.tsx
+++ b/packages/editor/src/components/EditorContainer.tsx
@@ -8,6 +8,7 @@ import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { SceneJson } from '@xrengine/common/src/interfaces/SceneInterface'
+import multiLogger from '@xrengine/common/src/logger'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { getEngineState, useEngineState } from '@xrengine/engine/src/ecs/classes/EngineState'
 import { gltfToSceneJson, sceneToGLTF } from '@xrengine/engine/src/scene/functions/GLTFConversion'
@@ -46,6 +47,8 @@ import { AppContext } from './Search/context'
 import Search from './Search/Search'
 import * as styles from './styles.module.scss'
 import ToolBar from './toolbar/ToolBar'
+
+const logger = multiLogger.child({ component: 'editor:EditorContainer' })
 
 /**
  *Styled component used as dock container.
@@ -135,7 +138,7 @@ const EditorContainer = () => {
       dispatchAction(EditorAction.sceneModified({ modified: true }))
       setDialogComponent(null)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       setDialogComponent(
         <ErrorDialog
           title={t('editor:loadingError')}
@@ -155,7 +158,7 @@ const EditorContainer = () => {
 
   useHookEffect(() => {
     if (sceneName.value && editorReady) {
-      console.log(`Loading scene ${sceneName.value} via given url`)
+      logger.info(`Loading scene ${sceneName.value} via given url`)
       loadScene(sceneName.value)
     }
   }, [editorReady, sceneName])
@@ -177,7 +180,7 @@ const EditorContainer = () => {
 
       setDialogComponent(null)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
 
       setDialogComponent(
         <ErrorDialog
@@ -201,7 +204,7 @@ const EditorContainer = () => {
       reRouteToLoadScene(sceneData.sceneName)
       setDialogComponent(null)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
 
       setDialogComponent(
         <ErrorDialog
@@ -218,13 +221,11 @@ const EditorContainer = () => {
    */
 
   const onEditorError = (error) => {
-    console.log(error)
+    logger.error(error)
     if (error['aborted']) {
       setDialogComponent(null)
       return
     }
-
-    console.error(error)
 
     setDialogComponent(
       <ErrorDialog
@@ -270,7 +271,7 @@ const EditorContainer = () => {
       }
       setDialogComponent(null)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       setDialogComponent(
         <ErrorDialog title={t('editor:savingError')} message={error.message || t('editor:savingErrorMsg')} />
       )
@@ -295,7 +296,7 @@ const EditorContainer = () => {
         const zipFiles = nuUrl.filter((url) => /\.zip$/.test(url))
         const extractPromises = [...zipFiles.map((zipped) => extractZip(zipped))]
         Promise.all(extractPromises).then(() => {
-          console.log('extraction complete')
+          logger.info('extraction complete')
         })
       }
     }
@@ -392,7 +393,7 @@ const EditorContainer = () => {
 
       setDialogComponent(null)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
 
       setDialogComponent(
         <ErrorDialog title={t('editor:savingError')} message={error.message || t('editor:savingErrorMsg')} />

--- a/packages/editor/src/components/projects/ProjectsPage.tsx
+++ b/packages/editor/src/components/projects/ProjectsPage.tsx
@@ -5,6 +5,7 @@ import { useHistory } from 'react-router-dom'
 import { ProjectService, useProjectState } from '@xrengine/client-core/src/common/services/ProjectService'
 import { useAuthState } from '@xrengine/client-core/src/user/services/AuthService'
 import { ProjectInterface } from '@xrengine/common/src/interfaces/ProjectInterface'
+import multiLogger from '@xrengine/common/src/logger'
 import { dispatchAction } from '@xrengine/hyperflux'
 
 import {
@@ -43,6 +44,8 @@ import { EditPermissionsDialog } from './EditPermissionsDialog'
 import { GithubRepoDialog } from './GithubRepoDialog'
 import { InstallProjectDialog } from './InstallProjectDialog'
 import styles from './styles.module.scss'
+
+const logger = multiLogger.child({ component: 'editor:ProjectsPage' })
 
 function sortAlphabetical(a, b) {
   if (a > b) return -1
@@ -163,7 +166,7 @@ const ProjectsPage = () => {
       setInstalledProjects(data.sort(sortAlphabetical) ?? [])
       if (activeProject) setActiveProject(data.find((item) => item.id === activeProject.id) as ProjectInterface | null)
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       setError(error)
     }
     setLoading(false)
@@ -178,7 +181,7 @@ const ProjectsPage = () => {
 
       setOfficialProjects((data.sort(sortAlphabetical) as ProjectInterface[]) ?? [])
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       setError(error)
     }
     setLoading(false)
@@ -193,7 +196,7 @@ const ProjectsPage = () => {
 
       setCommunityProjects(data.sort(sortAlphabetical) ?? [])
     } catch (error) {
-      console.error(error)
+      logger.error(error)
       setError(error)
     }
     setLoading(false)
@@ -210,7 +213,7 @@ const ProjectsPage = () => {
 
   // TODO: Implement tutorial
   const openTutorial = () => {
-    console.log('Implement Tutorial...')
+    logger.info('Implement Tutorial...')
   }
 
   const onClickExisting = (event, project) => {
@@ -264,7 +267,7 @@ const ProjectsPage = () => {
         await ProjectService.removeProject(proj.id)
         await fetchInstalledProjects()
       } catch (err) {
-        console.error(err)
+        logger.error(err)
       }
     }
 
@@ -286,7 +289,7 @@ const ProjectsPage = () => {
       setActiveProject(null)
       await fetchInstalledProjects()
     } catch (err) {
-      console.error(err)
+      logger.error(err)
       throw err
     }
   }
@@ -299,7 +302,7 @@ const ProjectsPage = () => {
       await ProjectService.uploadProject(url)
       await fetchInstalledProjects()
     } catch (err) {
-      console.error(err)
+      logger.error(err)
     }
 
     setUpdatingProject(false)
@@ -324,7 +327,7 @@ const ProjectsPage = () => {
       await ProjectService.pushProject(id)
       await fetchInstalledProjects()
     } catch (err) {
-      console.error(err)
+      logger.error(err)
     }
     setUploadingProject(false)
   }

--- a/packages/engine/src/ecs/classes/World.ts
+++ b/packages/engine/src/ecs/classes/World.ts
@@ -4,6 +4,7 @@ import { AudioListener, Object3D, OrthographicCamera, PerspectiveCamera, Raycast
 import { NetworkId } from '@xrengine/common/src/interfaces/NetworkId'
 import { ComponentJson } from '@xrengine/common/src/interfaces/SceneInterface'
 import { UserId } from '@xrengine/common/src/interfaces/UserId'
+import multiLogger from '@xrengine/common/src/logger'
 import { addTopic } from '@xrengine/hyperflux'
 import { Topic } from '@xrengine/hyperflux/functions/ActionFunctions'
 
@@ -48,6 +49,8 @@ import EntityTree from './EntityTree'
 const TimerConfig = {
   MAX_DELTA_SECONDS: 1 / 10
 }
+
+const logger = multiLogger.child({ component: 'engine:ecs:World' })
 
 export const CreateWorld = Symbol('CreateWorld')
 export class World {
@@ -217,7 +220,9 @@ export class World {
     const nameMap = this.#nameMap
     for (const entity of this.#nameQuery.enter()) {
       const { name } = getComponent(entity, NameComponent)
-      if (nameMap.has(name)) console.warn(`An Entity with name "${name}" already exists.`)
+      if (nameMap.has(name)) {
+        logger.warn(`An Entity with name "${name}" already exists.`)
+      }
       nameMap.set(name, entity)
       const obj3d = getComponent(entity, Object3DComponent)?.value
       if (obj3d) obj3d.name = name
@@ -322,7 +327,7 @@ export class World {
     const end = nowMilliseconds()
     const duration = end - start
     if (duration > 150) {
-      console.warn(`Long frame execution detected. Duration: ${duration}. \n Incoming actions: `, incomingActions)
+      logger.warn(`Long frame execution detected. Duration: ${duration}. \n Incoming actions: %o`, incomingActions)
     }
   }
 }

--- a/packages/engine/src/ecs/functions/ComponentFunctions.ts
+++ b/packages/engine/src/ecs/functions/ComponentFunctions.ts
@@ -2,8 +2,12 @@ import { State } from '@speigg/hookstate'
 import * as bitECS from 'bitecs'
 import { ArrayByType, ISchema, Type } from 'bitecs'
 
+import multiLogger from '@xrengine/common/src/logger'
+
 import { Engine } from '../classes/Engine'
 import { Entity } from '../classes/Entity'
+
+const logger = multiLogger.child({ component: 'engine:ecs:ComponentFunctions' })
 
 const INITIAL_COMPONENT_SIZE = 1000 // TODO set to 0 after next bitECS update
 bitECS.setDefaultSize(1000)
@@ -326,7 +330,7 @@ export const removeAllComponents = (entity: Entity, world = Engine.instance.curr
       removeComponent(entity, component as MappedComponent<any, any>, world)
     }
   } catch (_) {
-    console.warn('Components of entity already removed')
+    logger.warn('Components of entity already removed')
   }
 }
 

--- a/packages/engine/src/ecs/functions/FixedPipelineSystem.ts
+++ b/packages/engine/src/ecs/functions/FixedPipelineSystem.ts
@@ -1,8 +1,11 @@
+import multiLogger from '@xrengine/common/src/logger'
+
 import { nowMilliseconds } from '../../common/functions/nowMilliseconds'
 import { getEngineState } from '../classes/EngineState'
 import { World } from '../classes/World'
 import { SystemUpdateType } from './SystemUpdateType'
 
+const logger = multiLogger.child({ component: 'engine:ecs:FixedPipelineSystem' })
 /**
  * System for running simulation logic with fixed time intervals
  */
@@ -47,7 +50,7 @@ export default function FixedPipelineSystem(world: World, args: { tickRate: numb
     }
 
     if (updatesLimitReached || accumulator > maxTimeDifference) {
-      console.warn(
+      logger.warn(
         'FixedPipelineSystem: update limit reached, skipping world.fixedElapsedTime ahead to catch up with world.elapsedTime'
       )
       world.fixedElapsedSeconds = world.elapsedSeconds

--- a/packages/hyperflux/functions/StateFunctions.tsx
+++ b/packages/hyperflux/functions/StateFunctions.tsx
@@ -2,9 +2,13 @@ import { createState, SetInitialStateAction, State } from '@speigg/hookstate'
 import React from 'react'
 import Reconciler from 'react-reconciler'
 
+import multiLogger from '@xrengine/common/src/logger'
+
 import { HyperFlux, HyperStore } from './StoreFunctions'
 
 export * from '@speigg/hookstate'
+
+const logger = multiLogger.child({ component: 'hyperflux:State' })
 
 type StateDefinition<S> = {
   name: string
@@ -17,9 +21,12 @@ function defineState<S>(definition: StateDefinition<S>) {
 }
 
 function registerState<S>(StateDefinition: StateDefinition<S>, store = HyperFlux.store) {
-  console.log('[HyperFlux]: registerState', StateDefinition.name)
-  if (StateDefinition.name in store.state)
-    throw new Error(`State ${StateDefinition.name} has already been registered in Store`)
+  logger.info(`registerState ${StateDefinition.name}`)
+  if (StateDefinition.name in store.state) {
+    const err = new Error(`State ${StateDefinition.name} has already been registered in Store`)
+    logger.error(err)
+    throw err
+  }
   const initial =
     typeof StateDefinition.initial === 'function'
       ? (StateDefinition.initial as Function)()

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -85,6 +85,7 @@
     "octokit": "1.7.1",
     "pino": "^7.2.0",
     "pino-elasticsearch": "^6.2.0",
+    "pino-http": "^8.1.1",
     "pino-pretty": "^7.6.1",
     "pug": "^3.0.0",
     "request": "2.88.2",
@@ -93,8 +94,8 @@
     "simple-git": "3.6.0",
     "slugify": "^1.4.5",
     "socket.io": "4.4.1",
-    "typescript": "4.7.4",
     "trace-unhandled": "2.0.1",
+    "typescript": "4.7.4",
     "uint8arrays": "^3.0.0",
     "universal-analytics": "^0.5.0",
     "uuid": "8.3.2"

--- a/packages/server-core/src/assets/assetLibrary/asset-library.class.ts
+++ b/packages/server-core/src/assets/assetLibrary/asset-library.class.ts
@@ -48,7 +48,7 @@ export class AssetLibrary implements ServiceMethods<any> {
     try {
       const inPath = decodeURI(createParams.path)
       const pathData = /.*projects\/([\w\d\s\-_]+)\/assets\/([\w\d\s\-_]+).zip$/.exec(inPath)
-      if (!pathData) throw Error('could not extract path data')
+      if (!pathData) throw new Error('could not extract path data')
       const [_, projectName, fileName] = pathData
       const assetRoot = `${projectName}/assets/${fileName}`
       const fullPath = path.join(this.rootPath, assetRoot)
@@ -56,7 +56,7 @@ export class AssetLibrary implements ServiceMethods<any> {
       await extract(`${fullPath}.zip`, { dir: fullPath })
       return { assetRoot: assetRoot }
     } catch (e) {
-      throw Error('error unzipping archive:', e)
+      throw new Error('error unzipping archive:', e)
     }
   }
 }

--- a/packages/server-core/src/createApp.ts
+++ b/packages/server-core/src/createApp.ts
@@ -1,4 +1,4 @@
-import express, { static as _static, errorHandler, json, rest, urlencoded } from '@feathersjs/express'
+import express, { errorHandler, json, rest, urlencoded } from '@feathersjs/express'
 import { feathers } from '@feathersjs/feathers'
 import socketio from '@feathersjs/socketio'
 import * as k8s from '@kubernetes/client-node'
@@ -9,6 +9,7 @@ import swagger from 'feathers-swagger'
 import sync from 'feathers-sync'
 import helmet from 'helmet'
 import path from 'path'
+import pinoHttp from 'pino-http'
 import { Socket } from 'socket.io'
 
 import { pipe } from '@xrengine/common/src/utils/pipe'
@@ -20,6 +21,26 @@ import { createDefaultStorageProvider, createIPFSStorageProvider } from './media
 import sequelize from './sequelize'
 import services from './services'
 import authentication from './user/authentication'
+
+/**
+ * Logs all Express API calls (except for the ones marked as 'silent').
+ */
+const requestLogger = pinoHttp({
+  logger: logger.child({ component: 'api' }),
+
+  customLogLevel(req, res, err) {
+    if (res.req.url === '/api/log' || res.req.url === '/healthcheck') {
+      return 'silent'
+    } else if (res.statusCode === 404) {
+      return 'info'
+    } else if (res.statusCode >= 400 || err) {
+      return 'error'
+    } else if (res.statusCode >= 300 && res.statusCode < 400) {
+      return 'silent'
+    }
+    return 'info'
+  }
+})
 
 export const configureOpenAPI = () => (app: Application) => {
   app.configure(
@@ -155,6 +176,9 @@ export const createFeathersExpressApp = (
       credentials: true
     }) as any
   )
+
+  app.use(requestLogger)
+
   app.use(compress())
   app.use(json())
   app.use(urlencoded({ extended: true }))
@@ -174,6 +198,13 @@ export const createFeathersExpressApp = (
 
   app.use('/healthcheck', (req, res) => {
     res.sendStatus(200)
+  })
+
+  // Receive client-side log events (only active when APP_ENV != 'development')
+  app.post('/api/log', (req, res) => {
+    const { msg, ...mergeObject } = req.body
+    logger.info({ user: req.params?.user, ...mergeObject }, msg)
+    return res.status(204).send()
   })
 
   app.use(errorHandler({ logger }))

--- a/packages/server-core/src/logger.ts
+++ b/packages/server-core/src/logger.ts
@@ -1,3 +1,10 @@
+/**
+ * A server-side only multi-stream logger.
+ * For isomorphic or client-side logging, use packages/common/src/logger.ts
+ * (which will send all log events to this server-side logger here, via an
+ *  API endpoint).
+ */
+import os from 'os'
 import pino from 'pino'
 import pinoElastic from 'pino-elasticsearch'
 import pretty from 'pino-pretty'
@@ -20,7 +27,11 @@ const streams = [streamToPretty, streamToElastic]
 
 const logger = pino(
   {
-    level: 'debug'
+    level: 'debug',
+    base: {
+      hostname: os.hostname,
+      component: 'server-core'
+    }
   },
   pino.multistream(streams)
 )

--- a/packages/server-core/src/matchmaking/emulate.ts
+++ b/packages/server-core/src/matchmaking/emulate.ts
@@ -49,6 +49,7 @@ export async function emulate_getTicketsAssignment(app, ticketId, userId): Promi
 
   if (!matchUser) {
     // throw new BadRequest('MatchUser not found. ticket is outdated?')
+    // FIXME: not a valid Error format
     throw { code: 5, message: `Ticket id: ${ticketId} not found` }
   }
 


### PR DESCRIPTION
* Adds a `/api/log` endpoint to server-core, which receives all log events from `client`, `engine`, and `hyperflux` and sends them to Elastic for aggregation (only when `APP_ENV !== 'development'`) 
* Fixes `server-core` log events not having a `component` property
* Adds a `multiLogger` export to `common`.
* Adds error logging to `NotificationService.dispatchNotify()` (only when `variant === 'error'`)

Usage:

```ts
import multiLogger from '@xrengine/common/src/logger'
const logger = multiLogger.child({ component: 'client-core:ClientSettingService' }) // or appropriate component name

logger.error(err)
logger.info('Message')
logger.info('Message %o', { interpolation: 'values' })
logger.info({merge: 'object'}, 'Message goes here')
logger.info({merge: 'object'}, 'Message goes here %o', { interpolation: 'values' })
```

To test sending to Elasticsearch:

Edit your `.env.local`, set `VITE_FORCE_CLIENT_LOG_AGGREGATE=true`.
(You can then see the log events in local Kibana http://localhost:5601/app/kibana )