### PR TITLE
Multi-select/Delete all on avatar admin page

### DIFF
--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -302,7 +302,9 @@
       "rightClick": "Right Click",
       "scroll": "Scroll",
       "loading": "Loading",
-      "confirmAvatarDelete": "Do you want to delete avatar"
+      "confirmAvatarDelete": "Do you want to delete avatar",
+      "confirmMultiDelete": "Do you want to delete all of the selected avatars?",
+      "deleteSelected": "Delete selected avatars"
     },
     "dialog": {
       "noAccess": "No access",

--- a/packages/client-core/src/admin/common/Table.tsx
+++ b/packages/client-core/src/admin/common/Table.tsx
@@ -20,6 +20,7 @@ interface Props {
   rowsPerPage: number
   count: number
   fieldOrder?: string
+  fieldOrderBy?: string
   allowSort?: boolean
   setSortField?: (fueld: string) => void
   setFieldOrder?: (order: string) => void
@@ -100,7 +101,7 @@ const EnhancedTableHead = ({ order, orderBy, onRequestSort, columns }: EnhancedT
             className={styles.tableCellHeader}
             style={{ minWidth: headCell.minWidth }}
           >
-            {(headCell.id as any) === 'action' ? (
+            {(headCell.id as any) === 'action' || (headCell.id as any) === 'select' ? (
               <span>{headCell.label} </span>
             ) : (
               <TableSortLabel
@@ -131,6 +132,7 @@ const TableComponent = ({
   rowsPerPage,
   count,
   fieldOrder,
+  fieldOrderBy,
   allowSort,
   setSortField,
   setFieldOrder,
@@ -138,7 +140,7 @@ const TableComponent = ({
   handleRowsPerPageChange
 }: Props) => {
   const [order, setOrder] = React.useState<Order>(fieldOrder === 'desc' ? 'desc' : 'asc')
-  const [orderBy, setOrderBy] = React.useState<keyof Data>(column[0].id)
+  const [orderBy, setOrderBy] = React.useState<keyof Data>(fieldOrderBy ? fieldOrderBy : column[0].id)
   const handleRequestSort = (event: React.MouseEvent<unknown>, property: keyof Data) => {
     const isAsc = orderBy === property && order === 'asc'
     setOrder(isAsc ? 'desc' : 'asc')

--- a/packages/client-core/src/admin/common/variables/avatar.ts
+++ b/packages/client-core/src/admin/common/variables/avatar.ts
@@ -1,8 +1,8 @@
 import { AvatarInterface } from '@xrengine/common/src/interfaces/AvatarInterface'
 
 export interface AvatarColumn {
-  id: 'id' | 'name' | 'thumbnail' | 'action'
-  label: string
+  id: 'select' | 'id' | 'name' | 'thumbnail' | 'action'
+  label: string | React.ReactElement
   minWidth?: number
   align?: 'right'
 }
@@ -26,6 +26,7 @@ export const avatarColumns: AvatarColumn[] = [
 
 export interface AvatarData {
   el: AvatarInterface
+  select: JSX.Element
   id: string
   name: string | undefined
   action: JSX.Element

--- a/packages/client-core/src/admin/common/variables/invite.ts
+++ b/packages/client-core/src/admin/common/variables/invite.ts
@@ -1,6 +1,8 @@
+import React from 'react'
+
 export interface InviteColumn {
   id: 'id' | 'name' | 'passcode' | 'type' | 'action' | 'select' | 'spawnType' | 'spawnDetails' | 'targetObjectId'
-  label: string
+  label: string | React.ReactElement
   minWidth?: number
   align?: 'right' | 'center'
 }
@@ -46,11 +48,6 @@ export const inviteColumns: InviteColumn[] = [
     label: 'Spawn Details',
     minWidth: 65,
     align: 'center'
-  },
-  {
-    id: 'select',
-    label: 'Select',
-    minWidth: 65
   },
   {
     id: 'action',

--- a/packages/client-core/src/admin/components/Avatars/index.tsx
+++ b/packages/client-core/src/admin/components/Avatars/index.tsx
@@ -1,21 +1,33 @@
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import DeleteIcon from '@mui/icons-material/Delete'
+import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Grid from '@mui/material/Grid'
+import IconButton from '@mui/material/IconButton'
 
+import ConfirmDialog from '../../common/ConfirmDialog'
 import Search from '../../common/Search'
+import { AdminAvatarService } from '../../services/AvatarService'
 import styles from '../../styles/admin.module.scss'
 import AvatarDrawer, { AvatarDrawerMode } from './AvatarDrawer'
 import AvatarTable from './AvatarTable'
 
 const Avatar = () => {
+  const { t } = useTranslation()
   const [search, setSearch] = useState('')
   const [openAvatarDrawer, setOpenAvatarDrawer] = useState(false)
-  const { t } = useTranslation()
+  const [openDeleteAvatarModal, setOpenDeleteAvatarModal] = React.useState(false)
+  const [selectedAvatarIds, setSelectedAvatarIds] = useState(() => new Set<string>())
 
   const handleChange = (e: any) => {
     setSearch(e.target.value)
+  }
+
+  const handleDeleteAll = () => {
+    for (let id of selectedAvatarIds) AdminAvatarService.removeAdminAvatar(id)
+    setOpenDeleteAvatarModal(false)
   }
 
   return (
@@ -25,22 +37,47 @@ const Avatar = () => {
           <Search text="avatar" handleChange={handleChange} />
         </Grid>
         <Grid item xs={12} sm={4}>
-          <Button
-            className={styles.openModalBtn}
-            type="submit"
-            variant="contained"
-            onClick={() => setOpenAvatarDrawer(true)}
-          >
-            {t('user:avatar.createAvatar')}
-          </Button>
+          <Box sx={{ display: 'flex' }}>
+            <Button
+              className={styles.openModalBtn}
+              type="submit"
+              variant="contained"
+              onClick={() => setOpenAvatarDrawer(true)}
+            >
+              {t('user:avatar.createAvatar')}
+            </Button>
+
+            {selectedAvatarIds.size > 0 && (
+              <IconButton
+                className={styles.filterButton}
+                sx={{ ml: 1 }}
+                size="small"
+                title={t('admin:components.avatar.deleteSelected')}
+                onClick={() => setOpenDeleteAvatarModal(true)}
+              >
+                <DeleteIcon color="info" fontSize="large" />
+              </IconButton>
+            )}
+          </Box>
         </Grid>
       </Grid>
-
-      <AvatarTable className={styles.rootTableWithSearch} search={search} />
+      <AvatarTable
+        className={styles.rootTableWithSearch}
+        search={search}
+        selectedAvatarIds={selectedAvatarIds}
+        setSelectedAvatarIds={setSelectedAvatarIds}
+      />
 
       {openAvatarDrawer && (
         <AvatarDrawer open mode={AvatarDrawerMode.Create} onClose={() => setOpenAvatarDrawer(false)} />
       )}
+
+      <ConfirmDialog
+        open={openDeleteAvatarModal}
+        description={t('admin:components.avatar.confirmMultiDelete')}
+        onSubmit={handleDeleteAll}
+        onClose={() => setOpenDeleteAvatarModal(false)}
+      />
     </React.Fragment>
   )
 }

--- a/packages/client-core/src/admin/components/Invite/AdminInvites.tsx
+++ b/packages/client-core/src/admin/components/Invite/AdminInvites.tsx
@@ -8,7 +8,7 @@ import Checkbox from '@mui/material/Checkbox'
 import { INVITE_PAGE_LIMIT } from '../../../social/services/InviteService'
 import ConfirmDialog from '../../common/ConfirmDialog'
 import TableComponent from '../../common/Table'
-import { inviteColumns } from '../../common/variables/invite'
+import { InviteColumn, inviteColumns } from '../../common/variables/invite'
 import { AdminInviteService, useAdminInviteState } from '../../services/InviteService'
 import styles from '../../styles/admin.module.scss'
 import UpdateInviteModal from './UpdateInviteModal'
@@ -86,6 +86,17 @@ const AdminInvites = ({ search, selectedInviteIds, setSelectedInviteIds }: Props
 
   const createData = (invite: InviteInterface) => {
     return {
+      select: (
+        <>
+          <Checkbox
+            className={styles.checkbox}
+            checked={selectedInviteIds.has(invite.id)}
+            onChange={() => {
+              toggleSelection(invite.id)
+            }}
+          />
+        </>
+      ),
       id: invite.id,
       name: invite.invitee?.name || invite.token || '',
       passcode: invite.passcode,
@@ -116,31 +127,53 @@ const AdminInvites = ({ search, selectedInviteIds, setSelectedInviteIds }: Props
             <span className={styles.spanDange}>{t('admin:components.common.delete')}</span>
           </a>
         </>
-      ),
-      select: (
-        <>
-          <Checkbox
-            checked={selectedInviteIds.has(invite.id)}
-            onChange={() => {
-              toggleSelection(invite.id)
-            }}
-          />
-        </>
       )
     }
   }
 
   const rows = invites.value.map((el) => createData(el))
 
+  let allSelected: boolean | undefined = undefined
+  if (invites.value.length === selectedInviteIds.size) {
+    allSelected = true
+  } else if (selectedInviteIds.size === 0) {
+    allSelected = false
+  }
+
+  const columns: InviteColumn[] = [
+    {
+      id: 'select',
+      label: (
+        <Checkbox
+          className={styles.checkbox}
+          checked={allSelected === true}
+          indeterminate={allSelected === undefined}
+          onChange={(_event, checked) => {
+            if (checked || allSelected === undefined) {
+              const set = new Set<string>()
+              invites.value.map((item) => set.add(item.id))
+              setSelectedInviteIds(set)
+            } else {
+              setSelectedInviteIds(new Set<string>())
+            }
+          }}
+        />
+      ),
+      minWidth: 65
+    },
+    ...inviteColumns
+  ]
+
   return (
     <React.Fragment>
       <TableComponent
         allowSort={false}
         fieldOrder={fieldOrder}
+        fieldOrderBy="id"
         setSortField={setSortField}
         setFieldOrder={setFieldOrder}
         rows={rows}
-        column={inviteColumns}
+        column={columns}
         page={page}
         rowsPerPage={rowsPerPage}
         count={inviteCount}

--- a/packages/client-core/src/admin/components/Invite/index.tsx
+++ b/packages/client-core/src/admin/components/Invite/index.tsx
@@ -2,9 +2,11 @@ import { ConfirmProvider } from 'material-ui-confirm'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import DeleteIcon from '@mui/icons-material/Delete'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Grid from '@mui/material/Grid'
+import IconButton from '@mui/material/IconButton'
 
 import { useAuthState } from '../../../user/services/AuthService'
 import ConfirmDialog from '../../common/ConfirmDialog'
@@ -94,31 +96,34 @@ const InvitesConsole = () => {
     <div>
       <ConfirmProvider>
         <Grid container spacing={1} className={styles.mb10px}>
-          <Grid item xs={8}>
+          <Grid item sm={8} xs={12}>
             <Search text="invite" handleChange={handleSearchChange} />
           </Grid>
-          <Grid item xs={2}>
-            <Button
-              className={styles.openModalBtn}
-              type="button"
-              variant="contained"
-              color="primary"
-              onClick={() => setCreateInviteModalOpen(true)}
-            >
-              {t('admin:components.invite.create')}
-            </Button>
-          </Grid>
-          <Grid item xs={2}>
-            <Button
-              className={styles.openModalBtn}
-              type="button"
-              variant="contained"
-              color="primary"
-              disabled={selectedInviteIds.size === 0}
-              onClick={() => setDeleteMultiInviteModalOpen(true)}
-            >
-              {t('admin:components.invite.deleteSelected')}
-            </Button>
+          <Grid item sm={4} xs={8}>
+            <Box sx={{ display: 'flex' }}>
+              <Button
+                className={styles.openModalBtn}
+                sx={{ flexGrow: 1 }}
+                type="button"
+                variant="contained"
+                color="primary"
+                onClick={() => setCreateInviteModalOpen(true)}
+              >
+                {t('admin:components.invite.create')}
+              </Button>
+
+              {selectedInviteIds.size > 0 && (
+                <IconButton
+                  className={styles.filterButton}
+                  sx={{ ml: 1 }}
+                  size="small"
+                  title={t('admin:components.invite.deleteSelected')}
+                  onClick={() => setDeleteMultiInviteModalOpen(true)}
+                >
+                  <DeleteIcon color="info" fontSize="large" />
+                </IconButton>
+              )}
+            </Box>
           </Grid>
         </Grid>
         <div className={styles.rootTableWithSearch}>


### PR DESCRIPTION
## Summary

Added multi delete in avatars. Also updated invites section in admin panel to look similar to avatar's selected and delete workflow.

When no item is selected:
![image](https://user-images.githubusercontent.com/10975502/189469416-f295359a-3ad2-477e-804d-fe9a39f62910.png)

When items are selected, delete icon button is visible on right. Also, select all button works and its state is updated to reflect so.
![image](https://user-images.githubusercontent.com/10975502/189469467-fd0bf0e0-aef2-46da-8800-6f555def1a4a.png)


## References

closes #6841


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

