### PR TITLE
Strengthened scope restrictions on user CRUD.

### DIFF
--- a/packages/server-core/src/scope/scope/scope.hooks.ts
+++ b/packages/server-core/src/scope/scope/scope.hooks.ts
@@ -8,10 +8,10 @@ export default {
     all: [authenticate(), iff(isProvider('external'), verifyScope('admin', 'admin') as any)],
     find: [iff(isProvider('external'), verifyScope('user', 'read') as any)],
     get: [iff(isProvider('external'), verifyScope('user', 'read') as any)],
-    create: [iff(isProvider('external'), verifyScope('user', 'write') as any)],
+    create: [iff(isProvider('external'), verifyScope('admin', 'admin') as any, verifyScope('user', 'write') as any)],
     update: [disallow()],
     patch: [disallow()],
-    remove: [iff(isProvider('external'), verifyScope('user', 'write') as any)]
+    remove: [iff(isProvider('external'), verifyScope('admin', 'admin') as any, verifyScope('user', 'write') as any)]
   },
 
   after: {

--- a/packages/server-core/src/user/avatar/avatar.class.ts
+++ b/packages/server-core/src/user/avatar/avatar.class.ts
@@ -40,8 +40,8 @@ export class Avatar extends Service<AvatarInterface> {
         params.query.name = {
           [Op.like]: `%${params.query.search}%`
         }
-      delete params.query.search
     }
+    if (params?.query) delete params.query.search
     const avatars = (await super.find(params)) as Paginated<AvatarInterface>
     await Promise.all(
       avatars.data.map(async (avatar) => {

--- a/packages/server-core/src/user/user/user.class.ts
+++ b/packages/server-core/src/user/user/user.class.ts
@@ -150,10 +150,13 @@ export class User extends Service<UserInterface> {
     } else {
       if (
         loggedInUser.scopes &&
-        !loggedInUser?.scopes.find((scope) => scope.type === 'admin:admin') &&
+        !(
+          loggedInUser?.scopes.find((scope) => scope.type === 'admin:admin') &&
+          loggedInUser?.scopes.find((scope) => scope.type === 'user:read')
+        ) &&
         !params.isInternal
       )
-        throw new Forbidden('Must be system admin to execute this action')
+        throw new Forbidden('Must be system admin with user:read scope to execute this action')
       return await super.find(params)
     }
   }


### PR DESCRIPTION
## Summary

Users now need both admin:admin and user:read/write to perform any sort of user CRUD or scope CRUD.

Fixed a bug with removing search from avatar find queries. Passing null for search wasn't triggering removal from query params.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

