### PR TITLE
Added ability to have public and private avatars

### DIFF
--- a/packages/client-core/src/admin/components/Avatars/AvatarDrawer.tsx
+++ b/packages/client-core/src/admin/components/Avatars/AvatarDrawer.tsx
@@ -320,7 +320,8 @@ const AvatarDrawerContent = ({ open, mode, selectedAvatar, onClose }: Props) => 
         const uploadResponse = await AvatarService.uploadAvatarModel(
           avatarBlob,
           thumbnailBlob,
-          state.name + '_' + selectedAvatar.id
+          state.name + '_' + selectedAvatar.id,
+          selectedAvatar.isPublic
         )
         const removalPromises = [] as any
         if (uploadResponse[0].id !== selectedAvatar.modelResourceId)
@@ -329,7 +330,7 @@ const AvatarDrawerContent = ({ open, mode, selectedAvatar, onClose }: Props) => 
           removalPromises.push(AvatarService.removeStaticResource(selectedAvatar.thumbnailResourceId))
         await Promise.all(removalPromises)
         await AvatarService.patchAvatar(selectedAvatar.id, uploadResponse[0].id, uploadResponse[1].id, state.name)
-      } else await AvatarService.createAvatar(avatarBlob, thumbnailBlob, state.name)
+      } else await AvatarService.createAvatar(avatarBlob, thumbnailBlob, state.name, true)
       dispatchAction(AdminAvatarActions.avatarUpdated({}))
 
       onClose()

--- a/packages/client-core/src/systems/ui/ProfileDetailView/ReadyPlayerMenu.tsx
+++ b/packages/client-core/src/systems/ui/ProfileDetailView/ReadyPlayerMenu.tsx
@@ -136,7 +136,7 @@ const ReadyPlayerMenu = () => {
     var thumbnailName = avatarUrl.substring(0, avatarUrl.lastIndexOf('.')) + '.png'
 
     canvas.toBlob(async (blob) => {
-      await AvatarService.createAvatar(selectedFile, new File([blob!], thumbnailName), avatarName)
+      await AvatarService.createAvatar(selectedFile, new File([blob!], thumbnailName), avatarName, false)
       WidgetAppService.setWidgetVisibility(WidgetName.PROFILE, true)
     })
   }

--- a/packages/client-core/src/systems/ui/ProfileDetailView/UploadAvatarMenu.tsx
+++ b/packages/client-core/src/systems/ui/ProfileDetailView/UploadAvatarMenu.tsx
@@ -201,11 +201,11 @@ export const UploadAvatarMenu = () => {
           const uploadResponse = await AvatarService.uploadAvatarModel(avatarBlob, blob!, avatarName, false).then(
             resolve
           )
-          await AvatarService.createAvatar(uploadResponse[0], uploadResponse[1], avatarName)
+          await AvatarService.createAvatar(uploadResponse[0], uploadResponse[1], avatarName, false)
         })
       })
     } else {
-      await AvatarService.createAvatar(avatarBlob, thumbnailBlob, avatarName)
+      await AvatarService.createAvatar(avatarBlob, thumbnailBlob, avatarName, false)
     }
 
     WidgetAppService.setWidgetVisibility(WidgetName.PROFILE, true)

--- a/packages/client-core/src/user/components/UserMenu/menus/AvatarSelectMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/AvatarSelectMenu.tsx
@@ -39,7 +39,6 @@ const logger = multiLogger.child({ component: 'client-core:AvatarSelectMenu' })
 
 interface Props {
   avatarData?: StaticResourceInterface
-  isPublicAvatar?: boolean
   changeActiveMenu: Function
   onAvatarUpload?: () => void
 }
@@ -79,7 +78,7 @@ function TabPanel({ children, value, index }: TabPanelProps) {
   )
 }
 
