### PR TITLE
Fixed bug in resetting project to main branch.

### DIFF
--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -280,10 +280,8 @@ export class Project extends Service {
       const branchExists = await git.raw(['ls-remote', '--heads', repoPath, `${branchName}`])
       if (branchExists.length === 0) await git.checkoutLocalBranch(branchName)
       else {
-        if (data.reset) {
-          await git.branchLocal()
-        }
-        await git.checkout(branchName)
+        if (data.reset) await git.checkoutLocalBranch(branchName)
+        else await git.checkout(branchName)
       }
     } catch (err) {
       logger.error(err)


### PR DESCRIPTION
## Summary

Reset was using git.branchLocal, which just lists local branches, and then checking out branchName. If the remote repo exists, this was checking out the n-commits-behind deployment branch, not the main branch. Changed this so that on reset, it does git.checkoutLocalBranch, and only on non-resets does it do git.checkout


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

