### PR TITLE
Reduce heap memory

### DIFF
--- a/packages/client-core/src/admin/components/Users/UserDrawer.tsx
+++ b/packages/client-core/src/admin/components/Users/UserDrawer.tsx
@@ -106,7 +106,7 @@ const UserDrawer = ({ open, mode, selectedUser, onClose }: Props) => {
         ...defaultState,
         name: selectedUser.name || '',
         avatar: selectedUser.avatarId || '',
-        isGuest: selectedUser.isGuest || true,
+        isGuest: selectedUser.isGuest,
         scopes: selectedUser.scopes?.map((el) => ({ type: el.type })) || []
       })
     }

--- a/packages/editor/src/components/inputs/SelectInput.tsx
+++ b/packages/editor/src/components/inputs/SelectInput.tsx
@@ -111,7 +111,15 @@ export function SelectInput({
           icon: styles.icon
         }}
         disabled={disabled}
-        MenuProps={{ classes: { paper: styles.paper } }}
+        MenuProps={{
+          classes: { paper: styles.paper },
+          sx: {
+            // https://stackoverflow.com/a/69403132/2077741
+            '&& .Mui-selected': {
+              backgroundColor: 'var(--dropdownMenuSelectedBackground)'
+            }
+          }
+        }}
         IconComponent={ExpandMoreIcon}
       >
         {options.map((el, index) => (

--- a/packages/engine/src/assets/classes/AssetLoader.ts
+++ b/packages/engine/src/assets/classes/AssetLoader.ts
@@ -272,15 +272,12 @@ const assetLoadCallback = (url: string, assetType: AssetType, onLoad: (response:
     AssetLoader.processModelAsset(asset.scene)
   }
 
-  if (assetClass !== AssetClass.Asset) {
-    AssetLoader.Cache.set(url, asset)
-  }
   onLoad(asset)
 }
 
 const getAbsolutePath = (url) => (isAbsolutePath(url) ? url : Engine.instance.publicPath + url)
 
-const load = async (
+const load = (
   _url: string,
   onLoad = (response: any) => {},
   onProgress = (request: ProgressEvent) => {},
@@ -292,10 +289,6 @@ const load = async (
   }
   const url = getAbsolutePath(_url)
 
-  if (AssetLoader.Cache.has(url)) {
-    onLoad(AssetLoader.Cache.get(url))
-  }
-
   const assetType = AssetLoader.getAssetType(url)
   const loader = getLoader(assetType)
   const callback = assetLoadCallback(url, assetType, onLoad)
@@ -305,7 +298,7 @@ const load = async (
     // if (instanced) {
     //   ;(loader as GLTFLoader).parse(await instanceGLTF(url), null!, callback, onError)
     // } else {
-    loader.load(url, callback, onProgress, onError)
+    return loader.load(url, callback, onProgress, onError)
     // }
   } catch (error) {
     onError(error)
@@ -318,13 +311,7 @@ const loadAsync = async (url: string, onProgress = (request: ProgressEvent) => {
   })
 }
 
-// TODO: we are replciating code here, we should refactor AssetLoader to be entirely functional
-const getFromCache = (url: string) => {
-  return AssetLoader.Cache.get(getAbsolutePath(url))
-}
-
 export const AssetLoader = {
-  Cache: new Map<string, any>(),
   loaders: new Map<number, any>(),
   processModelAsset,
   handleLODs,
@@ -335,6 +322,5 @@ export const AssetLoader = {
   getLoader,
   assetLoadCallback,
   load,
-  loadAsync,
-  getFromCache
+  loadAsync
 }

--- a/packages/engine/src/assets/loaders/fbx/FBXLoader.js
+++ b/packages/engine/src/assets/loaders/fbx/FBXLoader.js
@@ -89,6 +89,10 @@ class FBXLoader extends Loader {
 			try {
 
 				onLoad( scope.parse( buffer, path ) );
+				// cleanup memory
+				fbxTree = undefined
+				connections = undefined
+				sceneGraph = undefined
 
 			} catch ( e ) {
 

--- a/packages/engine/src/avatar/functions/avatarFunctions.ts
+++ b/packages/engine/src/avatar/functions/avatarFunctions.ts
@@ -222,9 +222,9 @@ export const setupAvatarHeight = (entity: Entity, model: Object3D) => {
   resizeAvatar(entity, tempVec3ForHeight.y, tempVec3ForCenter)
 }
 
-export const loadGrowingEffectObject = (entity: Entity, originalMatList: Array<MaterialMap>) => {
-  const textureLight = AssetLoader.getFromCache('/itemLight.png')
-  const texturePlate = AssetLoader.getFromCache('/itemPlate.png')
+export const loadGrowingEffectObject = async (entity: Entity, originalMatList: Array<MaterialMap>) => {
+  const textureLight = await AssetLoader.loadAsync('/itemLight.png')
+  const texturePlate = await AssetLoader.loadAsync('/itemPlate.png')
 
   const lightMesh = new Mesh(
     new PlaneGeometry(0.04, 3.2),

--- a/packages/engine/src/avatar/functions/getInteractiveIsInReachDistance.ts
+++ b/packages/engine/src/avatar/functions/getInteractiveIsInReachDistance.ts
@@ -6,7 +6,7 @@ import { getComponent } from '../../ecs/functions/ComponentFunctions'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { getHandPosition, isInXR } from '../../xr/XRFunctions'
 
-export const interactiveReachDistance = 2
+export const interactiveReachDistance = 3
 export const interactiveReachDistanceVR = 2
 
 export const getInteractiveIsInReachDistance = (

--- a/packages/engine/src/debug/systems/DebugHelpersSystem.ts
+++ b/packages/engine/src/debug/systems/DebugHelpersSystem.ts
@@ -1,6 +1,7 @@
 import {
   ArrowHelper,
   Box3Helper,
+  CameraHelper,
   Color,
   ConeBufferGeometry,
   DoubleSide,
@@ -8,14 +9,14 @@ import {
   Mesh,
   MeshBasicMaterial,
   Object3D,
+  PerspectiveCamera,
   Quaternion,
   Vector3
 } from 'three'
 
-import { createActionQueue } from '@xrengine/hyperflux'
+import { createActionQueue, getState } from '@xrengine/hyperflux'
 
 import { AudioComponent } from '../../audio/components/AudioComponent'
-import { PositionalAudioTagComponent } from '../../audio/components/PositionalAudioTagComponent'
 import { AudioElementNodes } from '../../audio/systems/AudioSystem'
 import { AvatarComponent } from '../../avatar/components/AvatarComponent'
 import { Engine } from '../../ecs/classes/Engine'
@@ -23,16 +24,19 @@ import { Entity } from '../../ecs/classes/Entity'
 import { World } from '../../ecs/classes/World'
 import { defineQuery, getComponent } from '../../ecs/functions/ComponentFunctions'
 import { BoundingBoxComponent } from '../../interaction/components/BoundingBoxComponent'
+import { InteractorComponent } from '../../interaction/components/InteractorComponent'
 import { NavMeshComponent } from '../../navigation/component/NavMeshComponent'
 import { createGraphHelper } from '../../navigation/GraphHelper'
 import { createConvexRegionHelper } from '../../navigation/NavMeshHelper'
 import { VelocityComponent } from '../../physics/components/VelocityComponent'
-import { accessEngineRendererState, EngineRendererAction } from '../../renderer/EngineRendererState'
+import {
+  accessEngineRendererState,
+  EngineRendererAction,
+  EngineRendererState
+} from '../../renderer/EngineRendererState'
 import InfiniteGridHelper from '../../scene/classes/InfiniteGridHelper'
-import { MediaComponent } from '../../scene/components/MediaComponent'
 import { MediaElementComponent } from '../../scene/components/MediaElementComponent'
 import { Object3DComponent } from '../../scene/components/Object3DComponent'
-import { addIsHelperFlag } from '../../scene/functions/addIsHelperFlag'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { XRInputSourceComponent } from '../../xr/XRComponents'
 import { DebugArrowComponent } from '../DebugArrowComponent'
@@ -60,7 +64,8 @@ export default async function DebugHelpersSystem(world: World) {
     velocityArrow: new Map(),
     navmesh: new Map(),
     navpath: new Map(),
-    positionalAudioHelper: new Map()
+    positionalAudioHelper: new Map(),
+    interactorFrustum: new Map()
   }
 
   const avatarDebugQuery = defineQuery([AvatarComponent, VelocityComponent, TransformComponent])
@@ -70,6 +75,7 @@ export default async function DebugHelpersSystem(world: World) {
   const navmeshQuery = defineQuery([DebugNavMeshComponent, NavMeshComponent])
   // const navpathQuery = defineQuery([AutoPilotComponent])
   const audioHelper = defineQuery([AudioComponent])
+  const interactorQuery = defineQuery([InteractorComponent])
   // const navpathAddQuery = enterQuery(navpathQuery)
   // const navpathRemoveQuery = exitQuery(navpathQuery)
 
@@ -78,6 +84,9 @@ export default async function DebugHelpersSystem(world: World) {
       obj.visible = avatarDebugEnable
     })
     helpersByEntity.velocityArrow.forEach((obj: Object3D) => {
+      obj.visible = avatarDebugEnable
+    })
+    helpersByEntity.interactorFrustum.forEach((obj: Object3D) => {
       obj.visible = avatarDebugEnable
     })
     helpersByEntity.ikExtents.forEach((entry: Object3D[]) => {
@@ -101,6 +110,7 @@ export default async function DebugHelpersSystem(world: World) {
   return () => {
     for (const action of physicsDebugActionQueue()) physicsDebugUpdate(action.physicsDebugEnable)
     for (const action of avatarDebugActionQueue()) avatarDebugUpdate(action.avatarDebugEnable)
+    const debugEnabled = getState(EngineRendererState).avatarDebugEnable.value
 
     // ===== AVATAR ===== //
 
@@ -120,19 +130,20 @@ export default async function DebugHelpersSystem(world: World) {
       helpersByEntity.velocityArrow.delete(entity)
     }
 
-    for (const entity of avatarDebugQuery()) {
-      const avatar = getComponent(entity, AvatarComponent)
-      const velocity = getComponent(entity, VelocityComponent)
-      const transform = getComponent(entity, TransformComponent)
+    if (debugEnabled)
+      for (const entity of avatarDebugQuery()) {
+        const avatar = getComponent(entity, AvatarComponent)
+        const velocity = getComponent(entity, VelocityComponent)
+        const transform = getComponent(entity, TransformComponent)
 
-      // velocity
-      const velocityArrowHelper = helpersByEntity.velocityArrow.get(entity) as ArrowHelper
-      if (velocityArrowHelper != null) {
-        velocityArrowHelper.setDirection(vector3.copy(velocity.linear).normalize())
-        velocityArrowHelper.setLength(velocity.linear.length() * 20)
-        velocityArrowHelper.position.copy(transform.position).y += avatar.avatarHalfHeight
+        // velocity
+        const velocityArrowHelper = helpersByEntity.velocityArrow.get(entity) as ArrowHelper
+        if (velocityArrowHelper != null) {
+          velocityArrowHelper.setDirection(vector3.copy(velocity.linear).normalize())
+          velocityArrowHelper.setLength(velocity.linear.length() * 20)
+          velocityArrowHelper.position.copy(transform.position).y += avatar.avatarHalfHeight
+        }
       }
-    }
 
     for (const entity of ikAvatarQuery.enter()) {
       const engineRendererState = accessEngineRendererState()
@@ -148,16 +159,17 @@ export default async function DebugHelpersSystem(world: World) {
       helpersByEntity.ikExtents.set(entity, [debugHead, debugLeft, debugRight])
     }
 
-    for (const entity of ikAvatarQuery()) {
-      const xrInputSourceComponent = getComponent(entity, XRInputSourceComponent)
-      const [debugHead, debugLeft, debugRight] = helpersByEntity.ikExtents.get(entity) as Object3D[]
-      debugHead.position.copy(xrInputSourceComponent.head.getWorldPosition(vector3))
-      debugHead.quaternion.copy(xrInputSourceComponent.head.getWorldQuaternion(quat))
-      debugLeft.position.copy(xrInputSourceComponent.controllerLeft.getWorldPosition(vector3))
-      debugLeft.quaternion.copy(xrInputSourceComponent.controllerLeft.getWorldQuaternion(quat))
-      debugRight.position.copy(xrInputSourceComponent.controllerRight.getWorldPosition(vector3))
-      debugRight.quaternion.copy(xrInputSourceComponent.controllerRight.getWorldQuaternion(quat))
-    }
+    if (debugEnabled)
+      for (const entity of ikAvatarQuery()) {
+        const xrInputSourceComponent = getComponent(entity, XRInputSourceComponent)
+        const [debugHead, debugLeft, debugRight] = helpersByEntity.ikExtents.get(entity) as Object3D[]
+        debugHead.position.copy(xrInputSourceComponent.head.getWorldPosition(vector3))
+        debugHead.quaternion.copy(xrInputSourceComponent.head.getWorldQuaternion(quat))
+        debugLeft.position.copy(xrInputSourceComponent.controllerLeft.getWorldPosition(vector3))
+        debugLeft.quaternion.copy(xrInputSourceComponent.controllerLeft.getWorldQuaternion(quat))
+        debugRight.position.copy(xrInputSourceComponent.controllerRight.getWorldPosition(vector3))
+        debugRight.quaternion.copy(xrInputSourceComponent.controllerRight.getWorldQuaternion(quat))
+      }
 
     for (const entity of ikAvatarQuery.exit()) {
       ;(helpersByEntity.ikExtents.get(entity) as Object3D[]).forEach((obj: Object3D) => {
@@ -184,29 +196,29 @@ export default async function DebugHelpersSystem(world: World) {
 
     // ===== CUSTOM ===== //
 
-    for (const entity of arrowHelperQuery.enter()) {
-      const arrow = getComponent(entity, DebugArrowComponent)
-      const arrowHelper = new ArrowHelper(new Vector3(), new Vector3(0, 0, 0), 0.5, arrow.color)
-      arrowHelper.visible = accessEngineRendererState().physicsDebugEnable.value
-      Engine.instance.currentWorld.scene.add(arrowHelper)
-      helpersByEntity.helperArrow.set(entity, arrowHelper)
-    }
+    // for (const entity of arrowHelperQuery.enter()) {
+    //   const arrow = getComponent(entity, DebugArrowComponent)
+    //   const arrowHelper = new ArrowHelper(new Vector3(), new Vector3(0, 0, 0), 0.5, arrow.color)
+    //   arrowHelper.visible = accessEngineRendererState().physicsDebugEnable.value
+    //   Engine.instance.currentWorld.scene.add(arrowHelper)
+    //   helpersByEntity.helperArrow.set(entity, arrowHelper)
+    // }
 
-    for (const entity of arrowHelperQuery.exit()) {
-      const arrowHelper = helpersByEntity.helperArrow.get(entity) as Object3D
-      Engine.instance.currentWorld.scene.remove(arrowHelper)
-      helpersByEntity.helperArrow.delete(entity)
-    }
+    // for (const entity of arrowHelperQuery.exit()) {
+    //   const arrowHelper = helpersByEntity.helperArrow.get(entity) as Object3D
+    //   Engine.instance.currentWorld.scene.remove(arrowHelper)
+    //   helpersByEntity.helperArrow.delete(entity)
+    // }
 
-    for (const entity of arrowHelperQuery()) {
-      const arrow = getComponent(entity, DebugArrowComponent)
-      const arrowHelper = helpersByEntity.helperArrow.get(entity) as ArrowHelper
-      if (arrowHelper != null) {
-        arrowHelper.setDirection(arrow.direction.clone().normalize())
-        arrowHelper.setLength(arrow.direction.length())
-        arrowHelper.position.copy(arrow.position)
-      }
-    }
+    // if(debugEnabled)
+    //   for (const entity of arrowHelperQuery()) {
+    //     const arrow = getComponent(entity, DebugArrowComponent)
+    //     const arrowHelper = helpersByEntity.helperArrow.get(entity) as ArrowHelper
+    //     if (arrowHelper != null) {
+    //       arrowHelper.setDirection(arrow.direction.clone().normalize())
+    //       arrowHelper.position.copy(arrow.position)
+    //     }
+    //   }
 
     // ===== NAVMESH Helper ===== //
     for (const entity of navmeshQuery.enter()) {
@@ -221,20 +233,49 @@ export default async function DebugHelpersSystem(world: World) {
       Engine.instance.currentWorld.scene.add(helper)
       helpersByEntity.navmesh.set(entity, helper)
     }
-    for (const entity of navmeshQuery()) {
-      // update
-      const helper = helpersByEntity.navmesh.get(entity) as Object3D
-      const transform = getComponent(entity, TransformComponent)
-      helper.position.copy(transform.position)
-      // helper.quaternion.copy(transform.rotation)
-    }
+
     for (const entity of navmeshQuery.exit()) {
       const helper = helpersByEntity.navmesh.get(entity) as Object3D
       Engine.instance.currentWorld.scene.remove(helper)
       helpersByEntity.navmesh.delete(entity)
     }
+
+    if (debugEnabled)
+      for (const entity of navmeshQuery()) {
+        // update
+        const helper = helpersByEntity.navmesh.get(entity) as Object3D
+        const transform = getComponent(entity, TransformComponent)
+        helper.position.copy(transform.position)
+        // helper.quaternion.copy(transform.rotation)
+      }
     // ===== Autopilot Helper ===== //
     // TODO add createPathHelper for navpathQuery
+
+    for (const entity of interactorQuery.enter()) {
+      const interactor = getComponent(entity, InteractorComponent)
+      const helper = new CameraHelper(
+        getComponent(interactor.frustumCameraEntity, Object3DComponent).value as PerspectiveCamera
+      )
+      helpersByEntity.interactorFrustum.set(entity, helper)
+      Engine.instance.currentWorld.scene.add(helper)
+      helper.userData.isHelper = true
+      helper.visible = false
+    }
+
+    for (const entity of interactorQuery.exit()) {
+      const helper = helpersByEntity.interactorFrustum.get(entity)
+      Engine.instance.currentWorld.scene.remove(helper)
+      helpersByEntity.interactorFrustum.delete(entity)
+    }
+
+    if (debugEnabled)
+      for (const entity of interactorQuery()) {
+        const interactor = getComponent(entity, InteractorComponent)
+        const helper = helpersByEntity.interactorFrustum.get(entity) as CameraHelper
+        helper.matrix.copy(
+          (getComponent(interactor.frustumCameraEntity, Object3DComponent).value as PerspectiveCamera).matrix
+        )
+      }
 
     // todo refactor this
     if (Engine.instance.isEditor) {
@@ -246,22 +287,23 @@ export default async function DebugHelpersSystem(world: World) {
         helpersByEntity.positionalAudioHelper.delete(entity)
       }
 
-      for (const entity of audioHelper()) {
-        const obj3d = getComponent(entity, Object3DComponent)
-        const mediaComponent = getComponent(entity, MediaElementComponent)
-        const audioEl = AudioElementNodes.get(mediaComponent)!
+      if (debugEnabled)
+        for (const entity of audioHelper()) {
+          const obj3d = getComponent(entity, Object3DComponent)
+          const mediaComponent = getComponent(entity, MediaElementComponent)
+          const audioEl = AudioElementNodes.get(mediaComponent)!
 
-        if (!helpersByEntity.positionalAudioHelper.has(entity)) {
-          const helper = new PositionalAudioHelper(audioEl)
-          // helper.visible = false
-          helpersByEntity.positionalAudioHelper.set(entity, helper)
-          obj3d.value.add(helper)
-          helper.userData.isHelper = true
+          if (!helpersByEntity.positionalAudioHelper.has(entity)) {
+            const helper = new PositionalAudioHelper(audioEl)
+            // helper.visible = false
+            helpersByEntity.positionalAudioHelper.set(entity, helper)
+            obj3d.value.add(helper)
+            helper.userData.isHelper = true
+          }
+
+          const helper = helpersByEntity.positionalAudioHelper.get(entity)
+          audioEl.panner && helper?.update()
         }
-
-        const helper = helpersByEntity.positionalAudioHelper.get(entity)
-        audioEl.panner && helper?.update()
-      }
     }
 
     physicsDebugRenderer(world, accessEngineRendererState().physicsDebugEnable.value)

--- a/packages/engine/src/interaction/components/InteractorComponent.ts
+++ b/packages/engine/src/interaction/components/InteractorComponent.ts
@@ -1,11 +1,9 @@
-import { PerspectiveCamera } from 'three'
-
 import { Entity } from '../../ecs/classes/Entity'
 import { createMappedComponent } from '../../ecs/functions/ComponentFunctions'
 
 export type InteractorComponentType = {
   focusedInteractive: Entity | null
-  frustumCamera: PerspectiveCamera
+  frustumCameraEntity: Entity
   subFocusedArray: Entity[]
 }
 

--- a/packages/engine/src/interaction/functions/interactBoxRaycast.ts
+++ b/packages/engine/src/interaction/functions/interactBoxRaycast.ts
@@ -1,16 +1,15 @@
-import { Frustum, Matrix4 } from 'three'
+import { Frustum, Matrix4, PerspectiveCamera, Vector3 } from 'three'
 
 import { getEngineState } from '@xrengine/engine/src/ecs/classes/EngineState'
 import { dispatchAction } from '@xrengine/hyperflux'
 
 import { AvatarControllerComponent } from '../../avatar/components/AvatarControllerComponent'
-import { interactiveReachDistance } from '../../avatar/functions/getInteractiveIsInReachDistance'
 import { EngineActions } from '../../ecs/classes/EngineState'
 import { Entity } from '../../ecs/classes/Entity'
 import { getComponent } from '../../ecs/functions/ComponentFunctions'
+import { Object3DComponent } from '../../scene/components/Object3DComponent'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { BoundingBoxComponent } from '../components/BoundingBoxComponent'
-import { InteractableComponent } from '../components/InteractableComponent'
 import { InteractorComponent } from '../components/InteractorComponent'
 
 const mat4 = new Matrix4()
@@ -24,7 +23,7 @@ const projectionMatrix = new Matrix4().makePerspective(
 )
 const frustum = new Frustum()
 
-type RaycastResult = [Entity, boolean, number]
+const distanceSort = (a: any, b: any) => a[1] - b[1]
 
 /**
  * Checks if entity can interact with any of entities listed in 'interactive' array, checking distance, guards and raycast
@@ -40,47 +39,28 @@ export const interactBoxRaycast = (entity: Entity, raycastList: Entity[]) => {
 
   if (!controller || !interactor || !raycastList.length) return
 
-  // todo: add avatar's local head position to this calculation so its calculated from the head instead of the feet
+  const frustumCamera = getComponent(interactor.frustumCameraEntity, Object3DComponent).value as PerspectiveCamera
 
-  interactor.frustumCamera.updateMatrixWorld()
-  interactor.frustumCamera.matrixWorldInverse.copy(interactor.frustumCamera.matrixWorld).invert()
+  frustumCamera.updateMatrixWorld()
+  frustumCamera.matrixWorldInverse.copy(frustumCamera.matrixWorld).invert()
 
-  mat4.multiplyMatrices(projectionMatrix, interactor.frustumCamera.matrixWorldInverse)
+  mat4.multiplyMatrices(projectionMatrix, frustumCamera.matrixWorldInverse)
   frustum.setFromProjectionMatrix(mat4)
 
-  const subFocusedArray = raycastList
-    .map((entityIn): RaycastResult => {
-      const boundingBox = getComponent(entityIn, BoundingBoxComponent)
-      if (!boundingBox?.box) return [entityIn, false, 0]
-      return [entityIn, frustum.intersectsBox(boundingBox.box), boundingBox.box.distanceToPoint(transform.position)]
-    })
-    .filter((value) => value[1])
+  const subFocusedArray = [] as [Entity, number][]
 
-  if (!subFocusedArray.length) {
-    interactor.subFocusedArray = []
+  for (const entityIn of raycastList) {
+    const boundingBox = getComponent(entityIn, BoundingBoxComponent)
+    if (boundingBox?.box && frustum.intersectsBox(boundingBox.box)) {
+      subFocusedArray.push([entityIn, boundingBox.box.distanceToPoint(transform.position)])
+    }
   }
 
   interactor.subFocusedArray = subFocusedArray.map((v) => v[0])
 
-  let focussed = interactor.focusedInteractive
-  if (!focussed && subFocusedArray.length) {
-    const [entityInteractable, doesIntersectFrustrum, distanceToInteractor] = subFocusedArray.sort(
-      (a: any, b: any) => a[2] - b[2]
-    )[0]
+  const focussed = subFocusedArray.length && subFocusedArray.sort(distanceSort)[0][0]
 
-    focussed = entityInteractable
-  }
-
-  let resultIsCloseEnough = false
-  if (focussed) {
-    const interactable = getComponent(focussed, InteractableComponent)
-    if (!interactable) return
-    const boundingBox = getComponent(focussed, BoundingBoxComponent)
-    const distance = boundingBox.box.distanceToPoint(transform.position)
-    resultIsCloseEnough = distance < interactiveReachDistance
-  }
-
-  if (focussed && resultIsCloseEnough) {
+  if (focussed && interactor.focusedInteractive !== focussed && interactor.subFocusedArray.length) {
     interactor.focusedInteractive = focussed
     if (!interactor.subFocusedArray.includes(focussed)) {
       interactor.subFocusedArray.unshift(focussed)
@@ -88,7 +68,9 @@ export const interactBoxRaycast = (entity: Entity, raycastList: Entity[]) => {
     if (!availableInteractable) {
       dispatchAction(EngineActions.availableInteractable({ availableInteractable: focussed }))
     }
-  } else {
+  }
+
+  if (!focussed && interactor.focusedInteractive && !interactor.subFocusedArray.length) {
     interactor.focusedInteractive = null
     if (availableInteractable) {
       dispatchAction(EngineActions.availableInteractable({ availableInteractable: null }))

--- a/packages/engine/src/renderer/EngineRendererState.ts
+++ b/packages/engine/src/renderer/EngineRendererState.ts
@@ -28,7 +28,7 @@ type EngineRendererStateType = {
   gridHeight: number
 }
 
-const EngineRendererState = defineState({
+export const EngineRendererState = defineState({
   name: 'EngineRendererState',
   initial: () => ({
     qualityLevel: 5, // range from 0 to 5

--- a/packages/engine/src/scene/functions/loaders/ImageFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/ImageFunctions.ts
@@ -73,7 +73,7 @@ export const updateImage: ComponentUpdateFunction = (entity: Entity, properties:
         addError(entity, 'error', `Image format ${component.imageSource.split('.').pop()}not supported`)
         return
       }
-      const texture = AssetLoader.getFromCache(component.imageSource)
+      const texture = AssetLoader.load(component.imageSource)
 
       texture.encoding = sRGBEncoding
       texture.minFilter = LinearFilter

--- a/packages/engine/src/scene/functions/loaders/ModelFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/ModelFunctions.ts
@@ -49,7 +49,7 @@ export const deserializeModel: ComponentDeserializeFunction = (
   updateModel(entity, props)
 }
 
-export const updateModel: ComponentUpdateFunction = (entity: Entity, properties: ModelComponentType) => {
+export const updateModel: ComponentUpdateFunction = async (entity: Entity, properties: ModelComponentType) => {
   let scene: Object3DWithEntity
   if (properties.src) {
     try {
@@ -57,11 +57,11 @@ export const updateModel: ComponentUpdateFunction = (entity: Entity, properties:
       switch (/\.[\d\s\w]+$/.exec(properties.src)![0]) {
         case '.glb':
         case '.gltf':
-          const gltf = AssetLoader.getFromCache(properties.src) as GLTF
+          const gltf = (await AssetLoader.loadAsync(properties.src)) as GLTF
           scene = gltf.scene as any
           break
         case '.fbx':
-          scene = AssetLoader.getFromCache(properties.src).scene
+          scene = (await AssetLoader.loadAsync(properties.src)).scene
           break
         default:
           scene = new Object3D() as Object3DWithEntity

--- a/packages/engine/src/xr/XRControllerFunctions.ts
+++ b/packages/engine/src/xr/XRControllerFunctions.ts
@@ -98,7 +98,12 @@ export const initializeXRInputs = (entity: Entity) => {
   })
 }
 
-export const initializeHandModel = (entity: Entity, controller: any, handedness: string, isGrip: boolean = false) => {
+export const initializeHandModel = async (
+  entity: Entity,
+  controller: any,
+  handedness: string,
+  isGrip: boolean = false
+) => {
   const avatarInputState = accessAvatarInputSettingsState()
 
   let avatarInputControllerType = avatarInputState.controlType.value
@@ -115,7 +120,7 @@ export const initializeHandModel = (entity: Entity, controller: any, handedness:
    */
 
   const fileName = isGrip ? `${handedness}_controller.glb` : `${handedness}.glb`
-  const gltf = AssetLoader.getFromCache(`/default_assets/controllers/hands/${fileName}`)
+  const gltf = await AssetLoader.loadAsync(`/default_assets/controllers/hands/${fileName}`)
   let handMesh = gltf?.scene?.children[0]
 
   if (!handMesh) {


### PR DESCRIPTION
## Summary

The following commit proves that we can discard attribute buffers and texture data from the JS heap after these have been uploaded to the GPU. 

https://github.com/XRFoundation/XREngine/commit/cd422a3abc5def98f8d96a48ba4932c45bb368d6

However, we still have references to these buffers and texture data in our AssetLoader's in-memory cache, and we won't see the full benefit (potentially 50% or more reduction in our total heap memory usage) until we deal with that. 

This PR refactors our asset loading and scene loading logic to allow more data to be cleaned from the JS heap after successful GPU upload. 

## References

closes #6742


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

