### PR TITLE
Updated project backend to handle repos without write access.

### DIFF
--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -152,6 +152,7 @@
       "confirmProjectInvalidate": "Do you want to invalidate storage provider's cache of",
       "confirmProjectDelete": "Do you want to delete project",
       "confirmPushProjectToGithub": "Do you want to push this project to its associated GitHub repository",
+      "outdatedBuild": "This project has been updated locally since the last build",
       "userAccess": "User Access",
       "userInviteCode": "User Invite Code",
       "inviteCodeCantEmpty": "Invite code can't be empty",

--- a/packages/client-core/src/admin/components/Project/ProjectTable.tsx
+++ b/packages/client-core/src/admin/components/Project/ProjectTable.tsx
@@ -179,9 +179,7 @@ const ProjectTable = ({ className }: Props) => {
     setConfirm({
       open: true,
       processing: processing,
-      description: `${t('admin:components.project.confirmPushProjectToGithub')}? ${row.name} - ${
-        project?.repositoryPath
-      }`,
+      description: `${t('admin:components.project.confirmPushProjectToGithub')}? ${row.name} - ${row.repositoryPath}`,
       onSubmit: handlePushProjectToGithub
     })
   }


### PR DESCRIPTION
## Summary

The project API was not properly handling repos to which the authenticated user
or GH app did not have write access. project.update now does not push what it has
checked out with git itself, but instead, if a reset is being done, calls
pushProjectToGithub, which has been updated to handle resets by doing the
clone/force-push that was previously done in project.update.

pushProjectToGithub now returns if it detects that the repo it's assigned to is
not pushable because of lack of proper credentials.

project.find now checks if projects that the user has permission for are pushable by
the GH app before determining which are tagged as `hadWriteAccess`.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