-export const AvatarUploadModal = ({ avatarData, isPublicAvatar, changeActiveMenu, onAvatarUpload }: Props) => {
+export const AvatarUploadModal = ({ avatarData, changeActiveMenu, onAvatarUpload }: Props) => {
   const [selectedFile, setSelectedFile] = useState<any>(null)
   const [selectedThumbnail, setSelectedThumbnail] = useState<any>(null)
   const [avatarName, setAvatarName] = useState('')
@@ -233,11 +232,11 @@ export const AvatarUploadModal = ({ avatarData, isPublicAvatar, changeActiveMenu
         const newContext = canvas.getContext('2d')
         newContext?.drawImage(renderer.domElement, 0, 0)
         canvas.toBlob((blob) => {
-          AvatarService.createAvatar(avatarBlob, blob!, avatarName, isPublicAvatar)
+          AvatarService.createAvatar(avatarBlob, blob!, avatarName, false)
         })
       })
     } else {
-      await AvatarService.createAvatar(avatarBlob, thumbnailBlob, avatarName, isPublicAvatar)
+      await AvatarService.createAvatar(avatarBlob, thumbnailBlob, avatarName, false)
     }
 
     onAvatarUpload && onAvatarUpload()

--- a/packages/client-core/src/user/components/UserMenu/menus/ReadyPlayerMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ReadyPlayerMenu.tsx
@@ -20,7 +20,6 @@ import { Views } from '../util'
 import { addAnimationLogic, initialize3D, onWindowResize, validate } from './helperFunctions'
 
 interface Props {
-  isPublicAvatar?: boolean
   changeActiveMenu: Function
 }
 
@@ -28,7 +27,7 @@ let scene: Scene
 let camera: PerspectiveCamera
 let renderer: WebGLRenderer = null!
 
-const ReadyPlayerMenu = ({ isPublicAvatar, changeActiveMenu }: Props) => {
+const ReadyPlayerMenu = ({ changeActiveMenu }: Props) => {
   const { t } = useTranslation()
   const [selectedFile, setSelectedFile] = useState<Blob>()
   const [avatarName, setAvatarName] = useState('')
@@ -116,7 +115,7 @@ const ReadyPlayerMenu = ({ isPublicAvatar, changeActiveMenu }: Props) => {
 
     canvas.toBlob(async (blob) => {
       setShowLoading(true)
-      await AvatarService.createAvatar(selectedFile, new File([blob!], thumbnailName), avatarName, isPublicAvatar)
+      await AvatarService.createAvatar(selectedFile, new File([blob!], thumbnailName), avatarName, false)
       setShowLoading(false)
       changeActiveMenu(null)
     })

--- a/packages/client-core/src/user/services/AvatarService.ts
+++ b/packages/client-core/src/user/services/AvatarService.ts
@@ -13,13 +13,13 @@ import { uploadToFeathersService } from '../../util/upload'
 import { accessAuthState, AuthAction } from './AuthService'
 
 export const AvatarService = {
-  async createAvatar(model: Blob, thumbnail: Blob, avatarName: string, isPublicAvatar?: boolean) {
+  async createAvatar(model: Blob, thumbnail: Blob, avatarName: string, isPublic: boolean) {
     const newAvatar = await API.instance.client.service('avatar').create({
       name: avatarName,
-      isPublicAvatar: isPublicAvatar
+      isPublic
     })
 
-    const uploadResponse = await AvatarService.uploadAvatarModel(model, thumbnail, newAvatar.identifierName)
+    const uploadResponse = await AvatarService.uploadAvatarModel(model, thumbnail, newAvatar.identifierName, isPublic)
 
     const patchedAvatar = (await AvatarService.patchAvatar(
       newAvatar.id,
@@ -28,7 +28,7 @@ export const AvatarService = {
       newAvatar.name
     )) as AvatarInterface
 
-    if (!isPublicAvatar) {
+    if (!isPublic) {
       const selfUser = accessAuthState().user
       const userId = selfUser.id.value!
       await AvatarService.updateUserAvatarId(
@@ -96,12 +96,12 @@ export const AvatarService = {
     dispatchAction(AuthAction.avatarUpdatedAction({ url: result.url }))
   },
 
-  async uploadAvatarModel(avatar: Blob, thumbnail: Blob, avatarName: string, isPublicAvatar?: boolean) {
+  async uploadAvatarModel(avatar: Blob, thumbnail: Blob, avatarName: string, isPublic: boolean) {
     return uploadToFeathersService('upload-asset', [avatar, thumbnail], {
       type: 'user-avatar-upload',
       args: {
         avatarName,
-        isPublicAvatar: !!isPublicAvatar
+        isPublic
       }
     }).promise as Promise<StaticResourceInterface[]>
   }

--- a/packages/common/src/dbmodels/AvatarResource.ts
+++ b/packages/common/src/dbmodels/AvatarResource.ts
@@ -4,4 +4,6 @@ export interface AvatarInterface {
   identifierName: string
   modelResourceId: string
   thumbnailResourceId: string
+  isPublic: boolean
+  userId: string
 }

--- a/packages/common/src/interfaces/AvatarInterface.ts
+++ b/packages/common/src/interfaces/AvatarInterface.ts
@@ -3,6 +3,8 @@ import { StaticResourceInterface } from './StaticResourceInterface'
 export type AvatarInterface = {
   id: string
   name: string
+  isPublic: boolean
+  userId: string
   modelResourceId: string
   thumbnailResourceId: string
   identifierName: string

--- a/packages/common/src/interfaces/UploadAssetInterface.ts
+++ b/packages/common/src/interfaces/UploadAssetInterface.ts
@@ -4,7 +4,7 @@ export type AvatarUploadType = {
   userId?: string
   args: {
     avatarName: string
-    isPublicAvatar: boolean
+    isPublic: boolean
   }
 }
 

--- a/packages/server-core/src/hooks/verify-scope.ts
+++ b/packages/server-core/src/hooks/verify-scope.ts
@@ -30,3 +30,23 @@ export default (currentType: string, scopeToVerify: string) => {
     return context
   }
 }
+
+export const checkScope = async (user: UserInterface, app: Application, currentType: string, scopeToVerify: string) => {
+  const scopes = await app.service('scope').Model.findAll({
+    where: {
+      userId: user.id
+    },
+    raw: true,
+    nest: true
+  })
+  if (!scopes) throw new NotFoundException('No scope available for the current user.')
+
+  const currentScopes = scopes.reduce((result, sc) => {
+    if (sc.type.split(':')[0] === currentType) result.push(sc.type.split(':')[1])
+    return result
+  }, [])
+  if (!currentScopes.includes(scopeToVerify)) {
+    return false
+  }
+  return true
+}

--- a/packages/server-core/src/user/avatar/avatar.class.ts
+++ b/packages/server-core/src/user/avatar/avatar.class.ts
@@ -5,7 +5,9 @@ import { Op } from 'sequelize'
 import { AvatarInterface } from '@xrengine/common/src/interfaces/AvatarInterface'
 
 import { Application } from '../../../declarations'
+import { checkScope } from '../../hooks/verify-scope'
 import logger from '../../logger'
+import { UnauthorizedException } from '../../util/exceptions/exception'
 import { AvatarCreateArguments, AvatarPatchArguments } from './avatar-helper'
 
 export class Avatar extends Service<AvatarInterface> {
@@ -35,6 +37,11 @@ export class Avatar extends Service<AvatarInterface> {
   }
 
   async find(params?: Params): Promise<AvatarInterface[] | Paginated<AvatarInterface>> {
+    let isAdmin = false
+    if (params && params.user && params.user.id) {
+      isAdmin = await checkScope(params?.user, this.app, 'admin', 'admin')
+    }
+
     if (params?.query?.search != null) {
       if (params.query.search.length > 0)
         params.query.name = {
@@ -42,6 +49,29 @@ export class Avatar extends Service<AvatarInterface> {
         }
     }
     if (params?.query) delete params.query.search
+
+    if (!isAdmin && params) {
+      if (params.user && params.user.id) {
+        params.query = {
+          ...params?.query,
+          [Op.or]: [
+            {
+              isPublic: true
+            },
+            {
+              isPublic: false,
+              userId: params.user.id
+            }
+          ]
+        }
+      } else {
+        params.query = {
+          ...params?.query,
+          isPublic: true
+        }
+      }
+    }
+
     const avatars = (await super.find(params)) as Paginated<AvatarInterface>
     await Promise.all(
       avatars.data.map(async (avatar) => {
@@ -62,6 +92,8 @@ export class Avatar extends Service<AvatarInterface> {
   async create(data: AvatarCreateArguments, params?: Params): Promise<AvatarInterface> {
     let avatar = (await super.create({
       name: data.name,
+      isPublic: data.isPublic ?? true,
+      userId: params?.user.id,
       modelResourceId: data.modelResourceId,
       thumbnailResourceId: data.thumbnailResourceId
     })) as AvatarInterface
@@ -72,10 +104,20 @@ export class Avatar extends Service<AvatarInterface> {
   }
 
   async patch(id: string, data: AvatarPatchArguments, params?: Params): Promise<AvatarInterface> {
-    let avatar = (await super.patch(id, data, params)) as AvatarInterface
+    let avatar = (await super.get(id, params)) as AvatarInterface
+
+    if (avatar.userId !== params?.user.id && params && params.user && params.user.id) {
+      const hasPermission = await checkScope(params?.user, this.app, 'admin', 'admin')
+      if (!hasPermission) {
+        throw new UnauthorizedException(`Unauthorised to perform this action.`)
+      }
+    }
+
+    avatar = (await super.patch(id, data, params)) as AvatarInterface
     avatar = (await super.patch(avatar.id, {
       identifierName: avatar.name + '_' + avatar.id
     })) as AvatarInterface
+
     if (avatar.modelResourceId)
       try {
         avatar.modelResource = await this.app.service('static-resource').get(avatar.modelResourceId)

--- a/packages/server-core/src/user/avatar/avatar.hooks.ts
+++ b/packages/server-core/src/user/avatar/avatar.hooks.ts
@@ -1,6 +1,5 @@
 import { disallow, iff, isProvider } from 'feathers-hooks-common'
 
-import addAssociations from '../../hooks/add-associations'
 import authenticate from '../../hooks/authenticate'
 import verifyScope from '../../hooks/verify-scope'
 
@@ -11,7 +10,7 @@ export default {
     get: [],
     create: [],
     update: [disallow()],
-    patch: [iff(isProvider('external'), verifyScope('admin', 'admin') as any)],
+    patch: [],
     remove: [iff(isProvider('external'), verifyScope('admin', 'admin') as any)]
   },
   after: {

--- a/packages/server-core/src/user/avatar/avatar.model.ts
+++ b/packages/server-core/src/user/avatar/avatar.model.ts
@@ -28,6 +28,13 @@ export default (app: Application) => {
       },
       thumbnailResourceId: {
         type: DataTypes.STRING
+      },
+      isPublic: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: true
+      },
+      userId: {
+        type: DataTypes.UUID
       }
     },
     {


### PR DESCRIPTION
## Summary

- Avatars should have isPublic flag. 
- Avatars uploaded from admin panel or project import will be public. All other will be private
- Admins can view all avatars
- User can view public and their uploaded avatars.

For details please read the referenced issue details.

## References

closes #6865


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

