### PR TITLE
Made generate thumbnail and envmap optional in save scene.

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -720,8 +720,13 @@
       "header": "Your scene has been published.",
       "lbl-view": "View Your Scene"
     },
+    "saveScene": {
+      "title": "Save",
+      "lbl-thumbnail": "Generate thumbnail & envmap",
+      "lbl-confirm": "Save Scene"
+    },
     "saveNewScene": {
-      "title": "Support",
+      "title": "Save As",
       "lbl-name": "Scene Name",
       "info-name": "Name must be between 4 and 64 characters and cannot contain underscores",
       "lbl-confirm": "Save Scene"

--- a/packages/editor/src/components/EditorContainer.tsx
+++ b/packages/editor/src/components/EditorContainer.tsx
@@ -35,6 +35,7 @@ import ConfirmDialog from './dialogs/ConfirmDialog'
 import ErrorDialog from './dialogs/ErrorDialog'
 import { ProgressDialog } from './dialogs/ProgressDialog'
 import SaveNewSceneDialog from './dialogs/SaveNewSceneDialog'
+import SaveSceneDialog from './dialogs/SaveSceneDialog'
 import { DndWrapper } from './dnd/DndWrapper'
 import DragLayer from './dnd/DragLayer'
 import ElementList from './element/ElementList'
@@ -388,6 +389,16 @@ const EditorContainer = () => {
       }
       return
     }
