### PR TITLE
Add k8s active pod logging page in admin panel

### DIFF
--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -51,6 +51,7 @@
     },
     "common": {
       "cancel": "Cancel",
+      "close": "Close",
       "edit": "Edit",
       "submit": "Submit",
       "save": "Save",
@@ -354,17 +355,20 @@
       "clearAllScopes": "Clear All Scopes"
     },
     "server": {
-      "loading": "Loading Server Info",
+      "loading": "Fetching Server Info",
+      "loadingLogs": "Fetching Server Logs",
       "name": "Name",
       "status": "Status",
       "restarts": "Restarts",
       "containers": "Containers",
+      "container": "Container",
       "age": "Age",
       "logs": "Logs",
       "autoRefresh": "Auto Refresh",
       "none": "None",
       "seconds": "seconds",
-      "minutes": "minutes"
+      "minutes": "minutes",
+      "download": "Download"
     }
   }
 }

--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -351,6 +351,9 @@
       "isGuest": "Is guest",
       "selectAllScopes": "Select All Scopes",
       "clearAllScopes": "Clear All Scopes"
+    },
+    "server": {
+      "loading": "Loading Server Info"
     }
   }
 }

--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -353,7 +353,17 @@
       "clearAllScopes": "Clear All Scopes"
     },
     "server": {
-      "loading": "Loading Server Info"
+      "loading": "Loading Server Info",
+      "name": "Name",
+      "status": "Status",
+      "restarts": "Restarts",
+      "containers": "Containers",
+      "age": "Age",
+      "logs": "Logs",
+      "autoRefresh": "Auto Refresh",
+      "none": "None",
+      "seconds": "seconds",
+      "minutes": "minutes"
     }
   }
 }

--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -65,6 +65,7 @@
       "view": "View",
       "yes": "Yes",
       "no": "No",
+      "refresh": "Refresh",
       "fillRequiredFields": "Please fill all required field",
       "fixErrorFields": "Please fix all errors"
     },

--- a/packages/client-core/i18n/en/user.json
+++ b/packages/client-core/i18n/en/user.json
@@ -328,7 +328,8 @@
     "resources": "Resources",
     "benchmarking": "Benchmarking",
     "bots": "Bots",
