### PR TITLE
Fixed a bug with patching instanceservers as admin.

### DIFF
--- a/packages/instanceserver/src/channels.ts
+++ b/packages/instanceserver/src/channels.ts
@@ -194,15 +194,13 @@ const initializeInstance = async (
   } else {
     const instance = existingInstanceResult.data[0]
     if (locationId) {
-      const user = await app.service('user').get(userId)
-      const existingChannel = (await app.service('channel').find({
-        query: {
+      const existingChannel = await app.service('channel').Model.findOne({
+        where: {
           channelType: 'instance',
           instanceId: instance.id
-        },
-        'identity-provider': user['identity_providers']![0]
-      } as any)) as Channel[]
-      if (existingChannel.length === 0) {
+        }
+      })
+      if (!existingChannel) {
         await app.service('channel').create({
           channelType: 'instance',
           instanceId: instance.id


### PR DESCRIPTION
## Summary

As part of initializeInstance, the instanceserver was trying to get the user joining the server, but when done via an admin patching an instanceserver, there is no associated user. Replaced calling the feathers channel.find, which requires an identity-provider, with just calling findOne on the channel model.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

