### PR TITLE
Add Connecting To World UI

### DIFF
--- a/packages/client-core/src/components/Layout/index.tsx
+++ b/packages/client-core/src/components/Layout/index.tsx
@@ -2,15 +2,12 @@ import React, { Suspense, useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useTranslation } from 'react-i18next'
 
-import { useClientSettingState } from '@xrengine/client-core/src/admin/services/Setting/ClientSettingService'
-import {
-  AdminCoilSettingService,
-  useCoilSettingState
-} from '@xrengine/client-core/src/admin/services/Setting/CoilSettingService'
 import UIDialog from '@xrengine/client-core/src/common/components/Dialog'
 import UserMenu from '@xrengine/client-core/src/user/components/UserMenu'
 import { AudioEffectPlayer } from '@xrengine/engine/src/audio/systems/MediaSystem'
 import { isTouchAvailable } from '@xrengine/engine/src/common/functions/DetectFeatures'
+import { EngineState } from '@xrengine/engine/src/ecs/classes/EngineState'
+import { getState, useHookstate } from '@xrengine/hyperflux'
 
 import { Close, FullscreenExit, ZoomOutMap } from '@mui/icons-material'
 import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown'
@@ -38,7 +35,7 @@ interface Props {
 }
 
 const Layout = ({ useLoadingScreenOpacity, pageTitle, children, hideVideo, hideFullscreen }: Props): any => {
-  const clientSettingState = useClientSettingState()
+  const engineState = useHookstate(getState(EngineState))
   const [fullScreenActive, setFullScreenActive] = useFullscreen()
   const [showMediaIcons, setShowMediaIcons] = useState(true)
   const [showBottomIcons, setShowBottomIcons] = useState(true)
@@ -193,11 +190,13 @@ const Layout = ({ useLoadingScreenOpacity, pageTitle, children, hideVideo, hideF
                   {!hideVideo && <UserMediaWindows className={styles.userMediaWindows} />}
                 </div>
 
-                <InstanceChat
-                  animate={styles.animateBottom}
-                  hideOtherMenus={hideOtherMenus}
-                  setShowTouchPad={setShowTouchPad}
-                />
+                {engineState.connectedWorld.value && (
+                  <InstanceChat
+                    animate={styles.animateBottom}
+                    hideOtherMenus={hideOtherMenus}
+                    setShowTouchPad={setShowTouchPad}
+                  />
+                )}
               </div>
             </div>
           </>

--- a/packages/client-core/src/components/World/ConnectingToWorldServerModal.tsx
+++ b/packages/client-core/src/components/World/ConnectingToWorldServerModal.tsx
@@ -1,0 +1,23 @@
+import { useState } from '@hookstate/core'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { EngineState } from '@xrengine/engine/src/ecs/classes/EngineState'
+import { getState } from '@xrengine/hyperflux'
+
+import styles from './index.module.scss'
+
+export const ConnectingToWorldServerModal = () => {
+  const { t } = useTranslation()
+  const engineState = useState(getState(EngineState))
+
+  if (engineState.connectedWorld.value) return <></>
+
+  return (
+    <div className={styles.modalConnecting}>
+      <div className={styles.modalConnectingTitle}>
+        <p>{t('common:loader.connecting')}</p>
+      </div>
+    </div>
+  )
+}

--- a/packages/client-core/src/components/World/NetworkInstanceProvisioning.tsx
+++ b/packages/client-core/src/components/World/NetworkInstanceProvisioning.tsx
@@ -23,6 +23,7 @@ import { addActionReceptor, dispatchAction, removeActionReceptor, useHookEffect 
 
 import { PartyService, usePartyState } from '../../social/services/PartyService'
 import { UserServiceReceptor } from '../../user/services/UserService'
+import { ConnectingToWorldServerModal } from './ConnectingToWorldServerModal'
 import InstanceServerWarnings from './InstanceServerWarnings'
 
 export const NetworkInstanceProvisioning = () => {
@@ -193,7 +194,12 @@ export const NetworkInstanceProvisioning = () => {
     currentChannelInstanceConnection?.connecting
   ])
 
-  return <InstanceServerWarnings />
+  return (
+    <>
+      <InstanceServerWarnings />
+      <ConnectingToWorldServerModal />
+    </>
+  )
 }
 
 export default NetworkInstanceProvisioning

--- a/packages/client-core/src/components/World/index.module.scss
+++ b/packages/client-core/src/components/World/index.module.scss
@@ -1,0 +1,17 @@
+@import "@xrengine/client-core/src/styles/imports.module.scss";
+
+.modalConnecting {
+  right: 0;
+  bottom: 0;
+
+  // pointer-events: none;
+  z-index: 1000;
+  position: absolute;
+
+  .modalConnectingTitle {
+    padding: 20px 12px;
+    color: white;
+    text-shadow: 1px 1px 2px grey, 0 0 1em grey, 0 0 1em grey;
+    font-size: 0.7rem;
+  }
+}


### PR DESCRIPTION
## Summary

Hides instance chat if a world is not connected to, replacing it with small 'Connecting to world...' text to allow the user to see they are still connecting.

## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

