### PR TITLE
Fixed some bugs with user video.

### DIFF
--- a/packages/client-core/i18n/en/user.json
+++ b/packages/client-core/i18n/en/user.json
@@ -182,7 +182,7 @@
       "lbl-automatic": "Automatic",
       "xrusersetting": "XR",
       "other-audio-setting": "Other Audio Settings",
-      "use-positional-audio": "Spatial User Audio",
+      "use-positional-media": "Spatial User Audio and Video Above Avatar",
       "rotation": "Rotation",
       "rotation-smooth-speed": "Rotation Smooth Speed",
       "rotation-angle": "Rotation Angle",
@@ -256,7 +256,7 @@
         "resolution": "Resolution",
         "high": "High",
         "low": "Low",
-        "spatialAudio": "Use Spatial Audio",
+        "spatialMedia": "Use Spatial Media",
         "enterMuted": "Enter Room Muted"
       },
       "delete": {

--- a/packages/client-core/src/components/InstanceChat/index.tsx
+++ b/packages/client-core/src/components/InstanceChat/index.tsx
@@ -205,17 +205,18 @@ const InstanceChat = ({
   const [messageContainerVisible, setMessageContainerVisible] = useState(false)
   const messageRefInput = useRef<HTMLInputElement>()
 
-  const { dimensions, activeChannel, handleComposingMessageChange, packageMessage, composingMessage } = useChatHooks({
+  const { activeChannel, handleComposingMessageChange, packageMessage, composingMessage } = useChatHooks({
     chatWindowOpen,
     setUnreadMessages,
     messageRefInput: messageRefInput as any
   })
 
-  const sortedMessages = activeChannel
-    ? [...activeChannel.messages.value].sort(
-        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-      )
-    : []
+  const sortedMessages =
+    activeChannel && activeChannel.messages
+      ? [...activeChannel.messages.value].sort(
+          (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        )
+      : []
 
   const user = useAuthState().user
 

--- a/packages/client-core/src/components/UserMediaWindows/index.tsx
+++ b/packages/client-core/src/components/UserMediaWindows/index.tsx
@@ -6,8 +6,6 @@ import { useMediaStreamState } from '@xrengine/client-core/src/media/services/Me
 import { accessAuthState } from '@xrengine/client-core/src/user/services/AuthService'
 import { useUserState } from '@xrengine/client-core/src/user/services/UserService'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
-import { MediaSettingsState } from '@xrengine/engine/src/networking/MediaSettingsState'
-import { getState } from '@xrengine/hyperflux'
 
 import UserMediaWindow from '../UserMediaWindow'
 
@@ -41,13 +39,8 @@ const UserMediaWindows = ({ className }: Props): JSX.Element => {
   const consumers = mediaState.consumers.value
   const screenShareConsumers = consumers?.filter((consumer) => consumer.appData.mediaTag === 'screen-video') || []
 
-  const mediaSettingState = useHookstate(getState(MediaSettingsState))
-  const renderered =
-    mediaSettingState.immersiveMediaMode.value === 'off' ||
-    (mediaSettingState.immersiveMediaMode.value === 'auto' && !mediaSettingState.useImmersiveMedia.value)
-
   return (
-    <div className={className} style={{ display: renderered ? 'auto' : 'none' }}>
+    <div className={className}>
       {(mediaState.isScreenAudioEnabled.value || mediaState.isScreenVideoEnabled.value) && (
         <UserMediaWindow peerId={'screen_me'} key={'screen_me'} />
       )}

--- a/packages/client-core/src/systems/ui/ChatDetailView/index.tsx
+++ b/packages/client-core/src/systems/ui/ChatDetailView/index.tsx
@@ -25,11 +25,18 @@ function createChatDetailState() {
 const ChatDetailView = () => {
   const [unreadMessages, setUnreadMessages] = useState(false)
 
-  const { dimensions, sortedMessages, handleComposingMessageChange, packageMessage, composingMessage } = useChatHooks({
+  const { activeChannel, handleComposingMessageChange, packageMessage, composingMessage } = useChatHooks({
     chatWindowOpen: true,
     setUnreadMessages,
     messageRefInput: null!
   })
+
+  const sortedMessages =
+    activeChannel && activeChannel.messages
+      ? [...activeChannel.messages.value].sort(
+          (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        )
+      : []
 
   const user = useAuthState().user
 

--- a/packages/client-core/src/systems/ui/SettingDetailView/index.tsx
+++ b/packages/client-core/src/systems/ui/SettingDetailView/index.tsx
@@ -175,10 +175,10 @@ const SettingDetailView = () => {
                 <div className="sectionRow">
                   <SurroundSoundIcon />
                   <XRCheckboxButton
-                    labelContent={t('user:usermenu.setting.use-positional-audio')}
-                    checked={audioState.usePositionalAudio.value}
+                    labelContent={t('user:usermenu.setting.use-positional-media')}
+                    checked={audioState.usePositionalMedia.value}
                     onChange={(_, value: boolean) => {
-                      dispatchAction(AudioSettingAction.setUsePositionalAudio({ value }))
+                      dispatchAction(AudioSettingAction.setUsePositionalMedia({ value }))
                     }}
                   />
                 </div>

--- a/packages/client-core/src/user/components/UserMenu/index.module.scss
+++ b/packages/client-core/src/user/components/UserMenu/index.module.scss
@@ -70,6 +70,8 @@
       padding: 1em;
       margin-right: 5px;
       border-radius: 50%;
+      height: 50px;
+      width: 50px;
       background-color: var(--iconButtonBackground);
 
       @media (max-width: 500px) {

--- a/packages/client-core/src/user/components/UserMenu/menus/SettingMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/SettingMenu.tsx
@@ -187,12 +187,12 @@ const SettingMenu = (): JSX.Element => {
                   <span className={styles.materialIconBlock}>
                     <SurroundSoundIcon />
                   </span>
-                  <span className={styles.settingLabel}>{t('user:usermenu.setting.use-positional-audio')}</span>
+                  <span className={styles.settingLabel}>{t('user:usermenu.setting.use-positional-media')}</span>
                   <Checkbox
                     className={styles.checkboxBlock}
-                    checked={audioState.usePositionalAudio.value}
+                    checked={audioState.usePositionalMedia.value}
                     onChange={(_, value: boolean) => {
-                      dispatchAction(AudioSettingAction.setUsePositionalAudio({ value }))
+                      dispatchAction(AudioSettingAction.setUsePositionalMedia({ value }))
                     }}
                     onPointerUp={() => AudioEffectPlayer.instance.play(AudioEffectPlayer.SOUNDS.ui)}
                     onPointerEnter={() => AudioEffectPlayer.instance.play(AudioEffectPlayer.SOUNDS.ui)}

--- a/packages/engine/src/audio/AudioSettingConstants.ts
+++ b/packages/engine/src/audio/AudioSettingConstants.ts
@@ -2,7 +2,7 @@ const AudioSettingDBPrefix = 'audio-settings-'
 export const AudioSettingKeys = {
   AUDIO: AudioSettingDBPrefix + 'audio',
   MICROPHONE: AudioSettingDBPrefix + 'microphone',
-  USE_POSITIONAL_AUDIO: AudioSettingDBPrefix + 'usePositionalAudio',
+  USE_POSITIONAL_MEDIA: AudioSettingDBPrefix + 'usePositionalMedia',
   MEDIA_STREAM_VOLUME: AudioSettingDBPrefix + 'mediaStreamVolume',
   NOTIFICATION_VOLUME: AudioSettingDBPrefix + 'notificationVolume',
   SOUND_EFFECT_VOLUME: AudioSettingDBPrefix + 'soundEffectsVolume',

--- a/packages/engine/src/audio/AudioState.ts
+++ b/packages/engine/src/audio/AudioState.ts
@@ -15,7 +15,7 @@ export const AudioState = defineState({
   initial: () => ({
     masterVolume: 0.5,
     microphoneGain: 0.5,
-    usePositionalAudio: false, // only for avatars
+    usePositionalMedia: false, // only for avatars
     mediaStreamVolume: 0.5,
     notificationVolume: 0.5,
     soundEffectsVolume: 0.2,
@@ -32,8 +32,8 @@ export function restoreAudioSettings() {
     if (typeof v !== 'undefined')
       dispatchAction(AudioSettingAction.setMicrophoneVolume({ value: MathUtils.clamp(v, 0, 1) }))
   })
-  ClientStorage.get(AudioSettingKeys.USE_POSITIONAL_AUDIO).then((v: boolean) => {
-    if (typeof v !== 'undefined') dispatchAction(AudioSettingAction.setUsePositionalAudio({ value: Boolean(v) }))
+  ClientStorage.get(AudioSettingKeys.USE_POSITIONAL_MEDIA).then((v: boolean) => {
+    if (typeof v !== 'undefined') dispatchAction(AudioSettingAction.setUsePositionalMedia({ value: Boolean(v) }))
   })
   ClientStorage.get(AudioSettingKeys.MEDIA_STREAM_VOLUME).then((v: number) => {
     if (typeof v !== 'undefined')
@@ -67,9 +67,9 @@ export function AudioSettingReceptor(action) {
       s.merge({ microphoneGain: action.value })
       ClientStorage.set(AudioSettingKeys.MICROPHONE, action.value)
     })
-    .when(AudioSettingAction.setUsePositionalAudio.matches, (action) => {
-      s.merge({ usePositionalAudio: action.value })
-      ClientStorage.set(AudioSettingKeys.USE_POSITIONAL_AUDIO, action.value)
+    .when(AudioSettingAction.setUsePositionalMedia.matches, (action) => {
+      s.merge({ usePositionalMedia: action.value })
+      ClientStorage.set(AudioSettingKeys.USE_POSITIONAL_MEDIA, action.value)
     })
     .when(AudioSettingAction.setMediaStreamVolume.matches, (action) => {
       s.merge({ mediaStreamVolume: action.value })
@@ -118,8 +118,8 @@ export class AudioSettingAction {
     type: 'core.audio.MICROPHONE_VOLUME' as const,
     value: matches.number
   })
-  static setUsePositionalAudio = defineAction({
-    type: 'core.audio.POSITIONAL_AUDIO' as const,
+  static setUsePositionalMedia = defineAction({
+    type: 'core.audio.POSITIONAL_MEDIA' as const,
     value: matches.boolean
   })
   static setMediaStreamVolume = defineAction({

--- a/packages/engine/src/networking/MediaSettingsState.ts
+++ b/packages/engine/src/networking/MediaSettingsState.ts
@@ -58,5 +58,5 @@ export const shouldUseImmersiveMedia = () => {
   const immersiveMedia =
     mediaSettingState.immersiveMediaMode.value === 'on' ||
     (mediaSettingState.immersiveMediaMode.value === 'auto' && mediaSettingState.useImmersiveMedia.value)
-  return immersiveMedia || audioState.usePositionalAudio.value || xrSessionActive
+  return immersiveMedia || audioState.usePositionalMedia.value || xrSessionActive
 }

--- a/packages/engine/src/scene/schema/XRE_audioSettings.schema.json
+++ b/packages/engine/src/scene/schema/XRE_audioSettings.schema.json
@@ -6,7 +6,7 @@
   "description": "serialization extension for XREngine audio settings components",
   "allOf": [{ "$ref": "glTFProperty.schema.json" }],
   "properties": {
-    "usePositionalAudio": {
+    "usePositionalMedia": {
       "type": "boolean",
       "default": true
     },


### PR DESCRIPTION
## Summary

In immersive mode, applying the non-displayed consumer video to the user avatar UI was often not playing.
Changed this to creating a new video element from the consumer's track.

Made self video displayed in immersive mode, per feedback about not having self video being disorienting.
Moved application of display: auto/none to UserMediaWindow from UserMediaWindows, only applies to non-self
windows.

Renamed positionalAudio to positionalMedia (and all derivations of that). We are now using that setting to control
both spatial audio and showing users' video above their avatar.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

