### PR TITLE
Fixed some issues with admin page access and scope restrictions.

### DIFF
--- a/packages/client-core/src/admin/adminRoutes.tsx
+++ b/packages/client-core/src/admin/adminRoutes.tsx
@@ -44,7 +44,10 @@ const ProtectedRoutes = () => {
     instance: false,
     invite: false,
     globalAvatars: false,
-    benchmarking: false
+    benchmarking: false,
+    routes: false,
+    projects: false,
+    settings: false
   }
   const scopes = admin?.scopes?.value || []
 
@@ -91,18 +94,18 @@ const ProtectedRoutes = () => {
         {isEngineInitialized && (
           <Switch>
             <PrivateRoute exact path="/admin" component={analytic} />
-            <PrivateRoute exact path="/admin/avatars" component={avatars} />
-            <PrivateRoute exact path="/admin/benchmarking" component={benchmarking} />
-            <PrivateRoute exact path="/admin/groups" component={groups} />
-            <PrivateRoute exact path="/admin/instance" component={instance} />
-            <PrivateRoute exact path="/admin/invites" component={invites} />
-            <PrivateRoute exact path="/admin/locations" component={locations} />
-            <PrivateRoute exact path="/admin/routes" component={routes} />
-            <PrivateRoute exact path="/admin/parties" component={party} />
-            <PrivateRoute exact path="/admin/bots" component={botSetting} />
-            <PrivateRoute exact path="/admin/projects" component={projects} />
-            <PrivateRoute exact path="/admin/settings" component={setting} />
-            <PrivateRoute exact Path="/admin/users" component={users} />
+            {allowedRoutes.globalAvatars && <PrivateRoute exact path="/admin/avatars" component={avatars} />}
+            {allowedRoutes.benchmarking && <PrivateRoute exact path="/admin/benchmarking" component={benchmarking} />}
+            {allowedRoutes.groups && <PrivateRoute exact path="/admin/groups" component={groups} />}
+            {allowedRoutes.instance && <PrivateRoute exact path="/admin/instance" component={instance} />}
+            {allowedRoutes.invite && <PrivateRoute exact path="/admin/invites" component={invites} />}
+            {allowedRoutes.location && <PrivateRoute exact path="/admin/locations" component={locations} />}
+            {allowedRoutes.routes && <PrivateRoute exact path="/admin/routes" component={routes} />}
+            {allowedRoutes.party && <PrivateRoute exact path="/admin/parties" component={party} />}
+            {allowedRoutes.bot && <PrivateRoute exact path="/admin/bots" component={botSetting} />}
+            {allowedRoutes.projects && <PrivateRoute exact path="/admin/projects" component={projects} />}
+            {allowedRoutes.settings && <PrivateRoute exact path="/admin/settings" component={setting} />}
+            {allowedRoutes.user && <PrivateRoute exact Path="/admin/users" component={users} />}
           </Switch>
         )}
       </Suspense>

--- a/packages/client-core/src/admin/services/UserService.ts
+++ b/packages/client-core/src/admin/services/UserService.ts
@@ -6,7 +6,7 @@ import { defineAction, defineState, dispatchAction, getState, useState } from '@
 
 import { API } from '../../API'
 import { NotificationService } from '../../common/services/NotificationService'
-import { accessAuthState } from '../../user/services/AuthService'
+import { accessAuthState, AuthService } from '../../user/services/AuthService'
 
 //State
 export const USER_PAGE_LIMIT = 10
@@ -181,6 +181,7 @@ export const AdminUserService = {
     try {
       const result = (await API.instance.client.service('user').patch(id, user)) as UserInterface
       dispatchAction(AdminUserActions.userPatched({ user: result }))
+      if (id === accessAuthState().user.id.value) await AuthService.loadUserData(id)
     } catch (err) {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })
     }

--- a/packages/client-core/src/user/components/Dashboard/DashboardItems.tsx
+++ b/packages/client-core/src/user/components/Dashboard/DashboardItems.tsx
@@ -72,7 +72,7 @@ export const SidebarItems = (allowedRoutes) => [
     path: '/admin/benchmarking',
     icon: <Timeline style={{ color: 'white' }} />
   },
