### PR TITLE
Replace lodash upperFirst with existing capitalizeFirstLetter.

### DIFF
--- a/packages/client-core/src/admin/common/AutoComplete.tsx
+++ b/packages/client-core/src/admin/common/AutoComplete.tsx
@@ -1,5 +1,6 @@
-import _ from 'lodash'
 import * as React from 'react'
+
+import capitalizeFirstLetter from '@xrengine/common/src/utils/capitalizeFirstLetter'
 
 import { AutocompleteGetTagProps, useAutocomplete } from '@mui/base/AutocompleteUnstyled'
 import CheckIcon from '@mui/icons-material/Check'
@@ -70,7 +71,7 @@ const AutoComplete = ({ data, label, disabled, onChange, defaultValue = [] }: Pr
               }`}
             >
               <legend>
-                <span>{_.upperFirst(label)}</span>
+                <span>{capitalizeFirstLetter(label)}</span>
               </legend>
             </fieldset>
             {value.map((option: AutoCompleteData, index: number) => (

--- a/packages/client-core/src/admin/common/InputSelect.tsx
+++ b/packages/client-core/src/admin/common/InputSelect.tsx
@@ -1,6 +1,7 @@
-import _ from 'lodash'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
+
+import capitalizeFirstLetter from '@xrengine/common/src/utils/capitalizeFirstLetter'
 
 import Box from '@mui/material/Box'
 import FormControl from '@mui/material/FormControl'
@@ -63,12 +64,12 @@ const InputSelect = ({
           size="small"
           sx={{ flexGrow: 1 }}
         >
-          <InputLabel sx={{ zIndex: 999 }}>{_.upperFirst(label)}</InputLabel>
+          <InputLabel sx={{ zIndex: 999 }}>{capitalizeFirstLetter(label)}</InputLabel>
 
           <Select
             name={name}
             value={value}
-            label={_.upperFirst(label)}
+            label={capitalizeFirstLetter(label)}
             disabled={disabled}
             size={'small'}
             sx={{ opacity: disabled ? 0.38 : 1 }}

--- a/packages/client-core/src/admin/common/InputSwitch.tsx
+++ b/packages/client-core/src/admin/common/InputSwitch.tsx
@@ -1,5 +1,6 @@
-import _ from 'lodash'
 import React from 'react'
+
+import capitalizeFirstLetter from '@xrengine/common/src/utils/capitalizeFirstLetter'
 
 import Box from '@mui/material/Box'
 import FormControlLabel from '@mui/material/FormControlLabel'
@@ -23,7 +24,7 @@ const InputSwitch = ({ className, name, label, checked, disabled, sx, onChange }
     <Box sx={sx}>
       <FormControlLabel
         className={className ?? styles.switchField}
-        label={_.upperFirst(label)}
+        label={capitalizeFirstLetter(label)}
         control={<Switch name={name} checked={checked} disabled={disabled} onChange={onChange} />}
       />
     </Box>

--- a/packages/client-core/src/admin/common/InputText.tsx
+++ b/packages/client-core/src/admin/common/InputText.tsx
@@ -1,6 +1,7 @@
-import _ from 'lodash'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
+
+import capitalizeFirstLetter from '@xrengine/common/src/utils/capitalizeFirstLetter'
 
 import { InputLabel, OutlinedInput } from '@mui/material'
 import Box from '@mui/material/Box'
@@ -55,13 +56,13 @@ const InputText = ({
         disabled={disabled}
         size="small"
       >
-        <InputLabel sx={{ zIndex: 999 }}>{_.upperFirst(label)}</InputLabel>
+        <InputLabel sx={{ zIndex: 999 }}>{capitalizeFirstLetter(label)}</InputLabel>
 
         <OutlinedInput
           name={name}
           type={type}
           placeholder={placeholder}
-          label={_.upperFirst(label)}
+          label={capitalizeFirstLetter(label)}
           value={value}
           error={error ? true : false}
           disabled={disabled}

--- a/packages/client-core/src/admin/components/Bots/CreateBot.tsx
+++ b/packages/client-core/src/admin/components/Bots/CreateBot.tsx
@@ -1,10 +1,10 @@
-import _ from 'lodash'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { v4 as uuidv4 } from 'uuid'
 
 import { BotCommands, CreateBotAsAdmin } from '@xrengine/common/src/interfaces/AdminBot'
 import { Instance } from '@xrengine/common/src/interfaces/Instance'
+import capitalizeFirstLetter from '@xrengine/common/src/utils/capitalizeFirstLetter'
 
 import { Autorenew, Face, Save } from '@mui/icons-material'
 import Button from '@mui/material/Button'
@@ -146,7 +146,7 @@ const CreateBot = () => {
     const { name, value } = e.target
 
     let temp = { ...formErrors }
-    temp[name] = value.length < 2 ? `${_.upperFirst(name)} is required` : ''
+    temp[name] = value.length < 2 ? `${capitalizeFirstLetter(name)} is required` : ''
     setFormErrors(temp)
     setState({ ...state, [name]: value })
   }

--- a/packages/client-core/src/admin/components/Setting/ClientTheme/ColorSelectionArea.tsx
+++ b/packages/client-core/src/admin/components/Setting/ClientTheme/ColorSelectionArea.tsx
@@ -1,8 +1,8 @@
-import _ from 'lodash'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ThemeOptions } from '@xrengine/common/src/interfaces/ClientSetting'
+import capitalizeFirstLetter from '@xrengine/common/src/utils/capitalizeFirstLetter'
 
 import { Divider, Grid } from '@mui/material'
 
@@ -24,7 +24,7 @@ const ColorSelectionArea = ({ mode, colorModes, theme, onChangeMode, onChangeCol
 
   const colorModesMenu: InputMenuItem[] = colorModes.map((el) => {
     return {
-      label: _.upperFirst(el),
+      label: capitalizeFirstLetter(el),
       value: el
     }
   })

--- a/packages/client-core/src/admin/components/Setting/ClientTheme/ThemeSelectionArea.tsx
+++ b/packages/client-core/src/admin/components/Setting/ClientTheme/ThemeSelectionArea.tsx
@@ -1,8 +1,8 @@
-import _ from 'lodash'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ThemeMode } from '@xrengine/common/src/interfaces/ClientSetting'
+import capitalizeFirstLetter from '@xrengine/common/src/utils/capitalizeFirstLetter'
 
 import { Grid, Typography } from '@mui/material'
 
@@ -20,7 +20,7 @@ const ThemeSelectionArea = ({ themeModes, colorModes, onChangeThemeMode }: Theme
 
   const colorModesMenu: InputMenuItem[] = colorModes.map((el) => {
     return {
-      label: _.upperFirst(el),
+      label: capitalizeFirstLetter(el),
       value: el
     }
   })

--- a/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
@@ -1,7 +1,6 @@
 import { Ed25519Signature2020 } from '@digitalcredentials/ed25519-signature-2020'
 import { useHookstate } from '@hookstate/core'
 import * as polyfill from 'credential-handler-polyfill'
-import _ from 'lodash'
 import React, { useEffect, useState } from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { useTranslation } from 'react-i18next'
@@ -11,6 +10,7 @@ import { validateEmail, validatePhoneNumber } from '@xrengine/common/src/config'
 import { defaultThemeModes, defaultThemeSettings } from '@xrengine/common/src/constants/DefaultThemeSettings'
 import { generateDid, IKeyPairDescription, issueCredential } from '@xrengine/common/src/identity'
 import multiLogger from '@xrengine/common/src/logger'
+import capitalizeFirstLetter from '@xrengine/common/src/utils/capitalizeFirstLetter'
 import { AudioEffectPlayer } from '@xrengine/engine/src/audio/systems/AudioSystem'
 import { WorldState } from '@xrengine/engine/src/networking/interfaces/WorldState'
 import { getState } from '@xrengine/hyperflux'
@@ -99,7 +99,7 @@ const ProfileMenu = ({ className, hideLogin, isPopover, changeActiveMenu, onClos
 
   const colorModesMenu: InputMenuItem[] = Object.keys(themeSettings).map((el) => {
     return {
-      label: _.upperFirst(el),
+      label: capitalizeFirstLetter(el),
       value: el
     }
   })

--- a/packages/common/src/utils/capitalizeFirstLetter.ts
+++ b/packages/common/src/utils/capitalizeFirstLetter.ts
@@ -1,4 +1,11 @@
-function capitalizeFirstLetter(string: string): string {
+/**
+ * Capitalizes first letter of a string.
+ * Replacement for `_.upperFirst()`
+ * @param string
+ */
+export default function capitalizeFirstLetter(string?: string): string {
+  if (!string) {
+    return ''
+  }
   return string.charAt(0).toUpperCase() + string.slice(1)
 }
-export default capitalizeFirstLetter

--- a/packages/common/tests/utils/guessContentType.test.ts
+++ b/packages/common/tests/utils/guessContentType.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 
-import { guessContentType } from './guessContentType'
+import { guessContentType } from '../../src/utils/guessContentType'
 
 describe('guessContentType', () => {
   it('guessContentType', () => {


### PR DESCRIPTION
Minor/warmup refactoring - replacing usage of `lodash.upperFirst` with our own `capitalizeFirstLetter` (which is used through most of the engine).