### PR TITLE
Fixed a bug with restarting user video.

### DIFF
--- a/packages/instanceserver/src/WebRTCFunctions.ts
+++ b/packages/instanceserver/src/WebRTCFunctions.ts
@@ -840,13 +840,11 @@ export async function handleWebRtcPauseProducer(
     if (userId && network.peers.has(userId) && network.peers.get(userId)!.media![producer.appData.mediaTag as any]) {
       network.peers.get(userId)!.media![producer.appData.mediaTag as any].paused = true
       network.peers.get(userId)!.media![producer.appData.mediaTag as any].globalMute = globalMute || false
-      if (globalMute === true) {
-        const hostClient = Array.from(network.peers.entries()).find(([, client]) => {
-          return client.media && client.media![producer.appData.mediaTag as any]?.producerId === producerId
-        })!
-        if (hostClient && hostClient[1])
-          hostClient[1].socket!.emit(MessageTypes.WebRTCPauseProducer.toString(), producer.id, true)
-      }
+      const hostClient = Array.from(network.peers.entries()).find(([, client]) => {
+        return client.media && client.media![producer.appData.mediaTag as any]?.producerId === producerId
+      })!
+      if (hostClient && hostClient[1])
+        hostClient[1].socket!.emit(MessageTypes.WebRTCPauseProducer.toString(), producer.id, true)
     }
   }
   callback({ paused: true })


### PR DESCRIPTION
## Summary

useEffect watching videoStream.track.id in UserMediaWindow is not firing when a new track
replaces a paused producer's ended video track. For now, made pauseProducer in instanceserver
be emitted to all clients so that self user's handler can act on that to pause videoStream,
which will make resuming it trigger needed updates.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

