### PR TITLE
Fixed bugs in instance connections.

### DIFF
--- a/packages/instanceserver/src/channels.ts
+++ b/packages/instanceserver/src/channels.ts
@@ -480,7 +480,7 @@ const handleUserDisconnect = async (
     .catch((err) => {
       logger.warn(err, "Failed to patch user, probably because they don't have an ID yet.")
     })
-  logger.info('Patched disconnecting user to', userPatchResult)
+  logger.info('Patched disconnecting user to %o', userPatchResult)
   await app.service('instance-attendance').patch(
     null,
     {
@@ -499,8 +499,9 @@ const handleUserDisconnect = async (
 
   await new Promise((resolve) => setTimeout(resolve, config.instanceserver.shutdownDelayMs))
 
-  // check if there are no peers connected (1 being the server)
-  if (app.transport.peers.size === 1) await shutdownServer(app, instanceId)
+  // check if there are no peers connected (1 being the server,
+  // 0 if the serer was just starting when someone connected and disconnected)
+  if (app.transport.peers.size <= 1) await shutdownServer(app, instanceId)
 }
 
 const onConnection = (app: Application) => async (connection: SocketIOConnectionType) => {
@@ -562,13 +563,16 @@ const onConnection = (app: Application) => async (connection: SocketIOConnection
    */
   await createOrUpdateInstance(app, status, locationId, channelId, sceneId, userId)
 
-  connection.instanceId = app.instance.id
-  app.channel(`instanceIds/${app.instance.id as string}`).join(connection)
+  if (app.instance) {
+    connection.instanceId = app.instance.id
+    app.channel(`instanceIds/${app.instance.id as string}`).join(connection)
+  }
 
   await handleUserAttendance(app, userId)
 }
 
 const onDisconnection = (app: Application) => async (connection: SocketIOConnectionType) => {
+  logger.info('Disconnection: %o', connection)
   const token = connection.socketQuery?.token
   if (!token) return
 
@@ -590,14 +594,23 @@ const onDisconnection = (app: Application) => async (connection: SocketIOConnect
     const user = await app.service('user').get(userId)
     const instanceId = !config.kubernetes.enabled ? connection.instanceId : app.instance?.id
     let instance
+    logger.info('On disconnect, instanceId: ' + instanceId)
+    logger.info('Disconnecting user instanceId %s channelInstanceId %s: ', user.instanceId, user.channelInstanceId)
+
+    if (!instanceId) {
+      logger.info('No instanceId on user disconnect, waiting one second to see if initial user was connecting')
+      await new Promise((resolve) =>
+        setTimeout(() => {
+          resolve(null)
+        }, 1000)
+      )
+    }
     try {
       instance = app.instance && instanceId != null ? await app.service('instance').get(instanceId) : {}
     } catch (err) {
       logger.warn('Could not get instance, likely because it is a local one that no longer exists.')
     }
-    logger.info('instanceId: ' + instanceId)
-    logger.info('user instanceId: ' + user.instanceId)
-
+    logger.info('instanceId %s instance %o', instanceId, instance)
     if (instanceId != null && instance != null) {
       await handleUserDisconnect(app, connection, user, instanceId)
     }

--- a/packages/server-core/src/networking/instance-provision/instance-provision.class.ts
+++ b/packages/server-core/src/networking/instance-provision/instance-provision.class.ts
@@ -1,4 +1,4 @@
-import { BadRequest } from '@feathersjs/errors'
+import { BadRequest, NotAuthenticated } from '@feathersjs/errors'
 import { Id, NullableId, Params, ServiceMethods } from '@feathersjs/feathers'
 import _ from 'lodash'
 import Sequelize, { Op } from 'sequelize'
@@ -101,13 +101,15 @@ export async function checkForDuplicatedAssignments(
     }
   })
 
+  const duplicateLocationQuery = {
+    assigned: true,
+    ended: false
+  } as any
+
+  if (locationId) duplicateLocationQuery.locationId = locationId
+  if (channelId) duplicateLocationQuery.channelId = channelId
   const duplicateLocationAssignment: any = await app.service('instance').find({
-    query: {
-      locationId: locationId,
-      channelId: channelId,
-      assigned: true,
-      ended: false
-    }
+    query: duplicateLocationQuery
   })
 
   //If there's more than one instance assigned to this IP, then one of them was made in error, possibly because
@@ -344,19 +346,22 @@ export class InstanceProvision implements ServiceMethods<any> {
       const instanceId = params?.query?.instanceId
       const channelId = params?.query?.channelId
       const token = params?.query?.token
+      logger.info('instance-provision find', locationId, instanceId, channelId)
+      if (!token) throw new NotAuthenticated('No token provided')
+      // Check if JWT resolves to a user
+      const authResult = await (this.app.service('authentication') as any).strategies.jwt.authenticate(
+        { accessToken: token },
+        {}
+      )
+      const identityProvider = authResult['identity-provider']
+      if (identityProvider != null) userId = identityProvider.userId
+      else throw new BadRequest('Invalid user credentials')
+
       if (channelId != null) {
-        // Check if JWT resolves to a user
-        if (token != null) {
-          const authResult = await (this.app.service('authentication') as any).strategies.jwt.authenticate(
-            { accessToken: token },
-            {}
-          )
-          const identityProvider = authResult['identity-provider']
-          if (identityProvider != null) {
-            userId = identityProvider.userId
-          } else {
-            throw new BadRequest('Invalid user credentials')
-          }
+        try {
+          await this.app.service('channel').get(channelId)
+        } catch (err) {
+          throw new BadRequest('Invalid channel ID')
         }
         const channelInstance = await this.app.service('instance').Model.findOne({
           where: {
@@ -378,26 +383,9 @@ export class InstanceProvision implements ServiceMethods<any> {
           }
         }
       } else {
-        // Check if JWT resolves to a user
-        if (token != null) {
-          const authResult = await (this.app.service('authentication') as any).strategies.jwt.authenticate(
-            { accessToken: token },
-            {}
-          )
-          const identityProvider = authResult['identity-provider']
-          if (identityProvider != null) {
-            userId = identityProvider.userId
-          } else {
-            throw new BadRequest('Invalid user credentials')
-          }
-        }
-        if (locationId == null) {
-          throw new BadRequest('Missing location ID')
-        }
+        if (locationId == null) throw new BadRequest('Missing location ID')
         const location = await this.app.service('location').get(locationId)
-        if (location == null) {
-          throw new BadRequest('Invalid location ID')
-        }
+        if (location == null) throw new BadRequest('Invalid location ID')
         if (instanceId != null) {
           const instance: any = await this.app.service('instance').get(instanceId)
           if (instance == null || instance.ended === true) return getFreeInstanceserver(this.app, 0, locationId, null!)


### PR DESCRIPTION
## Summary

If a user disconnected right after connecting to a fresh instanceserver, the disconnect logic would
not work properly. Since app.instance had not been set, it would not call handleUserDisconnect.
Added a one-second timeout to wait for possible server startup to resolve with app.instance populated.

Updated check to call shutdownServer on peers.size <= 1. On near-simultaneous connection/disconnection,
the server peer may not have been created, leaving the number of peers 0. Prior check was if it was
exactly 1, which would not be true.

Fixed a bug in instance-provision where calling get(channelId) or get(locationId) wasn't being
try/caught, so if there was no channel, it was throwing an uncaught error.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