-    "setting": "Settings"
+    "setting": "Settings",
+    "server": "Server"
   },
   "resource": {
     "createResource": "Create Resource"

--- a/packages/client-core/i18n/en/user.json
+++ b/packages/client-core/i18n/en/user.json
@@ -296,7 +296,8 @@
       "scenes": "Scenes",
       "avatars": "Avatars",
       "benchmarking": "Benchmarking",
-      "bots": "Bots"
+      "bots": "Bots",
+      "server": "Server"
     }
   },
   "oauth": {

--- a/packages/client-core/package.json
+++ b/packages/client-core/package.json
@@ -60,6 +60,7 @@
     "hark": "^1.2.3",
     "i18next": "21.6.16",
     "image-palette-core": "0.2.2",
+    "javascript-time-ago": "^2.5.7",
     "jwt-decode": "3.1.2",
     "lodash": "4.17.21",
     "material-ui-confirm": "3.0.5",

--- a/packages/client-core/package.json
+++ b/packages/client-core/package.json
@@ -77,6 +77,7 @@
     "react-i18next": "11.16.6",
     "react-joystick-component": "4.0.0",
     "react-material-ui-form-validator": "3.0.0",
+    "react-reflex": "^4.0.9",
     "react-responsive": "9.0.0-beta.6",
     "react-router-dom": "5.3.0",
     "semantic-ui-react": "2.1.2",

--- a/packages/client-core/src/admin/adminRoutes.tsx
+++ b/packages/client-core/src/admin/adminRoutes.tsx
@@ -23,6 +23,7 @@ import party from './components/Party'
 import projects from './components/Project'
 import resources from './components/Resources'
 import routes from './components/Routes'
+import server from './components/Server'
 import setting from './components/Setting'
 import users from './components/Users'
 
@@ -50,7 +51,8 @@ const ProtectedRoutes = () => {
     benchmarking: false,
     routes: false,
     projects: false,
-    settings: false
+    settings: false,
+    server: false,
   }
   const scopes = admin?.scopes?.value || []
 
@@ -62,7 +64,7 @@ const ProtectedRoutes = () => {
 
   scopes.forEach((scope) => {
     if (Object.keys(allowedRoutes).includes(scope.type.split(':')[0])) {
-      if (scope.type.split(':')[1] === 'read') {
+      if (scope.type.split(':')[1] === 'read' || scope.type.split(':')[1] === 'admin') {
         allowedRoutes = {
           ...allowedRoutes,
           [scope.type.split(':')[0]]: true
@@ -105,6 +107,7 @@ const ProtectedRoutes = () => {
             {allowedRoutes.party && <PrivateRoute exact path="/admin/parties" component={party} />}
             {allowedRoutes.bot && <PrivateRoute exact path="/admin/bots" component={botSetting} />}
             {allowedRoutes.projects && <PrivateRoute exact path="/admin/projects" component={projects} />}
+            {allowedRoutes.server && <PrivateRoute exact path="/admin/server" component={server} />}
             {allowedRoutes.settings && <PrivateRoute exact path="/admin/settings" component={setting} />}
             {allowedRoutes.static_resource && <PrivateRoute exact path="/admin/resources" component={resources} />}
             {allowedRoutes.user && <PrivateRoute exact path="/admin/users" component={users} />}

--- a/packages/client-core/src/admin/adminRoutes.tsx
+++ b/packages/client-core/src/admin/adminRoutes.tsx
@@ -52,7 +52,7 @@ const ProtectedRoutes = () => {
     routes: false,
     projects: false,
     settings: false,
-    server: false,
+    server: false
   }
   const scopes = admin?.scopes?.value || []
 
@@ -64,7 +64,7 @@ const ProtectedRoutes = () => {
 
   scopes.forEach((scope) => {
     if (Object.keys(allowedRoutes).includes(scope.type.split(':')[0])) {
-      if (scope.type.split(':')[1] === 'read' || scope.type.split(':')[1] === 'admin') {
+      if (scope.type.split(':')[1] === 'read') {
         allowedRoutes = {
           ...allowedRoutes,
           [scope.type.split(':')[0]]: true

--- a/packages/client-core/src/admin/common/variables/server.ts
+++ b/packages/client-core/src/admin/common/variables/server.ts
@@ -1,0 +1,18 @@
+import { ServerPodInfo } from '@xrengine/common/src/interfaces/ServerInfo'
+
+export interface ServerColumn {
+  id: string
+  label: JSX.Element
+  minWidth?: number
+  align?: 'right'
+}
+
+export interface ServerPodData {
+  el: ServerPodInfo
+  name: string
+  status: string
+  age: string
+  containers: JSX.Element
+  restarts: string
+  action: JSX.Element
+}

--- a/packages/client-core/src/admin/components/Instance/index.tsx
+++ b/packages/client-core/src/admin/components/Instance/index.tsx
@@ -30,7 +30,7 @@ const Instance = () => {
   }
 
   return (
-    <React.Fragment>
+    <div>
       <Grid container spacing={1} className={styles.mb10px}>
         <Grid item xs={12} sm={8}>
           <Search text="instance" handleChange={handleChange} />
@@ -48,7 +48,7 @@ const Instance = () => {
       </Grid>
       <InstanceTable className={styles.rootTableWithSearch} search={search} />
       {patchInstanceserverOpen && <PatchInstanceserver open onClose={() => setPatchInstanceserverOpen(false)} />}
-    </React.Fragment>
+    </div>
   )
 }
 

--- a/packages/client-core/src/admin/components/Resources/index.tsx
+++ b/packages/client-core/src/admin/components/Resources/index.tsx
@@ -44,7 +44,7 @@ const Resources = () => {
   }, [])
 
   return (
-    <React.Fragment>
+    <div>
       <Grid container spacing={1} className={styles.mb10px}>
         <Grid item sm={8} xs={12}>
           <Search sx={{ flexGrow: 1 }} text={t('admin:components.resources.resources')} handleChange={handleChange} />
@@ -107,7 +107,7 @@ const Resources = () => {
           {t('admin:components.common.reset')}
         </Button>
       </Popover>
-    </React.Fragment>
+    </div>
   )
 }
 

--- a/packages/client-core/src/admin/components/Server/ServerLogs.tsx
+++ b/packages/client-core/src/admin/components/Server/ServerLogs.tsx
@@ -1,0 +1,190 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import multiLogger from '@xrengine/common/src/logger'
+
+import CloseIcon from '@mui/icons-material/Close'
+import DownloadIcon from '@mui/icons-material/Download'
+import SyncIcon from '@mui/icons-material/Sync'
+import Box from '@mui/material/Box'
+import CircularProgress from '@mui/material/CircularProgress'
+import IconButton from '@mui/material/IconButton'
+
+import InputSelect, { InputMenuItem } from '../../common/InputSelect'
+import LoadingView from '../../common/LoadingView'
+import { useServerInfoState } from '../../services/ServerInfoService'
+import { ServerLogsService, useServerLogsState } from '../../services/ServerLogsService'
+import styles from '../../styles/admin.module.scss'
+
+const logger = multiLogger.child({ component: 'client-core:ServerLogs' })
+
+const ServerLogs = () => {
+  const { t } = useTranslation()
+  const logsEndRef = useRef(null)
+  const [autoRefresh, setAutoRefresh] = useState('0')
+  const [intervalTimer, setIntervalTimer] = useState<NodeJS.Timer>()
+  const serverInfo = useServerInfoState()
+  const serverLogs = useServerLogsState()
+
+  const scrollLogsToBottom = () => {
+    ;(logsEndRef.current as any)?.scrollIntoView({ behavior: 'smooth' })
+  }
+
+  // Scroll to bottom of logs
+  useEffect(() => {
+    scrollLogsToBottom()
+  }, [serverLogs.logs.value])
+
+  useEffect(() => {
+    if (autoRefresh !== '0') {
+      const interval = setInterval(() => {
+        handleRefreshServerLogs()
+      }, parseInt(autoRefresh) * 1000)
+      setIntervalTimer(interval)
+      return () => {
+        if (interval) clearInterval(interval) // This represents the unmount function, in which you need to clear your interval to prevent memory leaks.
+      }
+    } else if (intervalTimer) {
+      clearInterval(intervalTimer)
+      setIntervalTimer(undefined)
+    }
+  }, [autoRefresh])
+
+  const handleRefreshServerLogs = () => {
+    logger.info('Refreshing server logs.')
+    ServerLogsService.fetchServerLogs(serverLogs.podName.value!, serverLogs.containerName.value!)
+  }
+
+  const handleAutoRefreshServerLogsChange = (e) => {
+    const { value } = e.target
+
+    setAutoRefresh(value)
+  }
+
+  const handleCloseServerLogs = () => {
+    ServerLogsService.resetServerLogs()
+  }
+
+  const handleDownloadServerLogs = () => {
+    const blob = new Blob([serverLogs.value.logs], { type: 'text/plain;charset=utf-8' })
+    window.open(URL.createObjectURL(blob), `${serverLogs.value.logs}.log.txt`)
+  }
+
+  const handleContainerServerLogsChange = (e) => {
+    const { value } = e.target
+
+    ServerLogsService.fetchServerLogs(serverLogs.podName.value!, value)
+  }
+
+  const containers = serverInfo.servers.value
+    .find((item) => item.id === 'all')
+    ?.pods.find((item) => item.name === serverLogs.podName.value!)
+  const containersMenu = containers?.containers.map((item) => {
+    return {
+      value: item.name,
+      label: item.name
+    } as InputMenuItem
+  })
+
+  const autoRefreshMenu: InputMenuItem[] = [
+    {
+      value: '0',
+      label: t('admin:components.server.none')
+    },
+    {
+      value: '10',
+      label: `10 ${t('admin:components.server.seconds')}`
+    },
+    {
+      value: '30',
+      label: `30 ${t('admin:components.server.seconds')}`
+    },
+    {
+      value: '60',
+      label: `60 ${t('admin:components.server.seconds')}`
+    },
+    {
+      value: '300',
+      label: `5 ${t('admin:components.server.minutes')}`
+    },
+    {
+      value: '600',
+      label: `10 ${t('admin:components.server.minutes')}`
+    }
+  ]
+
+  if (!serverLogs.value.fetched) {
+    return (
+      <LoadingView
+        title={t('admin:components.server.loadingLogs')}
+        variant="body2"
+        sx={{ position: 'absolute', top: 0 }}
+      />
+    )
+  }
+
+  return (
+    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', margin: '15px 0' }}>
+        <h5 style={{ fontSize: '18px' }}>
+          {t('admin:components.server.logs')}: {serverLogs.podName.value!}
+        </h5>
+
+        <InputSelect
+          name="autoRefresh"
+          label={t('admin:components.server.container')}
+          value={serverLogs.containerName.value!}
+          menu={containersMenu!}
+          sx={{ marginBottom: 0, width: '200px', marginRight: 1.5, marginLeft: 3 }}
+          onChange={handleContainerServerLogsChange}
+        />
+
+        <div style={{ flex: 1 }}></div>
+
+        <IconButton
+          title={t('admin:components.server.download')}
+          className={styles.iconButton}
+          onClick={handleDownloadServerLogs}
+        >
+          <DownloadIcon />
+        </IconButton>
+
+        {serverLogs.value.retrieving === false && (
+          <IconButton
+            title={t('admin:components.common.refresh')}
+            className={styles.iconButton}
+            sx={{ marginRight: 1.5 }}
+            onClick={handleRefreshServerLogs}
+          >
+            <SyncIcon />
+          </IconButton>
+        )}
+
+        {serverLogs.value.retrieving && <CircularProgress size={24} sx={{ marginRight: 1.5 }} />}
+
+        <InputSelect
+          name="autoRefresh"
+          label={t('admin:components.server.autoRefresh')}
+          value={autoRefresh}
+          menu={autoRefreshMenu}
+          sx={{ marginBottom: 0, width: '160px', marginRight: 1.5 }}
+          onChange={handleAutoRefreshServerLogsChange}
+        />
+
+        <IconButton
+          title={t('admin:components.common.close')}
+          className={styles.iconButton}
+          onClick={handleCloseServerLogs}
+        >
+          <CloseIcon />
+        </IconButton>
+      </Box>
+      <Box sx={{ overflow: 'auto' }}>
+        <pre style={{ fontSize: '14px' }}>{serverLogs.value.logs}</pre>
+        <pre ref={logsEndRef} />
+      </Box>
+    </Box>
+  )
+}
+
+export default ServerLogs

--- a/packages/client-core/src/admin/components/Server/ServerTable.tsx
+++ b/packages/client-core/src/admin/components/Server/ServerTable.tsx
@@ -6,6 +6,11 @@ import { useTranslation } from 'react-i18next'
 import { ServerPodInfo } from '@xrengine/common/src/interfaces/ServerInfo'
 import multiLogger from '@xrengine/common/src/logger'
 
+import SyncIcon from '@mui/icons-material/Sync'
+import Box from '@mui/material/Box'
+import CircularProgress from '@mui/material/CircularProgress'
+import IconButton from '@mui/material/IconButton'
+
 import InputSelect, { InputMenuItem } from '../../common/InputSelect'
 import TableComponent from '../../common/Table'
 import { ServerColumn, ServerPodData } from '../../common/variables/server'
@@ -31,8 +36,7 @@ const ServerTable = ({ selectedCard }: Props) => {
   useEffect(() => {
     if (autoRefresh !== '0') {
       const interval = setInterval(() => {
-        logger.info('Refreshing server info.')
-        ServerInfoService.fetchServerInfo()
+        handleRefreshServerInfo()
       }, parseInt(autoRefresh) * 1000)
       setIntervalTimer(interval)
       return () => {
@@ -78,7 +82,12 @@ const ServerTable = ({ selectedCard }: Props) => {
     }
   }
 
-  const handleAutoRefreshChange = (e) => {
+  const handleRefreshServerInfo = () => {
+    logger.info('Refreshing server info.')
+    ServerInfoService.fetchServerInfo()
+  }
+
+  const handleAutoRefreshServerInfoChange = (e) => {
     const { value } = e.target
 
     setAutoRefresh(value)
@@ -120,14 +129,27 @@ const ServerTable = ({ selectedCard }: Props) => {
     {
       id: 'action',
       label: (
-        <InputSelect
-          name="autoRefresh"
-          label={t('admin:components.server.autoRefresh')}
-          value={autoRefresh}
-          menu={autoRefreshMenu}
-          sx={{ marginBottom: 0 }}
-          onChange={handleAutoRefreshChange}
-        />
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          {serverInfo.value.retrieving === false && (
+            <IconButton
+              title={t('admin:components.common.refresh')}
+              className={styles.iconButton}
+              sx={{ marginRight: 1.5 }}
+              onClick={handleRefreshServerInfo}
+            >
+              <SyncIcon />
+            </IconButton>
+          )}
+          {serverInfo.value.retrieving && <CircularProgress size={24} sx={{ marginRight: 1.5 }} />}
+          <InputSelect
+            name="autoRefresh"
+            label={t('admin:components.server.autoRefresh')}
+            value={autoRefresh}
+            menu={autoRefreshMenu}
+            sx={{ marginBottom: 0, flex: 1 }}
+            onChange={handleAutoRefreshServerInfoChange}
+          />
+        </Box>
       ),
       minWidth: 65
     }

--- a/packages/client-core/src/admin/components/Server/ServerTable.tsx
+++ b/packages/client-core/src/admin/components/Server/ServerTable.tsx
@@ -1,0 +1,136 @@
+import TimeAgo from 'javascript-time-ago'
+import en from 'javascript-time-ago/locale/en'
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { ServerPodInfo } from '@xrengine/common/src/interfaces/ServerInfo'
+
+import InputSelect, { InputMenuItem } from '../../common/InputSelect'
+import TableComponent from '../../common/Table'
+import { ServerColumn, ServerPodData } from '../../common/variables/server'
+import { useServerInfoState } from '../../services/ServerInfoService'
+import styles from '../../styles/admin.module.scss'
+
+TimeAgo.addDefaultLocale(en)
+
+const timeAgo = new TimeAgo('en-US')
+
+interface Props {
+  selectedCard: string
+}
+
+const ServerTable = ({ selectedCard }: Props) => {
+  const { t } = useTranslation()
+  const [autoRefresh, setAutoRefresh] = useState('0')
+  const serverInfo = useServerInfoState()
+
+  const createData = (el: ServerPodInfo): ServerPodData => {
+    return {
+      el,
+      name: el.name,
+      status: el.status,
+      age: timeAgo.format(new Date(el.age)),
+      restarts: el.containers.map((item) => item.restarts).join(', '),
+      containers: (
+        <>
+          {el.containers.map((item) => (
+            <div
+              key={item.name}
+              className={`${styles.containerCircle} ${
+                item.status === 'Running'
+                  ? styles.containerGreen
+                  : item.status === 'Terminated'
+                  ? styles.containerRed
+                  : ''
+              }`}
+              title={`${t('admin:components.server.name')}: ${item.name}\n${t('admin:components.server.status')}: ${
+                item.status
+              }`}
+            />
+          ))}
+        </>
+      ),
+      action: (
+        <a href="#" className={styles.actionStyle} style={{ float: 'right' }} onClick={() => {}}>
+          <span className={styles.spanDange}>{t('admin:components.server.logs')}</span>
+        </a>
+      )
+    }
+  }
+
+  const handleAutoRefreshChange = (e) => {
+    const { value } = e.target
+
+    setAutoRefresh(value)
+  }
+
+  const autoRefreshMenu: InputMenuItem[] = [
+    {
+      value: '0',
+      label: t('admin:components.server.none')
+    },
+    {
+      value: '10',
+      label: `10 ${t('admin:components.server.seconds')}`
+    },
+    {
+      value: '30',
+      label: `30 ${t('admin:components.server.seconds')}`
+    },
+    {
+      value: '60',
+      label: `60 ${t('admin:components.server.seconds')}`
+    },
+    {
+      value: '300',
+      label: `5 ${t('admin:components.server.minutes')}`
+    },
+    {
+      value: '600',
+      label: `10 ${t('admin:components.server.minutes')}`
+    }
+  ]
+
+  const serverInfoDataColumns: ServerColumn[] = [
+    { id: 'name', label: t('admin:components.server.name'), minWidth: 65 },
+    { id: 'status', label: t('admin:components.server.status'), minWidth: 65 },
+    { id: 'restarts', label: t('admin:components.server.restarts'), minWidth: 65 },
+    { id: 'containers', label: t('admin:components.server.containers'), minWidth: 65 },
+    { id: 'age', label: t('admin:components.server.age'), minWidth: 65 },
+    {
+      id: 'action',
+      label: (
+        <InputSelect
+          name="autoRefresh"
+          label={t('admin:components.server.autoRefresh')}
+          value={autoRefresh}
+          menu={autoRefreshMenu}
+          sx={{ marginBottom: 0 }}
+          onChange={handleAutoRefreshChange}
+        />
+      ),
+      minWidth: 65
+    }
+  ]
+
+  const rows = serverInfo.value.servers
+    .find((item) => item.id === selectedCard)!
+    .pods.map((el) => {
+      return createData(el)
+    })
+
+  return (
+    <TableComponent
+      allowSort={false}
+      rows={rows}
+      column={serverInfoDataColumns}
+      page={0}
+      count={rows.length}
+      rowsPerPage={rows.length}
+      handlePageChange={() => {}}
+      handleRowsPerPageChange={() => {}}
+    />
+  )
+}
+
+export default ServerTable

--- a/packages/client-core/src/admin/components/Server/ServerTable.tsx
+++ b/packages/client-core/src/admin/components/Server/ServerTable.tsx
@@ -15,6 +15,7 @@ import InputSelect, { InputMenuItem } from '../../common/InputSelect'
 import TableComponent from '../../common/Table'
 import { ServerColumn, ServerPodData } from '../../common/variables/server'
 import { ServerInfoService, useServerInfoState } from '../../services/ServerInfoService'
+import { ServerLogsService } from '../../services/ServerLogsService'
 import styles from '../../styles/admin.module.scss'
 
 const logger = multiLogger.child({ component: 'client-core:ServerTable' })
@@ -76,7 +77,12 @@ const ServerTable = ({ selectedCard }: Props) => {
       ),
       action: (
         <a href="#" className={styles.actionStyle} style={{ float: 'right' }} onClick={() => {}}>
-          <span className={styles.spanDange}>{t('admin:components.server.logs')}</span>
+          <span
+            className={styles.spanDange}
+            onClick={() => ServerLogsService.fetchServerLogs(el.name, el.containers[el.containers.length - 1].name)}
+          >
+            {t('admin:components.server.logs')}
+          </span>
         </a>
       )
     }
@@ -140,7 +146,9 @@ const ServerTable = ({ selectedCard }: Props) => {
               <SyncIcon />
             </IconButton>
           )}
+
           {serverInfo.value.retrieving && <CircularProgress size={24} sx={{ marginRight: 1.5 }} />}
+
           <InputSelect
             name="autoRefresh"
             label={t('admin:components.server.autoRefresh')}

--- a/packages/client-core/src/admin/components/Server/index.tsx
+++ b/packages/client-core/src/admin/components/Server/index.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { ReflexContainer, ReflexElement, ReflexSplitter } from 'react-reflex'
 
-import { ServerInfoInterface, ServerPodInfo } from '@xrengine/common/src/interfaces/ServerInfo'
+import { ServerInfoInterface } from '@xrengine/common/src/interfaces/ServerInfo'
 
 import { Box, Card, CardActionArea, CardContent, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid'
@@ -11,10 +12,18 @@ import { ServerInfoService, useServerInfoState } from '../../services/ServerInfo
 import styles from '../../styles/admin.module.scss'
 import ServerTable from './ServerTable'
 
+import 'react-reflex/styles.css'
+
+import { useServerLogsState } from '../../services/ServerLogsService'
+import ServerLogs from './ServerLogs'
+
 const Server = () => {
   const { t } = useTranslation()
   const [selectedCard, setSelectedCard] = useState('all')
   const serverInfo = useServerInfoState()
+  const serverLogs = useServerLogsState()
+
+  let displayLogs = serverLogs.podName.value ? true : false
 
   useEffect(() => {
     ServerInfoService.fetchServerInfo()
@@ -27,7 +36,7 @@ const Server = () => {
   }
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+    <Box sx={{ height: 'calc(100% - 106px)' }}>
       <Grid container spacing={1} className={styles.mb10px}>
         {serverInfo.value.servers.map((item, index) => (
           <Grid item key={item.id} xs={12} sm={6} md={2}>
@@ -40,8 +49,22 @@ const Server = () => {
           </Grid>
         ))}
       </Grid>
+      {displayLogs === false && <ServerTable selectedCard={selectedCard} />}
+      {displayLogs && (
+        <ReflexContainer orientation="horizontal">
+          <ReflexElement flex={0.45} style={{ display: 'flex', flexDirection: 'column' }}>
+            <ServerTable selectedCard={selectedCard} />
+          </ReflexElement>
 
-      <ServerTable selectedCard={selectedCard} />
+          <>
+            <ReflexSplitter />
+
+            <ReflexElement flex={0.55} style={{ overflow: 'hidden' }}>
+              <ServerLogs />
+            </ReflexElement>
+          </>
+        </ReflexContainer>
+      )}
     </Box>
   )
 }

--- a/packages/client-core/src/admin/components/Server/index.tsx
+++ b/packages/client-core/src/admin/components/Server/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { ServerInfoInterface, ServerPodInfo } from '@xrengine/common/src/interfaces/ServerInfo'
 
-import { Card, CardActionArea, CardContent, Typography } from '@mui/material'
+import { Box, Card, CardActionArea, CardContent, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid'
 
 import LoadingView from '../../common/LoadingView'
@@ -27,7 +27,7 @@ const Server = () => {
   }
 
   return (
-    <React.Fragment>
+    <Box sx={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
       <Grid container spacing={1} className={styles.mb10px}>
         {serverInfo.value.servers.map((item, index) => (
           <Grid item key={item.id} xs={12} sm={6} md={2}>
@@ -42,7 +42,7 @@ const Server = () => {
       </Grid>
 
       <ServerTable selectedCard={selectedCard} />
-    </React.Fragment>
+    </Box>
   )
 }
 

--- a/packages/client-core/src/admin/components/Server/index.tsx
+++ b/packages/client-core/src/admin/components/Server/index.tsx
@@ -7,41 +7,19 @@ import { Card, CardActionArea, CardContent, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid'
 
 import LoadingView from '../../common/LoadingView'
-import { ServerInfoService } from '../../services/ServerInfoService'
+import { ServerInfoService, useServerInfoState } from '../../services/ServerInfoService'
 import styles from '../../styles/admin.module.scss'
 
 const Server = () => {
   const { t } = useTranslation()
-  const [isLoading, setIsLoading] = useState(true)
   const [selectedCard, setSelectedCard] = useState('all')
-  const [serverInfo, setServerInfo] = useState<ServerInfoInterface[]>([])
+  const serverInfo = useServerInfoState()
 
   useEffect(() => {
-    loadServerInfo()
+    ServerInfoService.fetchServerInfo()
   }, [])
 
-  const loadServerInfo = async () => {
-    setIsLoading(true)
-    let response: ServerInfoInterface[] = await ServerInfoService.fetchServerInfo()
-
-    const allPods: ServerPodInfo[] = []
-    for (const item of response) {
-      allPods.push(...item.pods)
-    }
-
-    response = [
-      {
-        id: 'all',
-        label: 'All',
-        pods: allPods
-      },
-      ...response
-    ]
-    setServerInfo(response)
-    setIsLoading(false)
-  }
-
-  if (isLoading) {
+  if (!serverInfo.value.fetched) {
     return (
       <LoadingView title={t('admin:components.server.loading')} variant="body2" sx={{ position: 'absolute', top: 0 }} />
     )
@@ -49,7 +27,7 @@ const Server = () => {
 
   return (
     <Grid container spacing={1} className={styles.mb10px}>
-      {serverInfo.map((item, index) => (
+      {serverInfo.value.servers.map((item, index) => (
         <Grid item xs={12} sm={6} md={2}>
           <ServerItemCard key={index} data={item} isSelected={selectedCard === item.id} onCardClick={setSelectedCard} />
         </Grid>

--- a/packages/client-core/src/admin/components/Server/index.tsx
+++ b/packages/client-core/src/admin/components/Server/index.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { ServerInfoInterface, ServerPodInfo } from '@xrengine/common/src/interfaces/ServerInfo'
+
+import { Card, CardActionArea, CardContent, Typography } from '@mui/material'
+import Grid from '@mui/material/Grid'
+
+import LoadingView from '../../common/LoadingView'
+import { ServerInfoService } from '../../services/ServerInfoService'
+import styles from '../../styles/admin.module.scss'
+
+const Server = () => {
+  const { t } = useTranslation()
+  const [isLoading, setIsLoading] = useState(true)
+  const [selectedCard, setSelectedCard] = useState('all')
+  const [serverInfo, setServerInfo] = useState<ServerInfoInterface[]>([])
+
+  useEffect(() => {
+    loadServerInfo()
+  }, [])
+
+  const loadServerInfo = async () => {
+    setIsLoading(true)
+    let response: ServerInfoInterface[] = await ServerInfoService.fetchServerInfo()
+
+    const allPods: ServerPodInfo[] = []
+    for (const item of response) {
+      allPods.push(...item.pods)
+    }
+
+    response = [
+      {
+        id: 'all',
+        label: 'All',
+        pods: allPods
+      },
+      ...response
+    ]
+    setServerInfo(response)
+    setIsLoading(false)
+  }
+
+  if (isLoading) {
+    return (
+      <LoadingView title={t('admin:components.server.loading')} variant="body2" sx={{ position: 'absolute', top: 0 }} />
+    )
+  }
+
+  return (
+    <Grid container spacing={1} className={styles.mb10px}>
+      {serverInfo.map((item, index) => (
+        <Grid item xs={12} sm={6} md={2}>
+          <ServerItemCard key={index} data={item} isSelected={selectedCard === item.id} onCardClick={setSelectedCard} />
+        </Grid>
+      ))}
+    </Grid>
+  )
+}
+
+interface ServerItemProps {
+  data: ServerInfoInterface
+  isSelected: boolean
+  onCardClick: (key: string) => void
+}
+
+const ServerItemCard = ({ data, isSelected, onCardClick }: ServerItemProps) => {
+  return (
+    <Card className={`${styles.rootCardNumber} ${isSelected ? styles.selectedCard : ''}`}>
+      <CardActionArea onClick={() => onCardClick(data.id)}>
+        <CardContent className="text-center">
+          <Typography variant="h5" component="h5" className={styles.label}>
+            {data.label}
+          </Typography>
+          <Typography variant="body1" component="p" className={styles.label}>
+            {data.pods.filter((item) => item.status === 'Running').length}/{data.pods.length}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  )
+}
+
+export default Server

--- a/packages/client-core/src/admin/components/Server/index.tsx
+++ b/packages/client-core/src/admin/components/Server/index.tsx
@@ -9,6 +9,7 @@ import Grid from '@mui/material/Grid'
 import LoadingView from '../../common/LoadingView'
 import { ServerInfoService, useServerInfoState } from '../../services/ServerInfoService'
 import styles from '../../styles/admin.module.scss'
+import ServerTable from './ServerTable'
 
 const Server = () => {
   const { t } = useTranslation()
@@ -26,13 +27,22 @@ const Server = () => {
   }
 
   return (
-    <Grid container spacing={1} className={styles.mb10px}>
-      {serverInfo.value.servers.map((item, index) => (
-        <Grid item xs={12} sm={6} md={2}>
-          <ServerItemCard key={index} data={item} isSelected={selectedCard === item.id} onCardClick={setSelectedCard} />
-        </Grid>
-      ))}
-    </Grid>
+    <React.Fragment>
+      <Grid container spacing={1} className={styles.mb10px}>
+        {serverInfo.value.servers.map((item, index) => (
+          <Grid item key={item.id} xs={12} sm={6} md={2}>
+            <ServerItemCard
+              key={index}
+              data={item}
+              isSelected={selectedCard === item.id}
+              onCardClick={setSelectedCard}
+            />
+          </Grid>
+        ))}
+      </Grid>
+
+      <ServerTable selectedCard={selectedCard} />
+    </React.Fragment>
   )
 }
 

--- a/packages/client-core/src/admin/services/ServerInfoService.ts
+++ b/packages/client-core/src/admin/services/ServerInfoService.ts
@@ -33,7 +33,7 @@ const fetchServerInfoRetrievedReceptor = (
     const state = getState(AdminServerInfoState)
     return state.merge({
       servers: action.data,
-      retrieving: true,
+      retrieving: false,
       fetched: true
     })
   } catch (err) {

--- a/packages/client-core/src/admin/services/ServerInfoService.ts
+++ b/packages/client-core/src/admin/services/ServerInfoService.ts
@@ -1,11 +1,86 @@
-import { ServerInfoInterface } from '@xrengine/common/src/interfaces/ServerInfo'
+import { ServerInfoInterface, ServerPodInfo } from '@xrengine/common/src/interfaces/ServerInfo'
+import { matches, Validator } from '@xrengine/engine/src/common/functions/MatchesUtils'
+import { defineAction, defineState, dispatchAction, getState, useState } from '@xrengine/hyperflux'
 
 import { API } from '../../API'
+import { NotificationService } from '../../common/services/NotificationService'
+
+//State
+const AdminServerInfoState = defineState({
+  name: 'AdminServerInfoState',
+  initial: () => ({
+    servers: [] as Array<ServerInfoInterface>,
+    retrieving: false,
+    fetched: false
+  })
+})
+
+const fetchServerInfoRequestedReceptor = (
+  action: typeof AdminServerInfoActions.fetchServerInfoRequested.matches._TYPE
+) => {
+  try {
+    const state = getState(AdminServerInfoState)
+    return state.merge({ retrieving: true })
+  } catch (err) {
+    NotificationService.dispatchNotify(err.message, { variant: 'error' })
+  }
+}
+
+const fetchServerInfoRetrievedReceptor = (
+  action: typeof AdminServerInfoActions.fetchServerInfoRetrieved.matches._TYPE
+) => {
+  try {
+    const state = getState(AdminServerInfoState)
+    return state.merge({
+      servers: action.data,
+      retrieving: true,
+      fetched: true
+    })
+  } catch (err) {
+    NotificationService.dispatchNotify(err.message, { variant: 'error' })
+  }
+}
+
+export const AdminServerInfoReceptors = {
+  fetchServerInfoRequestedReceptor,
+  fetchServerInfoRetrievedReceptor
+}
+
+export const accessServerInfoState = () => getState(AdminServerInfoState)
+
+export const useServerInfoState = () => useState(accessServerInfoState())
 
 //Service
 export const ServerInfoService = {
   fetchServerInfo: async () => {
-    const serverInfo: ServerInfoInterface[] = await API.instance.client.service('server-info').find()
-    return serverInfo
+    dispatchAction(AdminServerInfoActions.fetchServerInfoRequested({}))
+
+    let serverInfo: ServerInfoInterface[] = await API.instance.client.service('server-info').find()
+    const allPods: ServerPodInfo[] = []
+    for (const item of serverInfo) {
+      allPods.push(...item.pods)
+    }
+
+    serverInfo = [
+      {
+        id: 'all',
+        label: 'All',
+        pods: allPods
+      },
+      ...serverInfo
+    ]
+
+    dispatchAction(AdminServerInfoActions.fetchServerInfoRetrieved({ data: serverInfo }))
   }
+}
+
+//Action
+export class AdminServerInfoActions {
+  static fetchServerInfoRequested = defineAction({
+    type: 'xre.client.AdminServerInfo.FETCH_SERVER_INFO_REQUESTED' as const
+  })
+  static fetchServerInfoRetrieved = defineAction({
+    type: 'xre.client.AdminServerInfo.FETCH_SERVER_INFO_RETRIEVED' as const,
+    data: matches.array as Validator<unknown, ServerInfoInterface[]>
+  })
 }

--- a/packages/client-core/src/admin/services/ServerInfoService.ts
+++ b/packages/client-core/src/admin/services/ServerInfoService.ts
@@ -1,0 +1,11 @@
+import { ServerInfoInterface } from '@xrengine/common/src/interfaces/ServerInfo'
+
+import { API } from '../../API'
+
+//Service
+export const ServerInfoService = {
+  fetchServerInfo: async () => {
+    const serverInfo: ServerInfoInterface[] = await API.instance.client.service('server-info').find()
+    return serverInfo
+  }
+}

--- a/packages/client-core/src/admin/services/ServerLogsService.ts
+++ b/packages/client-core/src/admin/services/ServerLogsService.ts
@@ -1,0 +1,93 @@
+import { matches, Validator } from '@xrengine/engine/src/common/functions/MatchesUtils'
+import { defineAction, defineState, dispatchAction, getState, useState } from '@xrengine/hyperflux'
+
+import { API } from '../../API'
+import { NotificationService } from '../../common/services/NotificationService'
+
+//State
+const AdminServerLogsState = defineState({
+  name: 'AdminServerLogsState',
+  initial: () => ({
+    logs: '',
+    podName: '',
+    containerName: '',
+    retrieving: false,
+    fetched: false
+  })
+})
+
+const fetchServerLogsRequestedReceptor = (
+  action: typeof AdminServerLogsActions.fetchServerLogsRequested.matches._TYPE
+) => {
+  try {
+    const state = getState(AdminServerLogsState)
+
+    let newState: any = { retrieving: true }
+    if (state.podName.value !== action.podName || state.containerName.value !== action.containerName) {
+      newState = {
+        ...newState,
+        logs: '',
+        podName: action.podName,
+        containerName: action.containerName,
+        fetched: false
+      }
+    }
+
+    return state.merge(newState)
+  } catch (err) {
+    NotificationService.dispatchNotify(err.message, { variant: 'error' })
+  }
+}
+
+const fetchServerLogsRetrievedReceptor = (
+  action: typeof AdminServerLogsActions.fetchServerLogsRetrieved.matches._TYPE
+) => {
+  try {
+    const state = getState(AdminServerLogsState)
+    return state.merge({
+      logs: action.logs,
+      retrieving: false,
+      fetched: true
+    })
+  } catch (err) {
+    NotificationService.dispatchNotify(err.message, { variant: 'error' })
+  }
+}
+
+export const AdminServerLogsReceptors = {
+  fetchServerLogsRequestedReceptor,
+  fetchServerLogsRetrievedReceptor
+}
+
+export const accessServerLogsState = () => getState(AdminServerLogsState)
+
+export const useServerLogsState = () => useState(accessServerLogsState())
+
+//Service
+export const ServerLogsService = {
+  fetchServerLogs: async (podName: string, containerName: string) => {
+    dispatchAction(AdminServerLogsActions.fetchServerLogsRequested({ podName, containerName }))
+
+    const serverLogs: string = await API.instance.client
+      .service('server-logs')
+      .find({ query: { podName, containerName } })
+
+    dispatchAction(AdminServerLogsActions.fetchServerLogsRetrieved({ logs: serverLogs }))
+  },
+  resetServerLogs: () => {
+    dispatchAction(AdminServerLogsActions.fetchServerLogsRequested({ podName: '', containerName: '' }))
+  }
+}
+
+//Action
+export class AdminServerLogsActions {
+  static fetchServerLogsRequested = defineAction({
+    type: 'xre.client.AdminServerLogs.FETCH_SERVER_LOGS_REQUESTED' as const,
+    podName: matches.string,
+    containerName: matches.string
+  })
+  static fetchServerLogsRetrieved = defineAction({
+    type: 'xre.client.AdminServerLogs.FETCH_SERVER_LOGS_RETRIEVED' as const,
+    logs: matches.string
+  })
+}

--- a/packages/client-core/src/admin/styles/admin.module.scss
+++ b/packages/client-core/src/admin/styles/admin.module.scss
@@ -58,7 +58,7 @@
 
   &.forceVaporwave {
     background: linear-gradient(90deg, #5236ff, #c20560);
-    color: #FFF !important;
+    color: #fff !important;
   }
 
   &:hover {
@@ -467,6 +467,10 @@
 .rootCardNumber {
   min-width: 100%;
   background-color: var(--panelBackground);
+}
+
+.selectedCard {
+  background-color: var(--panelCards);
 }
 
 .label {

--- a/packages/client-core/src/admin/styles/admin.module.scss
+++ b/packages/client-core/src/admin/styles/admin.module.scss
@@ -691,3 +691,20 @@
   display: flex;
   flex-direction: row;
 }
+
+.containerCircle {
+  height: 15px;
+  width: 15px;
+  margin-right: 5px;
+  background-color: #bbb;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.containerGreen {
+  background-color: limegreen;
+}
+
+.containerRed {
+  background-color: red;
+}

--- a/packages/client-core/src/systems/AdminSystem.tsx
+++ b/packages/client-core/src/systems/AdminSystem.tsx
@@ -18,6 +18,7 @@ import { AdminRouteActions, AdminRouteReceptors } from '../admin/services/RouteS
 import { AdminSceneActions, AdminSceneReceptors } from '../admin/services/SceneService'
 import { AdminScopeTypeActions, AdminScopeTypeReceptor } from '../admin/services/ScopeTypeService'
 import { AdminServerInfoActions, AdminServerInfoReceptors } from '../admin/services/ServerInfoService'
+import { AdminServerLogsActions, AdminServerLogsReceptors } from '../admin/services/ServerLogsService'
 import { AdminRedisSettingActions, RedisSettingReceptors } from '../admin/services/Setting/AdminRedisSettingService'
 import {
   AdminAnalyticsSettingActions,
@@ -45,6 +46,8 @@ export default async function AdminSystem(world: World) {
   const fetchedAnalyticsQueue = createActionQueue(AdminAnalyticsSettingActions.fetchedAnalytics.matches)
   const fetchServerInfoRequestedQueue = createActionQueue(AdminServerInfoActions.fetchServerInfoRequested.matches)
   const fetchServerInfoRetrievedQueue = createActionQueue(AdminServerInfoActions.fetchServerInfoRetrieved.matches)
+  const fetchServerLogsRequestedQueue = createActionQueue(AdminServerLogsActions.fetchServerLogsRequested.matches)
+  const fetchServerLogsRetrievedQueue = createActionQueue(AdminServerLogsActions.fetchServerLogsRetrieved.matches)
   const redisSettingRetrievedQueue = createActionQueue(AdminRedisSettingActions.redisSettingRetrieved.matches)
   const awsSettingRetrievedQueue = createActionQueue(AdminAwsSettingActions.awsSettingRetrieved.matches)
   const awsSettingPatchedQueue = createActionQueue(AdminAwsSettingActions.awsSettingPatched.matches)
@@ -132,6 +135,10 @@ export default async function AdminSystem(world: World) {
       AdminServerInfoReceptors.fetchServerInfoRequestedReceptor(action)
     for (const action of fetchServerInfoRetrievedQueue())
       AdminServerInfoReceptors.fetchServerInfoRetrievedReceptor(action)
+    for (const action of fetchServerLogsRequestedQueue())
+      AdminServerLogsReceptors.fetchServerLogsRequestedReceptor(action)
+    for (const action of fetchServerLogsRetrievedQueue())
+      AdminServerLogsReceptors.fetchServerLogsRetrievedReceptor(action)
     for (const action of redisSettingRetrievedQueue()) RedisSettingReceptors.redisSettingRetrievedReceptor(action)
     for (const action of awsSettingRetrievedQueue()) AwsSettingReceptors.awsSettingRetrievedReceptor(action)
     for (const action of awsSettingPatchedQueue()) AwsSettingReceptors.awsSettingPatchedReceptor(action)

--- a/packages/client-core/src/systems/AdminSystem.tsx
+++ b/packages/client-core/src/systems/AdminSystem.tsx
@@ -17,6 +17,7 @@ import { AdminResourceActions, AdminResourceReceptors } from '../admin/services/
 import { AdminRouteActions, AdminRouteReceptors } from '../admin/services/RouteService'
 import { AdminSceneActions, AdminSceneReceptors } from '../admin/services/SceneService'
 import { AdminScopeTypeActions, AdminScopeTypeReceptor } from '../admin/services/ScopeTypeService'
+import { AdminServerInfoActions, AdminServerInfoReceptors } from '../admin/services/ServerInfoService'
 import { AdminRedisSettingActions, RedisSettingReceptors } from '../admin/services/Setting/AdminRedisSettingService'
 import {
   AdminAnalyticsSettingActions,
@@ -42,6 +43,8 @@ import { AdminUserActions, AdminUserReceptors } from '../admin/services/UserServ
 
 export default async function AdminSystem(world: World) {
   const fetchedAnalyticsQueue = createActionQueue(AdminAnalyticsSettingActions.fetchedAnalytics.matches)
+  const fetchServerInfoRequestedQueue = createActionQueue(AdminServerInfoActions.fetchServerInfoRequested.matches)
+  const fetchServerInfoRetrievedQueue = createActionQueue(AdminServerInfoActions.fetchServerInfoRetrieved.matches)
   const redisSettingRetrievedQueue = createActionQueue(AdminRedisSettingActions.redisSettingRetrieved.matches)
   const awsSettingRetrievedQueue = createActionQueue(AdminAwsSettingActions.awsSettingRetrieved.matches)
   const awsSettingPatchedQueue = createActionQueue(AdminAwsSettingActions.awsSettingPatched.matches)
@@ -125,6 +128,10 @@ export default async function AdminSystem(world: World) {
 
   const execute = () => {
     for (const action of fetchedAnalyticsQueue()) AnalyticsSettingReceptors.fetchedAnalyticsReceptor(action)
+    for (const action of fetchServerInfoRequestedQueue())
+      AdminServerInfoReceptors.fetchServerInfoRequestedReceptor(action)
+    for (const action of fetchServerInfoRetrievedQueue())
+      AdminServerInfoReceptors.fetchServerInfoRetrievedReceptor(action)
     for (const action of redisSettingRetrievedQueue()) RedisSettingReceptors.redisSettingRetrievedReceptor(action)
     for (const action of awsSettingRetrievedQueue()) AwsSettingReceptors.awsSettingRetrievedReceptor(action)
     for (const action of awsSettingPatchedQueue()) AwsSettingReceptors.awsSettingPatchedReceptor(action)
@@ -211,6 +218,8 @@ export default async function AdminSystem(world: World) {
 
   const cleanup = async () => {
     removeActionQueue(fetchedAnalyticsQueue)
+    removeActionQueue(fetchServerInfoRequestedQueue)
+    removeActionQueue(fetchServerInfoRetrievedQueue)
     removeActionQueue(redisSettingRetrievedQueue)
     removeActionQueue(awsSettingRetrievedQueue)
     removeActionQueue(awsSettingPatchedQueue)

--- a/packages/client-core/src/user/components/Dashboard/DashboardItems.tsx
+++ b/packages/client-core/src/user/components/Dashboard/DashboardItems.tsx
@@ -24,7 +24,7 @@ export const SidebarItems = (allowedRoutes) => [
     path: '/admin',
     icon: <DashboardIcon style={{ color: 'white' }} />
   },
-  allowedRoutes.admin && {
+  allowedRoutes.server && {
     name: 'user:dashboard.server',
     path: '/admin/server',
     icon: <Storage style={{ color: 'white' }} />

--- a/packages/client-core/src/user/components/Dashboard/DashboardItems.tsx
+++ b/packages/client-core/src/user/components/Dashboard/DashboardItems.tsx
@@ -12,6 +12,7 @@ import {
   PersonAdd,
   Settings,
   Shuffle,
+  Storage,
   SupervisorAccount,
   Timeline,
   Toys
@@ -22,6 +23,11 @@ export const SidebarItems = (allowedRoutes) => [
     name: 'user:dashboard.dashboard',
     path: '/admin',
     icon: <DashboardIcon style={{ color: 'white' }} />
+  },
+  allowedRoutes.admin && {
+    name: 'user:dashboard.server',
+    path: '/admin/server',
+    icon: <Storage style={{ color: 'white' }} />
   },
   allowedRoutes.projects && {
     name: 'user:dashboard.projects',

--- a/packages/client-core/src/user/components/Dashboard/DashboardMenuItem.tsx
+++ b/packages/client-core/src/user/components/Dashboard/DashboardMenuItem.tsx
@@ -37,12 +37,12 @@ const DashboardMenuItem = ({ location }: Props) => {
     routes: false,
     projects: false,
     settings: false,
-    admin: false
+    server: false
   }
 
   scopes.forEach((scope) => {
     if (Object.keys(allowedRoutes).includes(scope.type.split(':')[0])) {
-      if (scope.type.split(':')[1] === 'read' || scope.type.split(':')[1] === 'admin') {
+      if (scope.type.split(':')[1] === 'read') {
         allowedRoutes = {
           ...allowedRoutes,
           [scope.type.split(':')[0]]: true

--- a/packages/client-core/src/user/components/Dashboard/DashboardMenuItem.tsx
+++ b/packages/client-core/src/user/components/Dashboard/DashboardMenuItem.tsx
@@ -36,12 +36,13 @@ const DashboardMenuItem = ({ location }: Props) => {
     benchmarking: false,
     routes: false,
     projects: false,
-    settings: false
+    settings: false,
+    admin: false
   }
 
   scopes.forEach((scope) => {
     if (Object.keys(allowedRoutes).includes(scope.type.split(':')[0])) {
-      if (scope.type.split(':')[1] === 'read') {
+      if (scope.type.split(':')[1] === 'read' || scope.type.split(':')[1] === 'admin') {
         allowedRoutes = {
           ...allowedRoutes,
           [scope.type.split(':')[0]]: true

--- a/packages/client-core/src/user/components/Dashboard/index.tsx
+++ b/packages/client-core/src/user/components/Dashboard/index.tsx
@@ -145,7 +145,7 @@ const Dashboard = ({ children }: Props) => {
           [styles.contentWidthDrawerClosed]: !open
         })}
       >
-        <div>{children}</div>
+        {children}
       </main>
     </div>
   )

--- a/packages/common/src/interfaces/ServerInfo.ts
+++ b/packages/common/src/interfaces/ServerInfo.ts
@@ -1,0 +1,20 @@
+export interface ServerInfoInterface {
+  id: string
+  label: string
+  pods: ServerPodInfo[]
+}
+
+export interface ServerPodInfo {
+  name: string
+  status: string
+  age: Date
+  containers: ServerContainerInfo[]
+}
+
+export interface ServerContainerInfo {
+  name: string
+  restarts: number
+  status: string
+  ready: boolean
+  started: boolean
+}

--- a/packages/common/src/interfaces/ServerInfo.ts
+++ b/packages/common/src/interfaces/ServerInfo.ts
@@ -7,7 +7,7 @@ export interface ServerInfoInterface {
 export interface ServerPodInfo {
   name: string
   status: string
-  age: Date
+  age: string | Date
   containers: ServerContainerInfo[]
 }
 

--- a/packages/server-core/src/cluster/server-info/server-info-helper.ts
+++ b/packages/server-core/src/cluster/server-info/server-info-helper.ts
@@ -9,14 +9,6 @@ import logger from '../../ServerLogger'
 export const getServerInfo = async (app: Application): Promise<ServerInfoInterface[]> => {
   let serverInfo: ServerInfoInterface[] = []
 
-  //TODO: Remove this section
-  const kc = new k8s.KubeConfig()
-  kc.loadFromDefault()
-  app.k8DefaultClient = kc.makeApiClient(k8s.CoreV1Api)
-  app.k8AgonesClient = kc.makeApiClient(k8s.CustomObjectsApi)
-  config.server.releaseName = 'dev'
-  //TODO: End of remove this section
-
   try {
     logger.info('Attempting to check k8s server info')
 

--- a/packages/server-core/src/cluster/server-info/server-info-helper.ts
+++ b/packages/server-core/src/cluster/server-info/server-info-helper.ts
@@ -1,0 +1,162 @@
+import * as k8s from '@kubernetes/client-node'
+
+import { ServerContainerInfo, ServerInfoInterface, ServerPodInfo } from '@xrengine/common/src/interfaces/ServerInfo'
+
+import { Application } from '../../../declarations'
+import config from '../../appconfig'
+import logger from '../../ServerLogger'
+
+export const getServerInfo = async (app: Application): Promise<ServerInfoInterface[]> => {
+  let serverInfo: ServerInfoInterface[] = []
+
+  //TODO: Remove this section
+  const kc = new k8s.KubeConfig()
+  kc.loadFromDefault()
+  app.k8DefaultClient = kc.makeApiClient(k8s.CoreV1Api)
+  app.k8AgonesClient = kc.makeApiClient(k8s.CustomObjectsApi)
+  config.server.releaseName = 'dev'
+  //TODO: End of remove this section
+
+  try {
+    logger.info('Attempting to check k8s server info')
+
+    if (app.k8DefaultClient) {
+      const builderPods = await getPodsData(
+        `app.kubernetes.io/instance=${config.server.releaseName}-builder`,
+        'builder',
+        'Builder',
+        app
+      )
+      serverInfo.push(builderPods)
+
+      const clientPods = await getPodsData(
+        `app.kubernetes.io/instance=${config.server.releaseName},app.kubernetes.io/component=client`,
+        'client',
+        'Client',
+        app
+      )
+      serverInfo.push(clientPods)
+
+      const apiPods = await getPodsData(
+        `app.kubernetes.io/instance=${config.server.releaseName},app.kubernetes.io/component=api`,
+        'api',
+        'Api',
+        app
+      )
+      serverInfo.push(apiPods)
+
+      const instancePods = await getPodsData(
+        'agones.dev/role=gameserver',
+        'instance',
+        'Instance',
+        app,
+        `${config.server.releaseName}-instanceserver-`
+      )
+      serverInfo.push(instancePods)
+
+      const analyticsPods = await getPodsData(
+        `app.kubernetes.io/instance=${config.server.releaseName},app.kubernetes.io/component=analytics`,
+        'analytics',
+        'Analytics',
+        app
+      )
+      serverInfo.push(analyticsPods)
+    }
+
+    // if (app.k8AgonesClient) {
+    //   const instancePods = await getGameserversData(`agones.dev/fleet=${config.server.releaseName}-instanceserver`, 'instance', 'Instance', app)
+    //   serverInfo.push(instancePods)
+    // }
+  } catch (e) {
+    logger.error(e)
+    return e
+  }
+
+  return serverInfo
+}
+
+const getPodsData = async (labelSelector: string, id: string, label: string, app: Application, nameFilter?: string) => {
+  let pods: ServerPodInfo[] = []
+
+  try {
+    const podsResponse = await app.k8DefaultClient.listNamespacedPod(
+      'default',
+      undefined,
+      false,
+      undefined,
+      undefined,
+      labelSelector
+    )
+
+    let items = podsResponse.body.items
+    if (nameFilter) {
+      items = items.filter((item) => item.metadata?.name?.startsWith(nameFilter))
+    }
+
+    pods = getServerPodInfo(items)
+  } catch (err) {
+    logger.error('Failed to get pods info.', err)
+  }
+
+  return {
+    id,
+    label,
+    pods
+  }
+}
+
+const getGameserversData = async (labelSelector: string, id: string, label: string, app: Application) => {
+  let gameservers: ServerPodInfo[] = []
+
+  try {
+    const gameserversResponse = await app.k8AgonesClient.listNamespacedCustomObject(
+      'agones.dev',
+      'v1',
+      'default',
+      'gameservers',
+      undefined,
+      false,
+      undefined,
+      undefined,
+      labelSelector
+    )
+    gameservers = getServerPodInfo((gameserversResponse.body as any).items)
+  } catch (err) {
+    logger.error('Failed to get pods info.', err)
+  }
+
+  return {
+    id,
+    label,
+    pods: gameservers
+  }
+}
+
+const getServerPodInfo = (items: k8s.V1Pod[]) => {
+  return items.map((item) => {
+    return {
+      name: item.metadata?.name,
+      status: item.status?.phase,
+      age: item.status?.startTime,
+      containers: getServerContainerInfo(item.status?.containerStatuses!)
+    } as ServerPodInfo
+  })
+}
+
+const getServerContainerInfo = (items: k8s.V1ContainerStatus[]) => {
+  return items.map((item) => {
+    return {
+      name: item.name,
+      status: item.state?.running
+        ? 'Running'
+        : item.state?.terminated
+        ? 'Terminated'
+        : item.state?.waiting
+        ? 'Waiting'
+        : 'Undefined',
+      ready: item.ready,
+      started: item.started,
+      restarts: item.restartCount
+    } as ServerContainerInfo
+  })
+}

--- a/packages/server-core/src/cluster/server-info/server-info.class.ts
+++ b/packages/server-core/src/cluster/server-info/server-info.class.ts
@@ -1,0 +1,26 @@
+import { Params, ServiceMethods } from '@feathersjs/feathers'
+
+import { ServerInfoInterface } from '@xrengine/common/src/interfaces/ServerInfo'
+
+import { Application } from '../../../declarations'
+import { getServerInfo } from './server-info-helper'
+
+export class ServerInfo implements ServiceMethods<any> {
+  app: Application
+  options: any
+
+  constructor(options: any, app: Application) {
+    this.options = options
+    this.app = app
+  }
+
+  async find(params?: Params): Promise<ServerInfoInterface[]> {
+    return getServerInfo(this.app)
+  }
+
+  async get(): Promise<any> {}
+  async create(): Promise<any> {}
+  async update(): Promise<any> {}
+  async remove(): Promise<any> {}
+  async patch(): Promise<any> {}
+}

--- a/packages/server-core/src/cluster/server-info/server-info.hooks.ts
+++ b/packages/server-core/src/cluster/server-info/server-info.hooks.ts
@@ -1,0 +1,36 @@
+import { iff, isProvider } from 'feathers-hooks-common'
+
+import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
+
+export default {
+  before: {
+    all: [authenticate(), iff(isProvider('external'), verifyScope('admin', 'admin') as any)],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+
+  after: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+
+  error: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  }
+} as any

--- a/packages/server-core/src/cluster/server-info/server-info.service.ts
+++ b/packages/server-core/src/cluster/server-info/server-info.service.ts
@@ -1,0 +1,21 @@
+import { Application } from '../../../declarations'
+import { ServerInfo } from './server-info.class'
+import hooks from './server-info.hooks'
+
+declare module '@xrengine/common/declarations' {
+  interface ServiceTypes {
+    'server-info': ServerInfo
+  }
+}
+
+export default (app: Application): void => {
+  const options = {
+    paginate: app.get('paginate'),
+    multi: true
+  }
+
+  const event = new ServerInfo(options, app)
+  app.use('server-info', event)
+  const service = app.service('server-info')
+  service.hooks(hooks)
+}

--- a/packages/server-core/src/cluster/server-logs/server-logs-helper.ts
+++ b/packages/server-core/src/cluster/server-logs/server-logs-helper.ts
@@ -1,0 +1,42 @@
+import { BadRequest } from '@feathersjs/errors/lib'
+
+import { Application } from '../../../declarations'
+import config from '../../appconfig'
+import logger from '../../ServerLogger'
+
+export const getServerLogs = async (podName: string, containerName: string, app: Application): Promise<string> => {
+  let serverLogs = ''
+
+  try {
+    logger.info('Attempting to check k8s server logs')
+
+    if (podName.startsWith(`${config.server.releaseName}-`) === false) {
+      logger.error('You can only request server logs for current deployment.')
+      new BadRequest('You can only request server logs for current deployment.')
+    }
+
+    if (app.k8DefaultClient) {
+      const podLogs = await app.k8DefaultClient.readNamespacedPodLog(
+        podName,
+        'default',
+        containerName,
+        undefined,
+        false,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      )
+
+      serverLogs = podLogs.body
+    }
+  } catch (e) {
+    logger.error(e)
+    return e
+  }
+
+  return serverLogs
+}

--- a/packages/server-core/src/cluster/server-logs/server-logs.class.ts
+++ b/packages/server-core/src/cluster/server-logs/server-logs.class.ts
@@ -1,0 +1,34 @@
+import { BadRequest } from '@feathersjs/errors/lib'
+import { Params, ServiceMethods } from '@feathersjs/feathers'
+
+import { Application } from '../../../declarations'
+import logger from '../../ServerLogger'
+import { getServerLogs } from './server-logs-helper'
+
+export class ServerLogs implements ServiceMethods<any> {
+  app: Application
+  options: any
+
+  constructor(options: any, app: Application) {
+    this.options = options
+    this.app = app
+  }
+
+  async find(params?: Params): Promise<string> {
+    if (!params?.query?.podName) {
+      logger.info('podName is required in request to find server logs')
+      throw new BadRequest('podName is required in request to find server logs')
+    } else if (!params?.query?.containerName) {
+      logger.info('containerName is required in request to find server logs')
+      throw new BadRequest('containerName is required in request to find server logs')
+    }
+
+    return getServerLogs(params?.query?.podName, params?.query?.containerName, this.app)
+  }
+
+  async get(): Promise<any> {}
+  async create(): Promise<any> {}
+  async update(): Promise<any> {}
+  async remove(): Promise<any> {}
+  async patch(): Promise<any> {}
+}

--- a/packages/server-core/src/cluster/server-logs/server-logs.hooks.ts
+++ b/packages/server-core/src/cluster/server-logs/server-logs.hooks.ts
@@ -1,0 +1,36 @@
+import { iff, isProvider } from 'feathers-hooks-common'
+
+import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
+
+export default {
+  before: {
+    all: [authenticate(), iff(isProvider('external'), verifyScope('admin', 'admin') as any)],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+
+  after: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+
+  error: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  }
+} as any

--- a/packages/server-core/src/cluster/server-logs/server-logs.service.ts
+++ b/packages/server-core/src/cluster/server-logs/server-logs.service.ts
@@ -1,0 +1,21 @@
+import { Application } from '../../../declarations'
+import { ServerLogs } from './server-logs.class'
+import hooks from './server-logs.hooks'
+
+declare module '@xrengine/common/declarations' {
+  interface ServiceTypes {
+    'server-logs': ServerLogs
+  }
+}
+
+export default (app: Application): void => {
+  const options = {
+    paginate: app.get('paginate'),
+    multi: true
+  }
+
+  const event = new ServerLogs(options, app)
+  app.use('server-logs', event)
+  const service = app.service('server-logs')
+  service.hooks(hooks)
+}

--- a/packages/server-core/src/cluster/services.ts
+++ b/packages/server-core/src/cluster/services.ts
@@ -1,3 +1,4 @@
 import ServerInfo from './server-info/server-info.service'
+import ServerLogs from './server-logs/server-logs.service'
 
-export default [ServerInfo]
+export default [ServerInfo, ServerLogs]

--- a/packages/server-core/src/cluster/services.ts
+++ b/packages/server-core/src/cluster/services.ts
@@ -1,0 +1,3 @@
+import ServerInfo from './server-info/server-info.service'
+
+export default [ServerInfo]

--- a/packages/server-core/src/scope/scope-type/scope-type.seed.ts
+++ b/packages/server-core/src/scope/scope-type/scope-type.seed.ts
@@ -87,6 +87,12 @@ export const scopeTypeSeed = {
     },
     {
       type: 'settings:write'
+    },
+    {
+      type: 'server:read'
+    },
+    {
+      type: 'server:write'
     }
   ]
 }

--- a/packages/server-core/src/services.ts
+++ b/packages/server-core/src/services.ts
@@ -7,6 +7,7 @@ import { Application } from '../declarations'
 import AnalyticsServices from './analytics/services'
 import AssetServices from './assets/services'
 import BotService from './bot/services'
+import ClusterServices from './cluster/services'
 import MatchMakingServices from './matchmaking/services'
 import MediaServices from './media/services'
 import NetworkingServices from './networking/services'
@@ -52,7 +53,8 @@ export default (app: Application): void => {
     ...SettingService,
     ...RouteService,
     ...installedProjects,
-    ...MatchMakingServices
+    ...MatchMakingServices,
+    ...ClusterServices
   ].forEach((service) => {
     app.configure(service)
   })


### PR DESCRIPTION
## Summary

Introduced server section in admin panel to track server info of pods and logs.

https://user-images.githubusercontent.com/10975502/196365540-70192027-81e9-4afb-8d54-6c3d97be23ad.mp4

## References

closes #6972


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

