### PR TITLE
fix: import error

### DIFF
--- a/packages/client-core/src/Private.tsx
+++ b/packages/client-core/src/Private.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Route } from 'react-router'
+import { Route } from 'react-router-dom'
 
 import Dashboard from './user/components/Dashboard'
 


### PR DESCRIPTION
## Summary

Seems like there's an incorrect import on line 2 of `client-core/src/Private.tsx`. It's importing `Route` from `react-router` , which isn't declared as a dep in package.json. Also this causes the /admin routes to stop loading with this error, and changing it to `react-router-dom` fixes it.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