+
+    const result: { generateThumbnails: boolean } = (await new Promise((resolve) => {
+      setDialogComponent(<SaveSceneDialog onConfirm={resolve} onCancel={resolve} />)
+    })) as any
+
+    if (!result) {
+      setDialogComponent(null)
+      return
+    }
+
     const abortController = new AbortController()
 
     setDialogComponent(
@@ -404,12 +415,16 @@ const EditorContainer = () => {
     // Wait for 5ms so that the ProgressDialog shows up.
     await new Promise((resolve) => setTimeout(resolve, 5))
 
-    const blob = await takeScreenshot(512, 320)
-
     try {
       if (projectName.value) {
-        await uploadBPCEMBakeToServer(Engine.instance.currentWorld.entityTree.rootNode.entity)
-        await saveScene(projectName.value, sceneName.value, blob, abortController.signal)
+        if (result.generateThumbnails) {
+          const blob = await takeScreenshot(512, 320)
+
+          await uploadBPCEMBakeToServer(Engine.instance.currentWorld.entityTree.rootNode.entity)
+          await saveScene(projectName.value, sceneName.value, blob, abortController.signal)
+        } else {
+          await saveScene(projectName.value, sceneName.value, null, abortController.signal)
+        }
       }
 
       dispatchAction(EditorAction.sceneModified({ modified: false }))

--- a/packages/editor/src/components/dialogs/Dialog.tsx
+++ b/packages/editor/src/components/dialogs/Dialog.tsx
@@ -76,8 +76,10 @@ export const DialogContent = (styled as any).div`
  * @type {Styled component}
  */
 const DialogBottomNav = (styled as any).div`
+  display: flex;
   padding: 8px;
   margin: auto;
+  margin-bottom: 10px;
 
   a {
     color: var(--textColor);

--- a/packages/editor/src/components/dialogs/SaveSceneDialog.tsx
+++ b/packages/editor/src/components/dialogs/SaveSceneDialog.tsx
@@ -1,0 +1,82 @@
+import React, { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { dispatchAction, useState } from '@xrengine/hyperflux'
+
+import Box from '@mui/material/Box'
+
+import { EditorHelperAction, useEditorHelperState } from '../../services/EditorHelperState'
+import BooleanInput from '../inputs/BooleanInput'
+import { InfoTooltip } from '../layout/Tooltip'
+import Dialog from './Dialog'
+
+/**
+ * SaveSceneDialog used to show dialog when to save scene.
+ *
+ * @param       {function} onConfirm
+ * @param       {function} onCancel
+ * @constructor
+ */
+export function SaveSceneDialog({ onConfirm, onCancel }) {
+  const { t } = useTranslation()
+  const editorHelperState = useEditorHelperState()
+  const state = useState({
+    isGenerateThumbnailsEnabled: editorHelperState.isGenerateThumbnailsEnabled.value
+  })
+
+  const onChangeGenerateThumbnails = (value) => {
+    state.isGenerateThumbnailsEnabled.set(value)
+  }
+
+  /**
+   * onConfirmCallback callback function is used handle confirm dialog.
+   *
+   * @type {function}
+   */
+  const onConfirmCallback = useCallback(
+    (e) => {
+      e.preventDefault()
+
+      if (state.isGenerateThumbnailsEnabled.value !== editorHelperState.isGenerateThumbnailsEnabled.value) {
+        dispatchAction(
+          EditorHelperAction.changedGenerateThumbnails({
+            isGenerateThumbnailsEnabled: state.isGenerateThumbnailsEnabled.value
+          })
+        )
+      }
+
+      onConfirm({ generateThumbnails: state.isGenerateThumbnailsEnabled.value })
+    },
+    [onConfirm]
+  )
+
+  /**
+   * onCancelCallback callback function used to handle cancel of dialog.
+   *
+   * @type {function}
+   */
+  const onCancelCallback = useCallback(
+    (e) => {
+      e.preventDefault()
+      onCancel()
+    },
+    [onCancel]
+  )
+
+  //returning view for dialog view.
+  return (
+    <Dialog
+      title={t('editor:dialog.saveScene.title')}
+      onConfirm={onConfirmCallback}
+      onCancel={onCancelCallback}
+      confirmLabel={t('editor:dialog.saveScene.lbl-confirm')}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', margin: '10px' }}>
+        <BooleanInput value={state.isGenerateThumbnailsEnabled.value} onChange={onChangeGenerateThumbnails} />
+        <label style={{ marginLeft: '10px' }}>{t('editor:dialog.saveScene.lbl-thumbnail')}</label>
+      </Box>
+    </Dialog>
+  )
+}
+
+export default SaveSceneDialog

--- a/packages/editor/src/services/EditorHelperState.ts
+++ b/packages/editor/src/services/EditorHelperState.ts
@@ -27,6 +27,7 @@ type EditorHelperStateType = {
   translationSnap: number
   rotationSnap: number
   scaleSnap: number
+  isGenerateThumbnailsEnabled: boolean
 }
 
 const EditorHelperState = defineState({
@@ -42,7 +43,8 @@ const EditorHelperState = defineState({
       snapMode: SnapMode.Grid,
       translationSnap: 0.5,
       rotationSnap: 10,
-      scaleSnap: 0.1
+      scaleSnap: 0.1,
+      isGenerateThumbnailsEnabled: true
     } as EditorHelperStateType),
   onCreate: () => {
     syncStateWithLocalStorage(EditorHelperState, [
@@ -55,7 +57,8 @@ const EditorHelperState = defineState({
       'snapMode',
       'translationSnap',
       'rotationSnap',
-      'scaleSnap'
+      'scaleSnap',
+      'isGenerateThumbnailsEnabled'
     ])
   }
 })
@@ -104,6 +107,10 @@ export const EditorHelperServiceReceptor = (action): any => {
     })
     .when(EditorHelperAction.changeScaleSnap.matches, (action) => {
       s.merge({ scaleSnap: action.scaleSnap })
+      return s
+    })
+    .when(EditorHelperAction.changedGenerateThumbnails.matches, (action) => {
+      s.merge({ isGenerateThumbnailsEnabled: action.isGenerateThumbnailsEnabled })
       return s
     })
 }
@@ -162,5 +169,10 @@ export class EditorHelperAction {
   static changeScaleSnap = defineAction({
     type: 'xre.editor.EditorHelper.SCALE_SNAP_CHANGED' as const,
     scaleSnap: matches.number
+  })
+
+  static changedGenerateThumbnails = defineAction({
+    type: 'xre.editor.EditorHelper.GENERATE_THUMBNAILS_CHANGED' as const,
+    isGenerateThumbnailsEnabled: matches.boolean
   })
 }


### PR DESCRIPTION
## Summary

- Made generate thumbnail and envmap optional in save scene.
- Persisted the selected option in storage.

Here is how the save scene dialog looks like:
![image](https://user-images.githubusercontent.com/10975502/197953983-f67c17c4-6778-4045-a145-34e22733a5d9.png)


## References

closes #7092


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

