### PR TITLE
Fixed a bug in UserMediaWindow with pausing producers.

### DIFF
--- a/packages/client-core/src/components/MediaIconsBox/index.tsx
+++ b/packages/client-core/src/components/MediaIconsBox/index.tsx
@@ -1,20 +1,14 @@
 import React, { useEffect, useState } from 'react'
 
 import { VrIcon } from '@xrengine/client-core/src/common/components/Icons/Vricon'
-import {
-  MediaInstanceConnectionService,
-  useMediaInstanceConnectionState
-} from '@xrengine/client-core/src/common/services/MediaInstanceConnectionService'
+import { useMediaInstanceConnectionState } from '@xrengine/client-core/src/common/services/MediaInstanceConnectionService'
 import { MediaStreamService, useMediaStreamState } from '@xrengine/client-core/src/media/services/MediaStreamService'
-import { useChatState } from '@xrengine/client-core/src/social/services/ChatService'
 import { useLocationState } from '@xrengine/client-core/src/social/services/LocationService'
 import { MediaStreams } from '@xrengine/client-core/src/transports/MediaStreams'
 import {
   configureMediaTransports,
   createCamAudioProducer,
   createCamVideoProducer,
-  endVideoChat,
-  leaveNetwork,
   pauseProducer,
   resumeProducer,
   startScreenshare,
@@ -48,13 +42,6 @@ const MediaIconsBox = (props: Props) => {
   const [hasVideoDevice, setHasVideoDevice] = useState(false)
 
   const user = useAuthState().user
-  const chatState = useChatState()
-  const channelState = chatState.channels
-  const channels = channelState.channels.value
-  const channelEntries = Object.values(channels).filter((channel) => !!channel) as any
-  const instanceChannel = channelEntries.find(
-    (entry) => entry.instanceId === Engine.instance.currentWorld.worldNetwork?.hostId
-  )
   const currentLocation = useLocationState().currentLocation.location
   const channelConnectionState = useMediaInstanceConnectionState()
   const mediaHostId = Engine.instance.currentWorld.mediaNetwork?.hostId

--- a/packages/client-core/src/components/UserMediaWindow/index.module.scss
+++ b/packages/client-core/src/components/UserMediaWindow/index.module.scss
@@ -154,6 +154,14 @@
       width: 24px;
       margin: 0 5px;
 
+      &.mediaOn {
+        color: rgb(122 255 100 / 100%) !important;
+      }
+
+      &.mediaOff {
+        color: red !important;
+      }
+
       svg {
         width: 100%;
         height: 100%;

--- a/packages/client-core/src/components/UserMediaWindow/index.tsx
+++ b/packages/client-core/src/components/UserMediaWindow/index.tsx
@@ -145,10 +145,16 @@ export const useUserMediaWindowHook = ({ peerId }) => {
     } else {
       const network = Engine.instance.currentWorld.mediaNetwork as SocketWebRTCClientNetwork
       const videoConsumer = network.consumers?.find(
-        (c) => c.appData.peerId === userId && c.appData.mediaTag === (isScreen ? 'screen-video' : 'cam-video')
+        (c) =>
+          c.appData.peerId === userId &&
+          c.producerId === producerId &&
+          c.appData.mediaTag === (isScreen ? 'screen-video' : 'cam-video')
       )
       const audioConsumer = network.consumers?.find(
-        (c) => c.appData.peerId === userId && c.appData.mediaTag === (isScreen ? 'screen-audio' : 'cam-audio')
+        (c) =>
+          c.appData.peerId === userId &&
+          c.producerId === producerId &&
+          c.appData.mediaTag === (isScreen ? 'screen-audio' : 'cam-audio')
       )
       if (videoConsumer) {
         ;(videoConsumer as any).producerPaused = true
@@ -634,7 +640,15 @@ const UserMediaWindow = ({ peerId }: Props): JSX.Element => {
             <div className={styles['mute-controls']}>
               {videoStream && !videoProducerPaused ? (
                 <Tooltip title={!videoProducerPaused && !videoStreamPaused ? 'Pause Video' : 'Resume Video'}>
-                  <IconButton size="small" className={styles['icon-button']} onClick={toggleVideo}>
+                  <IconButton
+                    size="small"
+                    className={classNames({
+                      [styles['icon-button']]: true,
+                      [styles.mediaOff]: videoStreamPaused,
+                      [styles.mediaOn]: !videoStreamPaused
+                    })}
+                    onClick={toggleVideo}
+                  >
                     {videoStreamPaused ? <VideocamOff /> : <Videocam />}
                   </IconButton>
                 </Tooltip>
@@ -647,7 +661,15 @@ const UserMediaWindow = ({ peerId }: Props): JSX.Element => {
                       : (t('user:person.unmuteForEveryone') as string)
                   }
                 >
-                  <IconButton size="small" className={styles['icon-button']} onClick={toggleGlobalMute}>
+                  <IconButton
+                    size="small"
+                    className={classNames({
+                      [styles['icon-button']]: true,
+                      [styles.mediaOff]: audioProducerGlobalMute,
+                      [styles.mediaOn]: !audioProducerGlobalMute
+                    })}
+                    onClick={toggleGlobalMute}
+                  >
                     {audioProducerGlobalMute ? <VoiceOverOff /> : <RecordVoiceOver />}
                   </IconButton>
                 </Tooltip>
@@ -664,7 +686,15 @@ const UserMediaWindow = ({ peerId }: Props): JSX.Element => {
                       : t('user:person.unmuteThisPerson')) as string
                   }
                 >
-                  <IconButton size="small" className={styles['icon-button']} onClick={toggleAudio}>
+                  <IconButton
+                    size="small"
+                    className={classNames({
+                      [styles['icon-button']]: true,
+                      [styles.mediaOff]: audioStreamPaused,
+                      [styles.mediaOn]: !audioStreamPaused
+                    })}
+                    onClick={toggleAudio}
+                  >
                     {isSelfUser ? (
                       audioStreamPaused ? (
                         <MicOff />

--- a/packages/client-core/src/user/functions/userPatched.ts
+++ b/packages/client-core/src/user/functions/userPatched.ts
@@ -1,6 +1,7 @@
 import { t } from 'i18next'
 
 import { resolveUser } from '@xrengine/common/src/interfaces/User'
+import { UserId } from '@xrengine/common/src/interfaces/UserId'
 import multiLogger from '@xrengine/common/src/logger'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
 import { WorldState } from '@xrengine/engine/src/networking/interfaces/WorldState'
@@ -35,8 +36,11 @@ export const userPatched = (params) => {
     if (patchedUser.instanceId !== selfUser.instanceId.value) {
       const parsed = new URL(window.location.href)
       let query = parsed.searchParams
-      query.set('instanceId', patchedUser?.instanceId || '')
+      query.set('instanceId', patchedUser.instanceId || '')
       parsed.search = query.toString()
+      if (patchedUser.instanceId && Engine.instance.currentWorld._worldHostId !== patchedUser.instanceId)
+        Engine.instance.currentWorld._worldHostId = Engine.instance.currentWorld.worldNetwork.hostId =
+          patchedUser.instanceId as UserId
 
       if (typeof history.pushState !== 'undefined') {
         window.history.replaceState({}, '', parsed.toString())


### PR DESCRIPTION
## Summary

Pausing self producer was causing all consumers to be paused. pauseProducer listener
needed to check if consumers' producerId matched the ID of the producer being paused.

Added color to paused/active icons in UserMediaWindow. Gray-on-gray was hard to make out.

Attempted to fix a bug where client gets a bad instance provision. ID was getting updated
in URL when user's instanceId was patched, but Engine.instance.currentWorld._worldHostId
was staying on the invalid one. This led to infinite failed attempts to get the channel
since the world instanceId was incorrect. Made patchUser handler update currentWorld's
hostIds when this changes.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

