### PR TITLE
Fixed the issue of exceptions being thrown when a newly created scene…

### DIFF
--- a/packages/editor/src/components/assets/ScenesPanel.tsx
+++ b/packages/editor/src/components/assets/ScenesPanel.tsx
@@ -121,6 +121,7 @@ export default function ScenesPanel({ loadScene, newScene, toggleRefetchScenes }
     setRenaming(false)
     await renameScene(editorState.projectName.value as string, newName, activeScene!.name)
     dispatchAction(EditorAction.sceneChanged({ sceneName: newName }))
+    await sleep(1000)
     history.push(`/editor/${editorState.projectName.value}/${newName}`)
     setNewName('')
     fetchItems()
@@ -203,3 +204,5 @@ export default function ScenesPanel({ loadScene, newScene, toggleRefetchScenes }
     </>
   )
 }
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))


### PR DESCRIPTION
… is renamed

## Summary

This PR fixes the exceptions being thrown in browser console when a newly created scene is renamed without refresh/reload. It seems like the issue was due to route being changed instantaneously rather than waiting for dispatch to update states. I added a short delay of 1sec to ensure things are updated and exception is not thrown.


## References

closes #6607


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

