### PR TITLE
Fixed select dropdown theme in Editor

### DIFF
--- a/packages/editor/src/components/inputs/SelectInput.tsx
+++ b/packages/editor/src/components/inputs/SelectInput.tsx
@@ -111,7 +111,15 @@ export function SelectInput({
           icon: styles.icon
         }}
         disabled={disabled}
-        MenuProps={{ classes: { paper: styles.paper } }}
+        MenuProps={{
+          classes: { paper: styles.paper },
+          sx: {
+            // https://stackoverflow.com/a/69403132/2077741
+            '&& .Mui-selected': {
+              backgroundColor: 'var(--dropdownMenuSelectedBackground)'
+            }
+          }
+        }}
         IconComponent={ExpandMoreIcon}
       >
         {options.map((el, index) => (


### PR DESCRIPTION
## Summary

Fixed issue when a select dropdown is opened in editor, the initial selected value background doesn't match the theme.


## References

closes #6629


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

