### PR TITLE
Fixed several bugs in party logic.

### DIFF
--- a/packages/client-core/i18n/en/social.json
+++ b/packages/client-core/i18n/en/social.json
@@ -23,6 +23,10 @@
   "flames": "Flames",
   "continue": "Continue",
   "partyInvitationSent": "Party invitation sent",
+  "selfLeftParty": "You have left the party",
+  "otherLeftParty": " has left the party",
+  "selfJoinedParty": "You have joined a party",
+  "otherJoinedParty": " has joined the party",
   "arMedia": {
     "back": "Back",
     "clip": "Clip",

--- a/packages/client-core/src/admin/components/Analytics/index.tsx
+++ b/packages/client-core/src/admin/components/Analytics/index.tsx
@@ -10,7 +10,7 @@ import { Box, TextField, ToggleButton, ToggleButtonGroup } from '@mui/material'
 
 import { useAuthState } from '../../../user/services/AuthService'
 import { useAdminAnalyticsState } from '../../services/AnalyticsService'
-import { ADminAnalyticsService } from '../../services/AnalyticsService'
+import { AdminAnalyticsService } from '../../services/AnalyticsService'
 import styles from '../../styles/admin.module.scss'
 import ActivityGraph from './ActivityGraph'
 import Card from './CardNumber'
@@ -99,14 +99,14 @@ const Analytics = () => {
 
   useEffect(() => {
     if (refetch === true && startDate < endDate) {
-      ADminAnalyticsService.fetchActiveParties(startDate?.toDate(), endDate?.toDate())
-      ADminAnalyticsService.fetchInstanceUsers(startDate?.toDate(), endDate?.toDate())
-      ADminAnalyticsService.fetchChannelUsers(startDate?.toDate(), endDate?.toDate())
-      ADminAnalyticsService.fetchActiveLocations(startDate?.toDate(), endDate?.toDate())
-      ADminAnalyticsService.fetchActiveScenes(startDate?.toDate(), endDate?.toDate())
-      ADminAnalyticsService.fetchActiveInstances(startDate?.toDate(), endDate?.toDate())
-      ADminAnalyticsService.fetchDailyUsers(startDate?.toDate(), endDate?.toDate())
-      ADminAnalyticsService.fetchDailyNewUsers(startDate?.toDate(), endDate?.toDate())
+      AdminAnalyticsService.fetchActiveParties(startDate?.toDate(), endDate?.toDate())
+      AdminAnalyticsService.fetchInstanceUsers(startDate?.toDate(), endDate?.toDate())
+      AdminAnalyticsService.fetchChannelUsers(startDate?.toDate(), endDate?.toDate())
+      AdminAnalyticsService.fetchActiveLocations(startDate?.toDate(), endDate?.toDate())
+      AdminAnalyticsService.fetchActiveScenes(startDate?.toDate(), endDate?.toDate())
+      AdminAnalyticsService.fetchActiveInstances(startDate?.toDate(), endDate?.toDate())
+      AdminAnalyticsService.fetchDailyUsers(startDate?.toDate(), endDate?.toDate())
+      AdminAnalyticsService.fetchDailyNewUsers(startDate?.toDate(), endDate?.toDate())
       setRefetch(false)
     }
   }, [refetch, startDate, endDate])

--- a/packages/client-core/src/admin/services/AnalyticsService.ts
+++ b/packages/client-core/src/admin/services/AnalyticsService.ts
@@ -96,7 +96,7 @@ export const accessAdminAnalyticsState = () => getState(AdminAnalyticsState)
 export const useAdminAnalyticsState = () => useState(accessAdminAnalyticsState())
 
 //Service
-export const ADminAnalyticsService = {
+export const AdminAnalyticsService = {
   fetchActiveParties: async (startDate?: Date, endDate?: Date) => {
     try {
       const query = {

--- a/packages/client-core/src/admin/services/InviteService.ts
+++ b/packages/client-core/src/admin/services/InviteService.ts
@@ -81,7 +81,7 @@ export const AdminInviteService = {
     }
   },
   removeInvite: async (id: string) => {
-    const result = await API.instance.client.service('invite').remove(id)
+    const result = (await API.instance.client.service('invite').remove(id)) as InviteInterface
     dispatchAction(AdminInviteActions.inviteRemoved({ invite: result }))
   },
   createInvite: async (invite: any) => {

--- a/packages/client-core/src/common/services/MediaInstanceConnectionService.ts
+++ b/packages/client-core/src/common/services/MediaInstanceConnectionService.ts
@@ -36,7 +36,7 @@ const MediaInstanceState = defineState({
   name: 'MediaInstanceState',
   initial: () => ({
     instances: {} as { [id: string]: InstanceState },
-    acceptingPartyInvite: false
+    joiningNonInstanceMediaChannel: false
   })
 })
 
@@ -65,6 +65,7 @@ export const MediaInstanceConnectionServiceReceptor = (action) => {
       return s.instances[action.instanceId].connecting.set(true)
     })
     .when(MediaInstanceConnectionAction.serverConnected.matches, (action) => {
+      s.joiningNonInstanceMediaChannel.set(false)
       return s.instances[action.instanceId].merge({
         connected: true,
         connecting: false,
@@ -79,11 +80,8 @@ export const MediaInstanceConnectionServiceReceptor = (action) => {
     .when(MediaInstanceConnectionAction.disconnect.matches, (action) => {
       return s.instances[action.instanceId].set(none)
     })
-    .when(MediaInstanceConnectionAction.acceptingPartyInvite.matches, (action) => {
-      return s.acceptingPartyInvite.set(true)
-    })
-    .when(MediaInstanceConnectionAction.acceptedPartyInvite.matches, (action) => {
-      return s.acceptingPartyInvite.set(false)
+    .when(MediaInstanceConnectionAction.joiningNonInstanceMediaChannel.matches, (action) => {
+      return s.joiningNonInstanceMediaChannel.set(true)
     })
 }
 
@@ -207,11 +205,7 @@ export class MediaInstanceConnectionAction {
     instanceId: matches.string
   })
 
-  static acceptingPartyInvite = defineAction({
-    type: 'ACCEPTING_PARTY_INVITE' as const
-  })
-
-  static acceptedPartyInvite = defineAction({
-    type: 'ACCEPTED_PARTY_INVITE' as const
+  static joiningNonInstanceMediaChannel = defineAction({
+    type: 'JOINING_NON_INSTANCE_MEDIA_CHANNEL' as const
   })
 }

--- a/packages/client-core/src/components/UserMediaWindow/index.tsx
+++ b/packages/client-core/src/components/UserMediaWindow/index.tsx
@@ -8,6 +8,9 @@ import { useLocationState } from '@xrengine/client-core/src/social/services/Loca
 import { MediaStreams } from '@xrengine/client-core/src/transports/MediaStreams'
 import {
   applyScreenshareToTexture,
+  configureMediaTransports,
+  createCamAudioProducer,
+  createCamVideoProducer,
   globalMuteProducer,
   globalUnmuteProducer,
   pauseConsumer,
@@ -349,10 +352,15 @@ export const useUserMediaWindowHook = ({ peerId }) => {
     e.stopPropagation()
     const mediaNetwork = Engine.instance.currentWorld.mediaNetwork as SocketWebRTCClientNetwork
     if (peerId === 'cam_me') {
-      const videoPaused = MediaStreams.instance.toggleVideoPaused()
-      if (videoPaused) await pauseProducer(mediaNetwork, MediaStreams.instance.camVideoProducer)
-      else await resumeProducer(mediaNetwork, MediaStreams.instance.camVideoProducer)
-      MediaStreamService.updateCamVideoState()
+      if (await configureMediaTransports(mediaNetwork, ['video'])) {
+        if (MediaStreams.instance.camVideoProducer == null) await createCamVideoProducer(mediaNetwork)
+        else {
+          const videoPaused = MediaStreams.instance.toggleVideoPaused()
+          if (videoPaused) await pauseProducer(mediaNetwork, MediaStreams.instance.camVideoProducer)
+          else await resumeProducer(mediaNetwork, MediaStreams.instance.camVideoProducer)
+        }
+        MediaStreamService.updateCamVideoState()
+      }
     } else if (peerId === 'screen_me') {
       const videoPaused = MediaStreams.instance.toggleScreenShareVideoPaused()
       if (videoPaused) await pauseProducer(mediaNetwork, MediaStreams.instance.screenVideoProducer)
@@ -375,10 +383,15 @@ export const useUserMediaWindowHook = ({ peerId }) => {
     e.stopPropagation()
     const mediaNetwork = Engine.instance.currentWorld.mediaNetwork as SocketWebRTCClientNetwork
     if (peerId === 'cam_me') {
-      const audioPaused = MediaStreams.instance.toggleAudioPaused()
-      if (audioPaused) await pauseProducer(mediaNetwork, MediaStreams.instance.camAudioProducer)
-      else await resumeProducer(mediaNetwork, MediaStreams.instance.camAudioProducer)
-      MediaStreamService.updateCamAudioState()
+      if (await configureMediaTransports(mediaNetwork, ['audio'])) {
+        if (MediaStreams.instance.camAudioProducer == null) await createCamAudioProducer(mediaNetwork)
+        else {
+          const audioPaused = MediaStreams.instance.toggleAudioPaused()
+          if (audioPaused) await pauseProducer(mediaNetwork, MediaStreams.instance.camAudioProducer)
+          else await resumeProducer(mediaNetwork, MediaStreams.instance.camAudioProducer)
+        }
+        MediaStreamService.updateCamAudioState()
+      }
     } else if (peerId === 'screen_me') {
       const audioPaused = MediaStreams.instance.toggleScreenShareAudioPaused()
       if (audioPaused) await pauseProducer(mediaNetwork, MediaStreams.instance.screenAudioProducer)

--- a/packages/client-core/src/components/UserMediaWindows/index.tsx
+++ b/packages/client-core/src/components/UserMediaWindows/index.tsx
@@ -20,7 +20,7 @@ const UserMediaWindows = (): JSX.Element => {
   const displayedUsers =
     network?.hostId && currentChannelInstanceConnection
       ? currentChannelInstanceConnection.channelType?.value === 'party'
-        ? userState.layerUsers?.value.filter((user) => {
+        ? userState.channelLayerUsers?.value.filter((user) => {
             return (
               user.id !== selfUserId.value &&
               user.channelInstanceId != null &&

--- a/packages/client-core/src/components/World/InstanceServerWarnings.tsx
+++ b/packages/client-core/src/components/World/InstanceServerWarnings.tsx
@@ -165,20 +165,27 @@ const InstanceServerWarnings = () => {
         const partyChannel = Object.values(channels).find(
           (channel) => channel.channelType === 'party' && channel.partyId === selfUser.partyId.value
         )
-        const instanceChannel = Object.values(channels).find(
-          (channel) => channel.instanceId === Engine.instance.currentWorld.mediaNetwork?.hostId
-        )
-        const channelId = partyChannel ? partyChannel.id : instanceChannel!.id
-        setModalValues({
-          open: true,
-          title: t('common:instanceServer.noAvailableServers'),
-          body: t('common:instanceServer.noAvailableServersMessage'),
-          action: async () => MediaInstanceConnectionService.provisionServer(channelId, false),
-          parameters: [channelId, false],
-          noCountdown: false,
-          onClose: () => {}
-        })
-        break
+        const instanceChannel = Object.values(channels).find((channel) => channel.channelType === 'instance')
+
+        if (!partyChannel && !instanceChannel) {
+          setTimeout(() => {
+            ChatService.getInstanceChannel()
+            updateWarningModal(WarningModalTypes.NO_MEDIA_SERVER_PROVISIONED)
+          }, 2000)
+          break
+        } else {
+          const channelId = partyChannel ? partyChannel.id : instanceChannel!.id
+          setModalValues({
+            open: true,
+            title: t('common:instanceServer.noAvailableServers'),
+            body: t('common:instanceServer.noAvailableServersMessage'),
+            action: async () => MediaInstanceConnectionService.provisionServer(channelId, false),
+            parameters: [channelId, false],
+            noCountdown: false,
+            onClose: () => {}
+          })
+          break
+        }
       }
 
       case WarningModalTypes.INSTANCE_DISCONNECTED: {

--- a/packages/client-core/src/components/World/NetworkInstanceProvisioning.tsx
+++ b/packages/client-core/src/components/World/NetworkInstanceProvisioning.tsx
@@ -130,10 +130,14 @@ export const NetworkInstanceProvisioning = () => {
     }
   }, [chatState.instanceChannelFetched])
 
-  // periodically listening for users spatially near
   useHookEffect(() => {
     if (selfUser?.instanceId.value != null && userState.layerUsersUpdateNeeded.value) UserService.getLayerUsers(true)
   }, [selfUser?.instanceId, userState.layerUsersUpdateNeeded])
+
+  useHookEffect(() => {
+    if (selfUser?.channelInstanceId.value != null && userState.channelLayerUsersUpdateNeeded.value)
+      UserService.getLayerUsers(false)
+  }, [selfUser?.channelInstanceId, userState.channelLayerUsersUpdateNeeded])
 
   useHookEffect(() => {
     if (selfUser?.partyId?.value && chatState.channels.channels?.value) {

--- a/packages/client-core/src/social/services/InviteService.ts
+++ b/packages/client-core/src/social/services/InviteService.ts
@@ -301,7 +301,7 @@ export const InviteService = {
   acceptInvite: async (invite: Invite) => {
     try {
       if (invite.inviteType === 'party') {
-        dispatchAction(MediaInstanceConnectionAction.acceptingPartyInvite({}))
+        dispatchAction(MediaInstanceConnectionAction.joiningNonInstanceMediaChannel({}))
       }
       await API.instance.client.service('a-i').get(invite.id, {
         query: {

--- a/packages/client-core/src/user/components/UserMenu/menus/PartyMenu.module.scss
+++ b/packages/client-core/src/user/components/UserMenu/menus/PartyMenu.module.scss
@@ -82,7 +82,7 @@
           color: var(--blueHover);
           display: block;
           text-align: center;
-          width: 50px;
+          width: 100px;
         }
 
         .kick {

--- a/packages/client-core/src/user/components/UserMenu/menus/PartyMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/PartyMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { SendInvite } from '@xrengine/common/src/interfaces/Invite'
@@ -83,7 +83,6 @@ export const usePartyMenuHooks = () => {
 const SocialMenu = (): JSX.Element => {
   const { t } = useTranslation()
   const partyState = usePartyState()
-  const authUser = useAuthState().authUser.value
 
   const {
     createParty,
@@ -127,15 +126,14 @@ const SocialMenu = (): JSX.Element => {
                     <img src={user.user.static_resources && user.user.static_resources[0].url} alt="" />
                   </div>
                   <div className={styles.userName}>{user.user.name}</div>
+                  {user.isOwner && <img src="/icons/crown.svg" alt="" />}
                 </div>
-                {user.user.id === authUser.identityProvider.userId ? (
+                {user.user.id === selfUser.id.value ? (
                   <span className={styles.admin}>{t('user:usermenu.party.you')}</span>
                 ) : partyState.isOwned.value ? (
                   <Button className={styles.kick} onClick={() => kickUser(user.user.id)}>
                     {t('user:usermenu.party.kick')}
                   </Button>
-                ) : user.isOwner ? (
-                  <span className={styles.admin}>{t('user:usermenu.party.admin')}</span>
                 ) : null}
               </div>
             )
@@ -166,7 +164,7 @@ const SocialMenu = (): JSX.Element => {
           ) : (
             <div className={styles.controls}>
               <div className={styles.leaveInviteButtons}>
-                <Button className={styles.leave} onClick={() => kickUser(authUser.identityProvider.userId)}>
+                <Button className={styles.leave} onClick={() => kickUser(selfUser.id.value)}>
                   {t('user:usermenu.party.leave')}
                 </Button>
                 {isOwned && (

--- a/packages/client-core/src/user/functions/userPatched.ts
+++ b/packages/client-core/src/user/functions/userPatched.ts
@@ -6,7 +6,6 @@ import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { WorldState } from '@xrengine/engine/src/networking/interfaces/WorldState'
 import { dispatchAction, getState } from '@xrengine/hyperflux'
 
-import { MediaInstanceConnectionAction } from '../../common/services/MediaInstanceConnectionService'
 import { NotificationService } from '../../common/services/NotificationService'
 import { accessAuthState, AuthAction } from '../services/AuthService'
 import { accessUserState, UserAction } from '../services/UserService'
@@ -43,9 +42,6 @@ export const userPatched = (params) => {
         window.history.replaceState({}, '', parsed.toString())
       }
     }
-
-    if (patchedUser.partyId && patchedUser.partyId !== selfUser.partyId.value)
-      dispatchAction(MediaInstanceConnectionAction.acceptedPartyInvite({}))
   } else {
     const isLayerUser = userState.layerUsers.value.find((item) => item.id === patchedUser.id)
 

--- a/packages/client-core/src/user/services/UserService.ts
+++ b/packages/client-core/src/user/services/UserService.ts
@@ -6,9 +6,12 @@ import { RelationshipSeed } from '@xrengine/common/src/interfaces/Relationship'
 import { UserInterface } from '@xrengine/common/src/interfaces/User'
 import multiLogger from '@xrengine/common/src/logger'
 import { matches, Validator } from '@xrengine/engine/src/common/functions/MatchesUtils'
+import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { defineAction, defineState, dispatchAction, getState, useState } from '@xrengine/hyperflux'
 
 import { API } from '../../API'
+import { accessChatState } from '../../social/services/ChatService'
+import { accessAuthState } from './AuthService'
 
 const logger = multiLogger.child({ component: 'client-core:UserService' })
 
@@ -115,18 +118,17 @@ export const UserService = {
   },
 
   getLayerUsers: async (instance: boolean) => {
-    const search = window.location.search
-    let instanceId
-    if (search != null) {
-      instanceId = new URL(window.location.href).searchParams.get('instanceId')
-    }
+    let query = {
+      $limit: 1000,
+      action: instance ? 'layer-users' : 'channel-users'
+    } as any
+    if (!instance) query.channelInstanceId = Engine.instance.currentWorld._mediaHostId
+    else query.instanceId = Engine.instance.currentWorld._worldHostId
+    console.log('query', query)
     const layerUsers = (await API.instance.client.service('user').find({
-      query: {
-        $limit: 1000,
-        action: instance ? 'layer-users' : 'channel-users',
-        instanceId
-      }
+      query: query
     })) as Paginated<UserInterface>
+    console.log('layerUsers', layerUsers.data)
 
     const state = getState(UserState)
 

--- a/packages/instanceserver/src/channels.ts
+++ b/packages/instanceserver/src/channels.ts
@@ -461,7 +461,11 @@ const handleUserDisconnect = async (
           partyId: user.partyId
         }
       })
-      if (partyUser.total > 0) await app.service('party-user').remove(partyUser.data[0].id)
+      if (partyUser.total > 0) {
+        try {
+          await app.service('party-user').remove(partyUser.data[0].id)
+        } catch (err) {}
+      }
     }
   }
   // Patch the user's (channel)instanceId to null if they're leaving this instance.

--- a/packages/server-core/src/social/invite/invite.class.ts
+++ b/packages/server-core/src/social/invite/invite.class.ts
@@ -238,7 +238,8 @@ export class Invite extends Service<InviteDataType> {
     return result
   }
 
-  async remove(id: string, params?: Params): Promise<InviteDataType> {
+  async remove(id: string, params?: Params): Promise<InviteDataType[] | InviteDataType> {
+    if (!id) return super.remove(id, params)
     const invite = await this.app.service('invite').get(id)
     if (invite.inviteType === 'friend' && invite.inviteeId != null && !params?.preventUserRelationshipRemoval) {
       const selfUser = params!.user as UserInterface

--- a/packages/server-core/src/social/invite/invite.hooks.ts
+++ b/packages/server-core/src/social/invite/invite.hooks.ts
@@ -38,7 +38,7 @@ export default {
     create: [authenticate(), attachOwnerIdInBody('userId')],
     update: [iff(isProvider('external'), authenticate() as any, restrictUserRole('admin') as any)],
     patch: [iff(isProvider('external'), authenticate() as any, restrictUserRole('admin') as any)],
-    remove: [authenticate(), inviteRemoveAuthenticate()]
+    remove: [authenticate(), iff(isProvider('external'), inviteRemoveAuthenticate() as any)]
   },
 
   after: {

--- a/packages/server-core/src/social/invite/invite.service.ts
+++ b/packages/server-core/src/social/invite/invite.service.ts
@@ -17,7 +17,8 @@ declare module '@xrengine/common/declarations' {
 export default (app: Application) => {
   const options = {
     Model: createModel(app),
-    paginate: app.get('paginate')
+    paginate: app.get('paginate'),
+    multi: true
   }
 
   /**

--- a/packages/server-core/src/social/party/party.class.ts
+++ b/packages/server-core/src/social/party/party.class.ts
@@ -117,6 +117,7 @@ export class Party<T = PartyDataType> extends Service<T> {
         }
       })
 
+      console.log('existingPartyUsers', existingPartyUsers.data)
       await Promise.all(
         existingPartyUsers.data.map(
           (partyUser) =>
@@ -158,8 +159,20 @@ export class Party<T = PartyDataType> extends Service<T> {
         }
       })
     ).data
+    if (!params!.skipPartyUserDelete)
+      await Promise.all(
+        partyUsers.map(async (partyUser) =>
+          this.app.service('party-user').remove(partyUser.id, { skipPartyDelete: true })
+        )
+      )
     const removedParty = (await super.remove(id)) as T
     ;(removedParty as any).party_users = partyUsers
+    await this.app.service('invite').remove(null!, {
+      query: {
+        inviteType: 'party',
+        targetObjectId: id
+      }
+    })
     return removedParty
   }
 }

--- a/packages/server-core/src/social/party/party.service.ts
+++ b/packages/server-core/src/social/party/party.service.ts
@@ -60,7 +60,6 @@ export default (app: Application): void => {
     if (data.party_users) {
       const targetIds = data.party_users.map((partyUser) => partyUser.userId) || []
 
-      await Promise.all(data.party_users.map((partyUser) => app.service('party-user').emit('removed', partyUser)))
       return Promise.all(
         targetIds.map((userId: string) => {
           return app.channel(`userIds/${userId}`).send({ party: data })


### PR DESCRIPTION
## Summary

Refactored MediaInstanceState.acceptingPartyInvite to joiningNonInstanceMediaChannel.
This serves a similar purpose of recording when a user is leaving one party to join
another, so that leaving the first party's media server won't provision the instance
channel's media server. acceptingPartyInvite was being set to false too early in some
situations - this doesn't get cleared until the media server has been connected to.

Updated UserMediaWindows to use userState.channelLayerUsers when connected to a party.
This was always using layerUsers before, which wouldn't render windows for party
members in other location instances. Added useEffect to fetch channelLayerUsers when
its updateNeeded is true. Fixed getLayerUsers so it will make proper request for
channel users when fetching channelLayerUsers.

Added a crown icon next to the party owner.

Updated party user patch handler to recalculate whether the receiving user is now
the party owner, and patch party state accordingly.

Updated partyUser.remove and party.remove to remove duplicated messages. Previously,
party.remove would emit a party-user remove for each party-user but would rely on
party/party-user foreign key association to delete party users. Now, party.remove
will call party-user.remove on each party-user unless told not to, and party-user.remove
will call party.remove unless told not to; each handler, if the first to be called,
will tell the other to not remove anything else to prevent recursion.

Added toast notifications for other party users leaving, and self/other users joining
a party.

Updated partyUser.remove to delete all invitations to that party.
_A summary of changes being made in this PR_

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

