### PR TITLE
Fixed bug in pruning old S3 client files.

### DIFF
--- a/scripts/delete-old-s3-files.ts
+++ b/scripts/delete-old-s3-files.ts
@@ -12,9 +12,10 @@ cli.main(async () => {
     try {
         await createDefaultStorageProvider()
         const storageProvider = getStorageProvider()
-        const files = JSON.parse(fs.readFileSync('S3FilesToRemove.json', { encoding: 'utf-8' }))
-        while (files.length > 0) {
-            const toDelete = files.splice(0, 1000)
+        let filesToPruneResponse = await storageProvider.getObject('client/S3FilesToRemove.json')
+        let filesToPrune = JSON.parse(filesToPruneResponse.Body.toString('utf-8'))
+        while (filesToPrune.length > 0) {
+            const toDelete = filesToPrune.splice(0, 1000)
             await storageProvider.deleteResources(toDelete)
         }
         console.log('Deleted old S3 files')

--- a/scripts/get-deletable-client-files.ts
+++ b/scripts/get-deletable-client-files.ts
@@ -13,7 +13,12 @@ cli.main(async () => {
         const storageProvider = getStorageProvider()
         let files = await storageProvider.listFolderContent('client', true)
         files = files.filter(file => UNIQUIFIED_FILE_NAME_REGEX.test(file.name))
-        await fs.writeFileSync('S3FilesToRemove.json', JSON.stringify(files.map(file => file.key)))
+        const putData = {
+            Body: Buffer.from(JSON.stringify(files.map(file => file.key))),
+            ContentType: 'application/json',
+            Key: 'client/S3FilesToRemove.json'
+        }
+        await storageProvider.putObject(putData, { isDirectory: false })
         console.log('Created list of S3 files to delete after deployment')
         process.exit(0)
     } catch(err) {

--- a/scripts/push-client-to-s3.ts
+++ b/scripts/push-client-to-s3.ts
@@ -19,6 +19,8 @@ cli.main(async () => {
         const storageProvider = getStorageProvider()
         const clientPath = path.resolve(appRootPath.path, `packages/client/dist`)
         const files = getFilesRecursive(clientPath)
+        let filesToPruneResponse = await storageProvider.getObject('client/S3FilesToRemove.json')
+        const filesToPush = []
         await Promise.all(
             files
                 .map((file) => {
@@ -39,6 +41,7 @@ cli.main(async () => {
                                 putData.Key = `client${filePathRelative}`
                             }
                             await storageProvider.putObject(putData, { isDirectory: false })
+                            filesToPush.push(`client${filePathRelative}`)
                             resolve()
                         } catch (e) {
                             logger.error(e)
@@ -48,6 +51,15 @@ cli.main(async () => {
                 })
         )
         console.log('Pushed client files to S3')
+        let filesToPrune = JSON.parse(filesToPruneResponse.Body.toString('utf-8'))
+        filesToPrune = filesToPrune.filter(file => filesToPush.indexOf(file) < 0)
+        const putData = {
+            Body: Buffer.from(JSON.stringify(filesToPrune)),
+            ContentType: 'application/json',
+            Key: 'client/S3FilesToRemove.json'
+        }
+        await storageProvider.putObject(putData, { isDirectory: false })
+        console.log('Pushed filtered list of files to remove to S3')
         process.exit(0)
     } catch(err) {
         console.log('Error in pushing client images to S3:');


### PR DESCRIPTION
## Summary

Vite sometimes generates the same hash for a built file as the prior run. These files were getting deleted at the end of the build process because they were being recorded before the client build as files that existed and should be deleted, leading to missing files at the end of the process.

Made get-deletable-client-files.ts store the list of files to be pruned stored in S3. push-client-to-s3.ts now reads in the list from S3 and removes files whose names are the same as the just-built client files, then pushes that back to S3. delete-old-s3-files.ts gets the list from S3.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

