### PR TITLE
Fixed bug with project reset in deployed mode.

### DIFF
--- a/packages/server-core/src/projects/githubapp/githubapp-helper.ts
+++ b/packages/server-core/src/projects/githubapp/githubapp-helper.ts
@@ -272,7 +272,6 @@ export const pushProjectToGithub = async (
       const branches = await git.branchLocal()
       await git.push('origin', `${branches.current}:${defaultBranch}`, ['-f'])
     } else await uploadToRepo(octoKit, files, owner, repo, defaultBranch, project.name, githubIdentityProvider != null)
-    if (!isDev) deleteFolderRecursive(localProjectDirectory)
   } catch (err) {
     logger.error(err)
     throw err


### PR DESCRIPTION
In deployed mode, pushProjectToGithub was deleting the project folder after push. If the project had onInstall hooks to run, there was no local copy of the project to run on, and would throw errors. Removed the deletion to fix this.

## Summary

_A summary of changes being made in this PR_


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

