### PR TITLE
Fixed issue with redis connection string password.

### DIFF
--- a/packages/server-core/src/createApp.ts
+++ b/packages/server-core/src/createApp.ts
@@ -90,7 +90,7 @@ export const configureRedis = () => (app: Application) => {
     app.configure(
       sync({
         uri: config.redis.password
-          ? `redis://${config.redis.address}:${config.redis.port}?password=${config.redis.password}`
+          ? `redis://:${config.redis.password}@${config.redis.address}:${config.redis.port}`
           : `redis://${config.redis.address}:${config.redis.port}`
       })
     )


### PR DESCRIPTION
## Summary

feathers-sync v3 uses redis v4, which requires that the password be passed at the start of the connection string, as opposed to as a query parameter. Made this change.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

