### PR TITLE
Rate-limit the log aggregate API requests from the client.

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -22,6 +22,7 @@
     "@digitalbazaar/security-document-loader": "^2.0.0",
     "@digitalcredentials/bnid": "^2.1.2",
     "@digitalcredentials/did-method-key": "^2.0.3",
+    "@digitalcredentials/lru-memoize": "^2.1.4",
     "@digitalcredentials/vc": "^4.1.1",
     "@interop/did-web-resolver": "^2.2.1",
     "cross-fetch": "^3.1.5",

--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -79,7 +79,8 @@ const multiLogger = {
           consoleMethods[level](...args)
 
           // Send an async rate-limited request to backend /api/log endpoint for aggregation
-          if (hostDefined) {
+          // Also suppress logger.info() levels (the equivalent to console.log())
+          if (hostDefined && level !== 'info') {
             logRequestCache.memoize({
               key: logParams.msg,
               fn: () =>

--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -9,7 +9,12 @@
  *     Note: The sending/aggregation to Elastic only happens when APP_ENV !== 'development'.
  *
  */
+import { LruCache } from '@digitalcredentials/lru-memoize'
 import fetch from 'cross-fetch'
+
+const logRequestCache = new LruCache({
+  maxAge: 1000 * 5 // 5 seconds cache expiry
+})
 
 const hostDefined = !!globalThis.process.env['VITE_SERVER_HOST']
 // TODO: Hate to dupe the two config vars below, would prefer to load them from @xrengine/client-core/src/utils/config
@@ -58,7 +63,7 @@ const multiLogger = {
       const send = (level) => {
         const url = new URL('/api/log', serverHost)
 
-        return (...args) => {
+        return async (...args) => {
           const consoleMethods = {
             debug: console.debug.bind(console, `[${opts.component}]`),
             info: console.log.bind(console, `[${opts.component}]`),
@@ -73,16 +78,20 @@ const multiLogger = {
           // In addition to sending to logging endpoint,  output to console
           consoleMethods[level](...args)
 
-          // Send to backend /api/log endpoint for aggregation
+          // Send an async rate-limited request to backend /api/log endpoint for aggregation
           if (hostDefined) {
-            fetch(url, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                level,
-                component: opts.component,
-                ...logParams
-              })
+            logRequestCache.memoize({
+              key: logParams.msg,
+              fn: () =>
+                fetch(url, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({
+                    level,
+                    component: opts.component,
+                    ...logParams
+                  })
+                })
             })
           }
         }


### PR DESCRIPTION
## Summary

Closes #6798

## QA Steps

API /log requests from the client to the server should now happen every 5 seconds, and `net::ERR_INSUFFICIENT_RESOURCES` errors should be fixed. Also, only warn, error, debug and fatal level events will be sent server-side. (info/log events will only be displayed on browser console)

