### PR TITLE
Fixed some issues with updating projects.

### DIFF
--- a/packages/client-core/src/common/services/ProjectService.ts
+++ b/packages/client-core/src/common/services/ProjectService.ts
@@ -64,6 +64,7 @@ export const ProjectService = {
     const result = await API.instance.client.service('project').update({ url, name, reset })
     logger.info({ result }, 'Upload project result')
     dispatchAction(ProjectAction.postProject({}))
+    await API.instance.client.service('project-invalidate').patch({ projectName: name })
     await ProjectService.fetchProjects()
   },
 

--- a/packages/server-core/src/projects/githubapp/githubapp-helper.ts
+++ b/packages/server-core/src/projects/githubapp/githubapp-helper.ts
@@ -206,7 +206,7 @@ export const pushProjectToGithub = async (
       files.map(async (filePath) => {
         if (path.parse(filePath).ext.length > 0) {
           logger.info(`[ProjectLoader]: - downloading "${filePath}"`)
-          const fileResult = await storageProvider.getCachedObject(filePath)
+          const fileResult = await storageProvider.getObject(filePath)
           if (fileResult.Body.length === 0) logger.info(`[ProjectLoader]: WARNING file "${filePath}" is empty`)
           writeFileSyncRecursive(path.join(appRootPath.path, 'packages/projects', filePath), fileResult.Body)
         }

--- a/packages/server-core/src/projects/project/downloadProjects.ts
+++ b/packages/server-core/src/projects/project/downloadProjects.ts
@@ -31,7 +31,7 @@ export const download = async (projectName: string) => {
       files.map(async (filePath) => {
         if (path.parse(filePath).ext.length > 0) {
           logger.info(`[ProjectLoader]: - downloading "${filePath}"`)
-          const fileResult = await storageProvider.getCachedObject(filePath)
+          const fileResult = await storageProvider.getObject(filePath)
           if (fileResult.Body.length === 0) logger.info(`[ProjectLoader]: WARNING file "${filePath}" is empty`)
           writeFileSyncRecursive(path.join(appRootPath.path, 'packages/projects', filePath), fileResult.Body)
         }


### PR DESCRIPTION
## Summary

Added a cache invalidation call to ProjectService.uploadProject. If new files are being fetched, whether
from the deployment branch or as a reset from the main branch, all existing files caches are potentially
invalid and should be cleared.

Updated project download in downloadProjects.ts and githubapp-helper.ts to use storageProvider.getObject
instead of .getCachedObject. This prevents project rebuilding from inadvertently using an old cached
version of project files.



## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

