### PR TITLE
Fixed issues with key stuck on instance load and chat getting movement keys

### DIFF
--- a/packages/client-core/src/components/InstanceChat/index.tsx
+++ b/packages/client-core/src/components/InstanceChat/index.tsx
@@ -371,7 +371,6 @@ const InstanceChat = ({
                   label={newMessageLabel}
                   name="newMessage"
                   variant="standard"
-                  autoFocus
                   value={composingMessage}
                   inputProps={{
                     maxLength: 1000,


### PR DESCRIPTION
## Summary

Having 'autofocus' on the instance chat was causing problems. Since it's not display:none when closed, and it doesn't load until the instance has been connected to, if it was rendered when the user was moving, it was now getting focus. Their movement key presses were getting entered into the instance chat, and movement was never seeing the keyup that would tell it to stop. Removed autofocus from instance chat.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

