### PR TITLE
Fixed bugs in screen sharing.

### DIFF
--- a/packages/client-core/src/components/UserMediaWindow/index.tsx
+++ b/packages/client-core/src/components/UserMediaWindow/index.tsx
@@ -13,7 +13,8 @@ import {
   pauseConsumer,
   pauseProducer,
   resumeConsumer,
-  resumeProducer
+  resumeProducer,
+  stopScreenshare
 } from '@xrengine/client-core/src/transports/SocketWebRTCClientFunctions'
 import { getAvatarURLForUser } from '@xrengine/client-core/src/user/components/UserMenu/util'
 import { useAuthState } from '@xrengine/client-core/src/user/services/AuthService'
@@ -138,12 +139,13 @@ export const useUserMediaWindowHook = ({ peerId }) => {
   const closeProducerListener = (producerId: string) => {
     if (producerId === videoStreamRef?.current?.id) {
       videoRef.current?.srcObject?.getVideoTracks()[0].stop()
-      MediaStreams.instance.videoStream.getVideoTracks()[0].stop()
+      if (!isScreen) MediaStreams.instance.videoStream.getVideoTracks()[0].stop()
+      else MediaStreams.instance.localScreen.getVideoTracks()[0].stop
     }
 
     if (producerId === audioStreamRef?.current?.id) {
       audioRef.current?.srcObject?.getAudioTracks()[0].stop()
-      MediaStreams.instance.audioStream.getAudioTracks()[0].stop()
+      if (!isScreen) MediaStreams.instance.audioStream.getAudioTracks()[0].stop()
     }
   }
 
@@ -355,8 +357,8 @@ export const useUserMediaWindowHook = ({ peerId }) => {
       MediaStreamService.updateCamVideoState()
     } else if (peerId === 'screen_me') {
       const videoPaused = MediaStreams.instance.toggleScreenShareVideoPaused()
-      if (videoPaused) await pauseProducer(mediaNetwork, MediaStreams.instance.screenVideoProducer)
-      else await resumeProducer(mediaNetwork, MediaStreams.instance.screenVideoProducer)
+      if (videoPaused) await stopScreenshare(mediaNetwork)
+      // else await resumeProducer(mediaNetwork, MediaStreams.instance.screenVideoProducer)
       setVideoStreamPaused(videoPaused)
       MediaStreamService.updateScreenAudioState()
       MediaStreamService.updateScreenVideoState()

--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -961,7 +961,7 @@ export const startScreenshare = async (network: SocketWebRTCClientNetwork) => {
   MediaStreams.instance.setScreenShareVideoPaused(false)
   MediaStreams.instance.screenVideoProducer = await network.sendTransport.produce({
     track: MediaStreams.instance.localScreen.getVideoTracks()[0],
-    encodings: SCREEN_SHARE_SIMULCAST_ENCODINGS, // TODO: Add me
+    encodings: SCREEN_SHARE_SIMULCAST_ENCODINGS,
     appData: { mediaTag: 'screen-video', channelType: channelType, channelId: channelId }
   })
 

--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -15,7 +15,10 @@ import { EngineActions } from '@xrengine/engine/src/ecs/classes/EngineState'
 import { defineQuery, getComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
 import { NetworkTopics } from '@xrengine/engine/src/networking/classes/Network'
 import { PUBLIC_STUN_SERVERS } from '@xrengine/engine/src/networking/constants/STUNServers'
-import { CAM_VIDEO_SIMULCAST_ENCODINGS } from '@xrengine/engine/src/networking/constants/VideoConstants'
+import {
+  CAM_VIDEO_SIMULCAST_ENCODINGS,
+  SCREEN_SHARE_SIMULCAST_ENCODINGS
+} from '@xrengine/engine/src/networking/constants/VideoConstants'
 import { MessageTypes } from '@xrengine/engine/src/networking/enums/MessageTypes'
 import { NetworkPeerFunctions } from '@xrengine/engine/src/networking/functions/NetworkPeerFunctions'
 import { JoinWorldRequestData, receiveJoinWorld } from '@xrengine/engine/src/networking/functions/receiveJoinWorld'
@@ -955,12 +958,12 @@ export const startScreenshare = async (network: SocketWebRTCClientNetwork) => {
   const channelId = currentChannelInstanceConnection.channelId.value
 
   // create a producer for video
+  MediaStreams.instance.setScreenShareVideoPaused(false)
   MediaStreams.instance.screenVideoProducer = await network.sendTransport.produce({
     track: MediaStreams.instance.localScreen.getVideoTracks()[0],
-    encodings: [], // TODO: Add me
+    encodings: SCREEN_SHARE_SIMULCAST_ENCODINGS, // TODO: Add me
     appData: { mediaTag: 'screen-video', channelType: channelType, channelId: channelId }
   })
-  MediaStreams.instance.setScreenShareVideoPaused(false)
 
   // create a producer for audio, if we have it
   if (MediaStreams.instance.localScreen.getAudioTracks().length) {
@@ -984,6 +987,7 @@ export const startScreenshare = async (network: SocketWebRTCClientNetwork) => {
 export const stopScreenshare = async (network: SocketWebRTCClientNetwork) => {
   logger.info('Screen share stopped')
   await MediaStreams.instance.screenVideoProducer.pause()
+  MediaStreams.instance.setScreenShareVideoPaused(true)
 
   const { error } = await network.request(MessageTypes.WebRTCCloseProducer.toString(), {
     producerId: MediaStreams.instance.screenVideoProducer.id
@@ -993,7 +997,6 @@ export const stopScreenshare = async (network: SocketWebRTCClientNetwork) => {
 
   await MediaStreams.instance.screenVideoProducer.close()
   MediaStreams.instance.screenVideoProducer = null
-  MediaStreams.instance.setScreenShareVideoPaused(true)
 
   if (MediaStreams.instance.screenAudioProducer) {
     const { error: screenAudioProducerError } = await network.request(MessageTypes.WebRTCCloseProducer.toString(), {

--- a/packages/engine/src/networking/constants/VideoConstants.ts
+++ b/packages/engine/src/networking/constants/VideoConstants.ts
@@ -1,4 +1,3 @@
-/** VIDEO_CONSTRAINTS is video quality levels. */
 export const VIDEO_CONSTRAINTS = {
   qvga: { width: { ideal: 320 }, height: { ideal: 240 } },
   vga: { width: { ideal: 640 }, height: { ideal: 480 } },
@@ -6,7 +5,6 @@ export const VIDEO_CONSTRAINTS = {
   fhd: { width: { ideal: 1920 }, height: { ideal: 1080 } }
 }
 
-/** localMediaConstraints is passed to the getUserMedia object to request a lower video quality than the maximum. */
 export const localAudioConstraints: MediaStreamConstraints = {
   audio: {
     autoGainControl: true,
@@ -17,19 +15,19 @@ export const localAudioConstraints: MediaStreamConstraints = {
 
 export const localVideoConstraints: MediaStreamConstraints = {
   video: {
-    width: VIDEO_CONSTRAINTS.hd.width,
-    height: VIDEO_CONSTRAINTS.hd.height,
-    frameRate: { max: 30 }
+    width: VIDEO_CONSTRAINTS.fhd.width,
+    height: VIDEO_CONSTRAINTS.fhd.height,
+    frameRate: { max: 60 }
   }
 }
 
-/**
- * Encodings for outgoing video.\
- * Just two resolutions, for now, as chrome 75 seems to ignore more
- * than two encodings.
- */
 export const CAM_VIDEO_SIMULCAST_ENCODINGS = [
-  { maxBitrate: 36000, scaleResolutionDownBy: 4 },
-  { maxBitrate: 96000, scaleResolutionDownBy: 2 },
-  { maxBitrate: 680000, scaleResolutionDownBy: 1 }
+  { scaleResolutionDownBy: 4, maxBitrate: 500000 },
+  { scaleResolutionDownBy: 2, maxBitrate: 1000000 },
+  { scaleResolutionDownBy: 1, maxBitrate: 100000000 }
+]
+
+export const SCREEN_SHARE_SIMULCAST_ENCODINGS = [
+  { dtx: true, maxBitrate: 1500000 },
+  { dtx: true, maxBitrate: 6000000 }
 ]

--- a/packages/instanceserver/src/WebRTCFunctions.ts
+++ b/packages/instanceserver/src/WebRTCFunctions.ts
@@ -70,7 +70,6 @@ export const sendNewProducer =
   (network: SocketWebRTCServerNetwork, socket: SocketIO.Socket, channelType: string, channelId?: string) =>
   async (producer: Producer): Promise<void> => {
     const userId = getUserIdFromSocketId(network, socket.id)!
-    const world = Engine.instance.currentWorld
     const selfClient = network.peers.get(userId)!
     if (selfClient?.socketId != null) {
       for (const [, client] of network.peers) {
@@ -237,7 +236,6 @@ export async function closeConsumer(network: SocketWebRTCServerNetwork, consumer
 
   network.consumers = network.consumers.filter((c) => c.id !== consumer.id)
 
-  const world = Engine.instance.currentWorld
   for (const [, client] of network.peers) {
     if (client.socket) {
       client.socket!.emit(MessageTypes.WebRTCCloseConsumer.toString(), consumer.id)
@@ -595,7 +593,6 @@ export async function handleWebRtcSendTrack(network: SocketWebRTCServerNetwork, 
     }
     network.producers?.push(producer)
 
-    const world = Engine.instance.currentWorld
     if (userId && network.peers.has(userId)) {
       network.peers.get(userId)!.media![appData.mediaTag] = {
         paused,
@@ -833,7 +830,6 @@ export async function handleWebRtcPauseProducer(
   callback
 ): Promise<any> {
   const userId = getUserIdFromSocketId(network, socket.id)
-  const world = Engine.instance.currentWorld
   const { producerId, globalMute } = data
   const producer = network.producers.find((p) => p.id === producerId)
   if (producer) {


### PR DESCRIPTION
## Summary

Consumer cycling of screenshare video was due to very low framerate.
This was caused by not setting dtx: true on screenshare producer encodings.

Fixed some issues in order of screenshareVideoPaused being set.

Fixed bug where UserMediaWindow screenshare pause being clicked was
pausing camVideo.

_A summary of changes being made in this PR_


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

