### PR TITLE
Added better handling of OAuth login cancellation.

### DIFF
--- a/packages/server-core/src/user/strategies/discord.ts
+++ b/packages/server-core/src/user/strategies/discord.ts
@@ -110,7 +110,14 @@ export class DiscordStrategy extends CustomOAuthStrategy {
   }
 
   async authenticate(authentication: AuthenticationRequest, originalParams: Params) {
-    if (authentication.error && authentication.error === 'access_denied') throw new Error(authentication.error)
+    if (authentication.error) {
+      if (authentication.error === 'access_denied') throw new Error('You canceled the Discord OAuth login flow')
+      else
+        throw new Error(
+          'There was a problem with the Discord OAuth login flow: ' + authentication.error_description ||
+            authentication.error
+        )
+    }
     return super.authenticate(authentication, originalParams)
   }
 }

--- a/packages/server-core/src/user/strategies/facebook.ts
+++ b/packages/server-core/src/user/strategies/facebook.ts
@@ -1,3 +1,4 @@
+import { AuthenticationRequest } from '@feathersjs/authentication'
 import { Paginated, Params } from '@feathersjs/feathers'
 import { random } from 'lodash'
 
@@ -106,6 +107,18 @@ export class FacebookStrategy extends CustomOAuthStrategy {
       if (instanceId != null) returned = returned.concat(`&instanceId=${instanceId}`)
       return returned
     }
+  }
+
+  async authenticate(authentication: AuthenticationRequest, originalParams: Params) {
+    if (authentication.error) {
+      if (authentication.error?.error?.type === 'OAuthException')
+        throw new Error('You canceled the GitHub OAuth login flow')
+      else
+        throw new Error(
+          'There was a problem with the Facebook OAuth login flow: ' + authentication.error?.error?.message
+        )
+    }
+    return super.authenticate(authentication, originalParams)
   }
 }
 export default FacebookStrategy

--- a/packages/server-core/src/user/strategies/github.ts
+++ b/packages/server-core/src/user/strategies/github.ts
@@ -113,6 +113,11 @@ export class GithubStrategy extends CustomOAuthStrategy {
   }
 
   async authenticate(authentication: AuthenticationRequest, originalParams: CustomOAuthParams) {
+    if (authentication.error) {
+      if (authentication.error.message === 'Bad credentials')
+        throw new Error('You canceled the GitHub OAuth login flow')
+      else throw new Error('There was a problem with the GitHub OAuth login flow: ' + authentication.error.message)
+    }
     originalParams.access_token = authentication.access_token
     return super.authenticate(authentication, originalParams)
   }

--- a/packages/server-core/src/user/strategies/google.ts
+++ b/packages/server-core/src/user/strategies/google.ts
@@ -1,3 +1,4 @@
+import { AuthenticationRequest } from '@feathersjs/authentication'
 import { Paginated, Params } from '@feathersjs/feathers'
 import { random } from 'lodash'
 
@@ -106,6 +107,15 @@ export class Googlestrategy extends CustomOAuthStrategy {
       if (instanceId != null) returned = returned.concat(`&instanceId=${instanceId}`)
       return returned
     }
+  }
+
+  async authenticate(authentication: AuthenticationRequest, originalParams: Params) {
+    if (authentication.error)
+      throw new Error(
+        'There was a problem with the Google OAuth login flow: ' + authentication.error_description ||
+          authentication.error
+      )
+    return super.authenticate(authentication, originalParams)
   }
 }
 export default Googlestrategy

--- a/packages/server-core/src/user/strategies/linkedin.ts
+++ b/packages/server-core/src/user/strategies/linkedin.ts
@@ -1,3 +1,4 @@
+import { AuthenticationRequest } from '@feathersjs/authentication'
 import { Paginated, Params } from '@feathersjs/feathers'
 import { random } from 'lodash'
 
@@ -106,6 +107,20 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
       if (instanceId != null) returned = returned.concat(`&instanceId=${instanceId}`)
       return returned
     }
+  }
+
+  async authenticate(authentication: AuthenticationRequest, originalParams: Params) {
+    console.log('authentication', authentication)
+    if (authentication.error) {
+      if (authentication.error === 'user_cancelled_authorize')
+        throw new Error('You canceled the LinkedIn OAuth login flow')
+      else
+        throw new Error(
+          'There was a problem with the LinkedIn OAuth login flow: ' + authentication.error_description ||
+            authentication.error
+        )
+    }
+    return super.authenticate(authentication, originalParams)
   }
 }
 export default LinkedInStrategy


### PR DESCRIPTION
## Summary

For most OAuth providers, if the user canceled the initial authorization, we were not handling it properly and creating dummy identity-providers, thus logging them in. Added/updated authenticate overrides to look for errors on the returned data and throw appropriate errors.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

