### PR TITLE
Client logs to ElasticSearch only (no console).

### DIFF
--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -85,7 +85,6 @@
     "octokit": "1.7.1",
     "pino": "^7.2.0",
     "pino-elasticsearch": "^6.2.0",
-    "pino-http": "^8.1.1",
     "pino-pretty": "^7.6.1",
     "pug": "^3.0.0",
     "request": "2.88.2",

--- a/packages/server-core/src/createApp.ts
+++ b/packages/server-core/src/createApp.ts
@@ -9,7 +9,6 @@ import swagger from 'feathers-swagger'
 import sync from 'feathers-sync'
 import helmet from 'helmet'
 import path from 'path'
-import pinoHttp from 'pino-http'
 import { Socket } from 'socket.io'
 
 import { isDev } from '@xrengine/common/src/utils/isDev'
@@ -17,31 +16,11 @@ import { pipe } from '@xrengine/common/src/utils/pipe'
 
 import { Application, ServerTypeMode } from '../declarations'
 import config from './appconfig'
-import logger from './logger'
+import { elasticOnlyLogger, logger } from './logger'
 import { createDefaultStorageProvider, createIPFSStorageProvider } from './media/storageprovider/storageprovider'
 import sequelize from './sequelize'
 import services from './services'
 import authentication from './user/authentication'
-
-/**
- * Logs all Express API calls (except for the ones marked as 'silent').
- */
-const requestLogger = pinoHttp({
-  logger: logger.child({ component: 'api' }),
-
-  customLogLevel(req, res, err) {
-    if (res.req.url === '/api/log' || res.req.url === '/healthcheck') {
-      return 'silent'
-    } else if (res.statusCode === 404) {
-      return 'info'
-    } else if (res.statusCode >= 400 || err) {
-      return 'error'
-    } else if (res.statusCode >= 300 && res.statusCode < 400) {
-      return 'silent'
-    }
-    return 'info'
-  }
-})
 
 export const configureOpenAPI = () => (app: Application) => {
   app.configure(
@@ -109,10 +88,9 @@ export const configureRedis = () => (app: Application) => {
   if (config.redis.enabled) {
     app.configure(
       sync({
-        uri:
-          config.redis.password != null && config.redis.password !== ''
-            ? `redis://${config.redis.address}:${config.redis.port}?password=${config.redis.password}`
-            : `redis://${config.redis.address}:${config.redis.port}`
+        uri: config.redis.password
+          ? `redis://${config.redis.address}:${config.redis.port}?password=${config.redis.password}`
+          : `redis://${config.redis.address}:${config.redis.port}`
       })
     )
     app.sync.ready.then(() => {
@@ -178,10 +156,6 @@ export const createFeathersExpressApp = (
     }) as any
   )
 
-  // TODO: Investigate why this is letting healthcheck requests through
-  // Disabling for the moment
-  // app.use(requestLogger)
-
   app.use(compress())
   app.use(json())
   app.use(urlencoded({ extended: true }))
@@ -206,7 +180,7 @@ export const createFeathersExpressApp = (
   // Receive client-side log events (only active when APP_ENV != 'development')
   app.post('/api/log', (req, res) => {
     const { msg, ...mergeObject } = req.body
-    if (!isDev) logger.info({ user: req.params?.user, ...mergeObject }, msg)
+    if (!isDev) elasticOnlyLogger.info({ user: req.params?.user, ...mergeObject }, msg)
     return res.status(204).send()
   })
 

--- a/packages/server-core/src/logger.ts
+++ b/packages/server-core/src/logger.ts
@@ -26,7 +26,7 @@ const streamToElastic = pinoElastic({
 
 const streams = [streamToPretty, streamToElastic]
 
-const logger = pino(
+export const logger = pino(
   {
     level: 'debug',
     enable: useLogger,
@@ -36,6 +36,18 @@ const logger = pino(
     }
   },
   pino.multistream(streams)
+)
+
+export const elasticOnlyLogger = pino(
+  {
+    level: 'debug',
+    enable: useLogger,
+    base: {
+      hostname: os.hostname,
+      component: 'server-core'
+    }
+  },
+  streamToElastic
 )
 
 export default logger


### PR DESCRIPTION
Only send client-side logs (via logging api endpoint) to ElasticSearch, but not to server console.