-  {
+  allowedRoutes.settings && {
     name: 'user:dashboard.setting',
     path: '/admin/settings',
     icon: <Settings style={{ color: 'white' }} />

--- a/packages/client-core/src/user/components/Dashboard/DashboardMenuItem.tsx
+++ b/packages/client-core/src/user/components/Dashboard/DashboardMenuItem.tsx
@@ -23,17 +23,19 @@ const DashboardMenuItem = ({ location }: Props) => {
   const { t } = useTranslation()
 
   let allowedRoutes = {
-    routes: true,
     location: false,
     user: false,
     bot: false,
+    scene: false,
     party: false,
     groups: false,
     instance: false,
     invite: false,
     globalAvatars: false,
     benchmarking: false,
-    projects: false
+    routes: false,
+    projects: false,
+    settings: false
   }
 
   scopes.forEach((scope) => {

--- a/packages/server-core/src/hooks/verify-scope.test.ts
+++ b/packages/server-core/src/hooks/verify-scope.test.ts
@@ -105,6 +105,11 @@ describe('verify-scope', () => {
       userRole
     })) as UserInterface
 
+    await app.service('scope').create({
+      type: 'location:read',
+      userId: user.id
+    })
+
     const verifyLocationReadScope = verifyScope('location', 'read')
     const hookContext = mockUserHookContext(user, app)
 

--- a/packages/server-core/src/hooks/verify-scope.ts
+++ b/packages/server-core/src/hooks/verify-scope.ts
@@ -10,8 +10,6 @@ export default (currentType: string, scopeToVerify: string) => {
     if (context.params.isInternal) return context
     const loggedInUser = context.params.user as UserInterface
     if (!loggedInUser) throw new UnauthenticatedException('No logged in user')
-    const user = await context.app.service('user').get(loggedInUser.id!)
-    if (user.userRole === 'admin') return context
     const scopes = await context.app.service('scope').Model.findAll({
       where: {
         userId: loggedInUser.id
@@ -19,13 +17,10 @@ export default (currentType: string, scopeToVerify: string) => {
       raw: true,
       nest: true
     })
-    if (!scopes) {
-      throw new NotFoundException('No scope available for the current user.')
-    }
+    if (!scopes) throw new NotFoundException('No scope available for the current user.')
+
     const currentScopes = scopes.reduce((result, sc) => {
-      if (sc.type.split(':')[0] === currentType) {
-        result.push(sc.type.split(':')[1])
-      }
+      if (sc.type.split(':')[0] === currentType) result.push(sc.type.split(':')[1])
       return result
     }, [])
     if (!currentScopes.includes(scopeToVerify))

--- a/packages/server-core/src/scope/scope-type/scope-type.seed.ts
+++ b/packages/server-core/src/scope/scope-type/scope-type.seed.ts
@@ -78,6 +78,12 @@ export const scopeTypeSeed = {
     },
     {
       type: 'projects:write'
+    },
+    {
+      type: 'settings:read'
+    },
+    {
+      type: 'settings:write'
     }
   ]
 }

--- a/packages/server-core/src/scope/scope/scope.hooks.ts
+++ b/packages/server-core/src/scope/scope/scope.hooks.ts
@@ -2,16 +2,17 @@ import { disallow, iff, isProvider } from 'feathers-hooks-common'
 
 import authenticate from '../../hooks/authenticate'
 import restrictUserRole from '../../hooks/restrict-user-role'
+import verifyScope from '../../hooks/verify-scope'
 
 export default {
   before: {
     all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    find: [],
-    get: [],
-    create: [],
+    find: [iff(isProvider('external'), verifyScope('user', 'read') as any)],
+    get: [iff(isProvider('external'), verifyScope('user', 'read') as any)],
+    create: [iff(isProvider('external'), verifyScope('user', 'write') as any)],
     update: [disallow()],
     patch: [disallow()],
-    remove: []
+    remove: [iff(isProvider('external'), verifyScope('user', 'write') as any)]
   },
 
   after: {

--- a/packages/server-core/src/setting/analytics-setting/analytics.hooks.ts
+++ b/packages/server-core/src/setting/analytics-setting/analytics.hooks.ts
@@ -3,16 +3,17 @@ import { iff, isProvider } from 'feathers-hooks-common'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 
 import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
 
 export default {
   before: {
     all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: []
+    find: [iff(isProvider('external'), verifyScope('settings', 'read') as any)],
+    get: [iff(isProvider('external'), verifyScope('settings', 'read') as any)],
+    create: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    update: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    patch: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    remove: [iff(isProvider('external'), verifyScope('settings', 'write') as any)]
   },
 
   after: {

--- a/packages/server-core/src/setting/authentication-setting/authentication.hooks.ts
+++ b/packages/server-core/src/setting/authentication-setting/authentication.hooks.ts
@@ -3,16 +3,17 @@ import { iff, isProvider } from 'feathers-hooks-common'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 
 import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
 
 export default {
   before: {
     all: [authenticate()],
     find: [],
-    get: [iff(isProvider('external'), restrictUserRole('admin') as any)],
-    create: [iff(isProvider('external'), restrictUserRole('admin') as any)],
-    update: [iff(isProvider('external'), restrictUserRole('admin') as any)],
-    patch: [iff(isProvider('external'), restrictUserRole('admin') as any)],
-    remove: [iff(isProvider('external'), restrictUserRole('admin') as any)]
+    get: [iff(isProvider('external'), restrictUserRole('admin') as any, verifyScope('settings', 'read') as any)],
+    create: [iff(isProvider('external'), restrictUserRole('admin') as any, verifyScope('settings', 'write') as any)],
+    update: [iff(isProvider('external'), restrictUserRole('admin') as any, verifyScope('settings', 'write') as any)],
+    patch: [iff(isProvider('external'), restrictUserRole('admin') as any, verifyScope('settings', 'write') as any)],
+    remove: [iff(isProvider('external'), restrictUserRole('admin') as any, verifyScope('settings', 'write') as any)]
   },
 
   after: {

--- a/packages/server-core/src/setting/aws-setting/aws-setting.hooks.ts
+++ b/packages/server-core/src/setting/aws-setting/aws-setting.hooks.ts
@@ -3,16 +3,17 @@ import { iff, isProvider } from 'feathers-hooks-common'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 
 import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
 
 export default {
   before: {
     all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: []
+    find: [iff(isProvider('external'), verifyScope('settings', 'read') as any)],
+    get: [iff(isProvider('external'), verifyScope('settings', 'read') as any)],
+    create: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    update: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    patch: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    remove: [iff(isProvider('external'), verifyScope('settings', 'write') as any)]
   },
 
   after: {

--- a/packages/server-core/src/setting/chargebee-setting/chargebee-setting.hooks.ts
+++ b/packages/server-core/src/setting/chargebee-setting/chargebee-setting.hooks.ts
@@ -3,16 +3,17 @@ import { iff, isProvider } from 'feathers-hooks-common'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 
 import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
 
 export default {
   before: {
     all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: []
+    find: [iff(isProvider('external'), verifyScope('settings', 'read') as any)],
+    get: [iff(isProvider('external'), verifyScope('settings', 'read') as any)],
+    create: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    update: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    patch: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    remove: [iff(isProvider('external'), verifyScope('settings', 'write') as any)]
   },
 
   after: {

--- a/packages/server-core/src/setting/client-setting/client-setting.hooks.ts
+++ b/packages/server-core/src/setting/client-setting/client-setting.hooks.ts
@@ -3,16 +3,29 @@ import { iff, isProvider } from 'feathers-hooks-common'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 
 import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
 
 export default {
   before: {
     all: [],
     find: [],
     get: [],
-    create: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    update: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    patch: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    remove: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)]
+    create: [
+      authenticate(),
+      iff(isProvider('external'), restrictUserRole('admin') as any, verifyScope('settings', 'write') as any)
+    ],
+    update: [
+      authenticate(),
+      iff(isProvider('external'), restrictUserRole('admin') as any, verifyScope('settings', 'write') as any)
+    ],
+    patch: [
+      authenticate(),
+      iff(isProvider('external'), restrictUserRole('admin') as any, verifyScope('settings', 'write') as any)
+    ],
+    remove: [
+      authenticate(),
+      iff(isProvider('external'), restrictUserRole('admin') as any, verifyScope('settings', 'write') as any)
+    ]
   },
 
   after: {

--- a/packages/server-core/src/setting/coil-setting/coil-setting.hooks.ts
+++ b/packages/server-core/src/setting/coil-setting/coil-setting.hooks.ts
@@ -3,16 +3,17 @@ import { iff, isProvider } from 'feathers-hooks-common'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 
 import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
 
 export default {
   before: {
     all: [authenticate()],
     find: [],
     get: [],
-    create: [iff(isProvider('external'), restrictUserRole('admin') as any)],
-    update: [iff(isProvider('external'), restrictUserRole('admin') as any)],
-    patch: [iff(isProvider('external'), restrictUserRole('admin') as any)],
-    remove: [iff(isProvider('external'), restrictUserRole('admin') as any)]
+    create: [iff(isProvider('external'), restrictUserRole('admin') as any, verifyScope('settings', 'write') as any)],
+    update: [iff(isProvider('external'), restrictUserRole('admin') as any, verifyScope('settings', 'write') as any)],
+    patch: [iff(isProvider('external'), restrictUserRole('admin') as any, verifyScope('settings', 'write') as any)],
+    remove: [iff(isProvider('external'), restrictUserRole('admin') as any, verifyScope('settings', 'write') as any)]
   },
 
   after: {

--- a/packages/server-core/src/setting/email-setting/email-setting.hooks.ts
+++ b/packages/server-core/src/setting/email-setting/email-setting.hooks.ts
@@ -3,16 +3,17 @@ import { iff, isProvider } from 'feathers-hooks-common'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 
 import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
 
 export default {
   before: {
     all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: []
+    find: [iff(isProvider('external'), verifyScope('settings', 'read') as any)],
+    get: [iff(isProvider('external'), verifyScope('settings', 'read') as any)],
+    create: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    update: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    patch: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    remove: [iff(isProvider('external'), verifyScope('settings', 'write') as any)]
   },
 
   after: {

--- a/packages/server-core/src/setting/instance-server-setting/instance-server-setting.hooks.ts
+++ b/packages/server-core/src/setting/instance-server-setting/instance-server-setting.hooks.ts
@@ -3,16 +3,17 @@ import { iff, isProvider } from 'feathers-hooks-common'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 
 import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
 
 export default {
   before: {
     all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: []
+    find: [iff(isProvider('external'), verifyScope('settings', 'read') as any)],
+    get: [iff(isProvider('external'), verifyScope('settings', 'read') as any)],
+    create: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    update: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    patch: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    remove: [iff(isProvider('external'), verifyScope('settings', 'write') as any)]
   },
 
   after: {

--- a/packages/server-core/src/setting/project-setting/project-setting.hooks.ts
+++ b/packages/server-core/src/setting/project-setting/project-setting.hooks.ts
@@ -12,7 +12,10 @@ export default {
     get: [disallow()],
     create: [disallow()],
     update: [disallow()],
-    patch: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
+    patch: [
+      authenticate(),
+      iff(isProvider('external'), restrictUserRole('admin') as any, verifyScope('editor', 'write') as any)
+    ],
     remove: [disallow()]
   },
 

--- a/packages/server-core/src/setting/redis-setting/redis-setting.hooks.ts
+++ b/packages/server-core/src/setting/redis-setting/redis-setting.hooks.ts
@@ -3,16 +3,17 @@ import { iff, isProvider } from 'feathers-hooks-common'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 
 import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
 
 export default {
   before: {
     all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: []
+    find: [iff(isProvider('external'), verifyScope('settings', 'read') as any)],
+    get: [iff(isProvider('external'), verifyScope('settings', 'read') as any)],
+    create: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    update: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    patch: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    remove: [iff(isProvider('external'), verifyScope('settings', 'write') as any)]
   },
 
   after: {

--- a/packages/server-core/src/setting/server-setting/server-setting.hooks.ts
+++ b/packages/server-core/src/setting/server-setting/server-setting.hooks.ts
@@ -3,16 +3,17 @@ import { iff, isProvider } from 'feathers-hooks-common'
 import restrictUserRole from '@xrengine/server-core/src/hooks/restrict-user-role'
 
 import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
 
 export default {
   before: {
     all: [authenticate(), iff(isProvider('external'), restrictUserRole('admin') as any)],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: []
+    find: [iff(isProvider('external'), verifyScope('settings', 'read') as any)],
+    get: [iff(isProvider('external'), verifyScope('settings', 'read') as any)],
+    create: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    update: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    patch: [iff(isProvider('external'), verifyScope('settings', 'write') as any)],
+    remove: [iff(isProvider('external'), verifyScope('settings', 'write') as any)]
   },
 
   after: {


### PR DESCRIPTION
## Summary

Access to projects and settings pages was not being controlled by scopes.
Standardized allowedRoutes in both adminRoutes and DashboardMenuItem.

Actual use of scopes to determine ability to access an admin service page
was not being used - admins without scopes could access /admin/users, for example.

Added settings scope-types, made them checked when hitting all settings methods
that aren't publicly available.

verify-scope hook now does not let admins through automatically, they must also
have the appropriate scope.

On an admin patching their own user, triggers a re-fetch of their user object
so that updated scopes can be applied to page render immediately.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

