### PR TITLE
Disable general Express request logging for the API server.

### DIFF
--- a/packages/server-core/src/createApp.ts
+++ b/packages/server-core/src/createApp.ts
@@ -177,7 +177,9 @@ export const createFeathersExpressApp = (
     }) as any
   )
 
-  app.use(requestLogger)
+  // TODO: Investigate why this is letting healthcheck requests through
+  // Disabling for the moment
+  // app.use(requestLogger)
 
   app.use(compress())
   app.use(json())


### PR DESCRIPTION
Currently, the customLogLevel logic doesn't seem to be working, so the request logging is capturing all healthcheck and `/api/log` requests. Disabling for investigation.