### PR TITLE
Collider refactor, animations fix

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -184,8 +184,11 @@
       "error-url": "Error Loading From URL"
     },
     "collider": {
-      "description": "An invisible box that objects will bounce off of or rest on top of.\nWithout colliders, objects will fall through floors and go through walls.",
-      "lbl-isTrigger": "Trigger"
+      "description": "An invisible collider that objects will bounce off of or rest on top of.\nSetting trigger events can make stuff happen on player touch.",
+      "lbl-events": "Trigger Events",
+      "lbl-shape": "Shape",
+      "lbl-scale": "Scale Multiplier",
+      "lbl-type": "Type"
     },
     "camera": {
       "name": "Camera",
@@ -296,6 +299,14 @@
       "lbl-skyColor": "Sky Color",
       "lbl-groundColor": "Ground Color",
       "lbl-intensity": "Intensity"
+    },
+    "animationSequencer":{
+      "name": "Animation Sequencer",
+      "description": "Plays animations on a target object when prompted by a trigger.",
+      "lbl-targetObject": "Target Object",
+      "lbl-animationIndex": "Animation Index",
+      "lbl-loop": "Loop Animation",
+      "lbl-playOnStart": "Play on Start"
     },
     "image": {
       "name": "Image",
@@ -544,10 +555,13 @@
       "lbl-scale": "Scale"
     },
     "triggereVolume": {
-      "description": "Sets a property on the target object on enter and leave.",
+      "description": "Calls a function on the target object on trigger",
+      "eventDescription": "Trigger Event:",
       "lbl-target": "Object",
-      "lbl-onenter": "On Enter",
-      "lbl-onexit": "On Exit",
+      "lbl-targetComponent": "Target Component",
+      "lbl-onenter": "On Player Touch",
+      "lbl-onexit": "On Player Exit",
+      "lbl-triggerType": "Trigger Type",
       "lbl-showHelper": "Show Helper Mesh",
       "ph-errorNode": "Error missing node.",
       "ph-selectNode": "Select node..."

--- a/packages/editor/src/components/properties/ColliderNodeEditor.tsx
+++ b/packages/editor/src/components/properties/ColliderNodeEditor.tsx
@@ -1,22 +1,29 @@
 import { RigidBodyType, ShapeType } from '@dimforge/rapier3d-compat'
+import { hookstate, StateMethods, useHookstate } from '@hookstate/core'
+import { clone, cloneDeep } from 'lodash'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Vector3 } from 'three'
 
 import { camelCaseToSpacedString } from '@xrengine/common/src/utils/camelCaseToSpacedString'
+import { number } from '@xrengine/engine/src/common/functions/MatchesUtils'
 import { Engine } from '@xrengine/engine/src/ecs/classes/Engine'
-import { defineQuery, getComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
-import { CallbackComponent } from '@xrengine/engine/src/scene/components/CallbackComponent'
-import { ColliderComponent, ColliderComponentType } from '@xrengine/engine/src/scene/components/ColliderComponent'
+import { Entity } from '@xrengine/engine/src/ecs/classes/Entity'
+import { defineQuery, getComponent, updateComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
+import { CallbackComponent, EmptyCallback } from '@xrengine/engine/src/scene/components/CallbackComponent'
+import { ColliderComponent } from '@xrengine/engine/src/scene/components/ColliderComponent'
 import { NameComponent } from '@xrengine/engine/src/scene/components/NameComponent'
-import { supportedColliderShapes } from '@xrengine/engine/src/scene/functions/loaders/ColliderFunctions'
+import { supportedColliderShapes, updateCollider } from '@xrengine/engine/src/scene/functions/loaders/ColliderFunctions'
 
 import PanToolIcon from '@mui/icons-material/PanTool'
 
 import { setPropertyOnSelectionEntities } from '../../classes/History'
 import BooleanInput from '../inputs/BooleanInput'
 import InputGroup from '../inputs/InputGroup'
+import NumericInput from '../inputs/NumericInput'
 import SelectInput from '../inputs/SelectInput'
 import StringInput from '../inputs/StringInput'
+import Vector3Input from '../inputs/Vector3Input'
 import NodeEditor from './NodeEditor'
 import { EditorComponentType, updateProperty } from './Util'
 
@@ -44,25 +51,32 @@ type OptionsType = Array<{
 const callbackQuery = defineQuery([CallbackComponent])
 
 export const ColliderNodeEditor: EditorComponentType = (props) => {
-  const { t } = useTranslation()
-  const [options, setOptions] = useState<OptionsType>([{ label: 'Self', value: 'Self', callbacks: [] }])
+  const [options, setOptions] = useState<OptionsType>([{ label: 'Self', value: '', callbacks: [] }])
 
   const colliderComponent = getComponent(props.node.entity, ColliderComponent)
 
+  const { t } = useTranslation()
+
   useEffect(() => {
+    if (colliderComponent.triggerCount.value > 0 && !props.multiEdit)
+      updateIsTrigger(colliderComponent.triggerCount.value)
+
     const options = [] as OptionsType
     options.push({
       label: 'Self',
       value: 'Self',
       callbacks: []
     })
+
     for (const entity of callbackQuery()) {
       if (entity === props.node.entity) continue
       const callbacks = getComponent(entity, CallbackComponent)
+      const coptions = Object.keys(callbacks)
+      coptions.push(EmptyCallback)
       options.push({
         label: getComponent(entity, NameComponent)?.name,
         value: Engine.instance.currentWorld.entityTree.entityNodeMap.get(entity)!.uuid,
-        callbacks: Object.keys(callbacks).map((cb) => {
+        callbacks: coptions.map((cb) => {
           return { label: cb, value: cb }
         })
       })
@@ -70,60 +84,137 @@ export const ColliderNodeEditor: EditorComponentType = (props) => {
     setOptions(options)
   }, [])
 
-  const updateIsTrigger = (val) => {
-    const props = { isTrigger: val } as Partial<ColliderComponentType>
-    if (val) {
-      props.target = colliderComponent.target ?? 'Self'
-      props.onEnter = colliderComponent.onEnter ?? ''
-      props.onExit = colliderComponent.onExit ?? ''
+  const [events, setEvents] = useState<eventType>([])
+
+  const updateIsTrigger = (events: number) => {
+    const props = { triggerCount: events } as Partial<typeof colliderComponent.value>
+    if (events > 0) {
+      const triggerEvents = [] as eventType
+      const _enters = [] as string[]
+      const _exits = [] as string[]
+      const _targets = [] as string[]
+      for (let i = 0; i < events; i++) {
+        _enters[i] = colliderComponent.onEnter.value[i] ?? EmptyCallback
+        _exits[i] = colliderComponent.onExit.value[i] ?? EmptyCallback
+        _targets[i] = colliderComponent.target.value[i] ?? 'Self'
+
+        triggerEvents[i] = {
+          target: _targets[i],
+          onEnter: _enters[i],
+          onExit: _exits[i]
+        }
+      }
+      setEvents(triggerEvents)
+
+      props.target = _targets
+      props.onEnter = _enters
+      props.onExit = _exits
     }
-    setPropertyOnSelectionEntities({
-      component: ColliderComponent,
-      properties: [props]
-    })
+    setPropertyOnSelectionEntities(
+      {
+        component: ColliderComponent,
+        properties: [props]
+      },
+      false
+    )
   }
 
-  const triggerProps = () => {
+  type eventType = Array<{
+    target: string
+    onEnter: string
+    onExit: string
+  }>
+
+  const triggerProps = (e: typeof events[0], i: number) => {
     //function to handle the changes in target
-    const onChangeTarget = (target) => {
-      setPropertyOnSelectionEntities({
-        component: ColliderComponent,
-        properties: [
-          {
-            target: target === 'Self' ? '' : target,
-            onEnter: '',
-            onExit: ''
-          }
-        ]
-      })
+
+    const onChangeTarget = (target: string) => {
+      const newTarget = options.find((o) => o.value === target)
+      const targetArray = cloneDeep(colliderComponent.target.value)
+      targetArray[i] = newTarget ? newTarget.value : ''
+
+      const enterCallback = colliderComponent.onEnter.value[i]
+      const exitCallback = colliderComponent.onExit.value[i]
+
+      const onEnterArray = cloneDeep(colliderComponent.onEnter.value)
+      onEnterArray[i] = newTarget?.callbacks.some((c) => c.label == enterCallback) ? enterCallback : EmptyCallback
+
+      const onExitArray = cloneDeep(colliderComponent.onExit.value)
+      onExitArray[i] = newTarget?.callbacks.some((c) => c.label == exitCallback) ? exitCallback : EmptyCallback
+
+      setPropertyOnSelectionEntities(
+        {
+          component: ColliderComponent,
+          properties: [
+            {
+              target: targetArray,
+              onEnter: onEnterArray,
+              onExit: onExitArray
+            }
+          ]
+        },
+        false
+      )
     }
 
-    const targetOption = options.find((o) => o.value === colliderComponent.target)
+    const onChangeEnter = (newEvent: string) => {
+      const onEnterArray = cloneDeep(colliderComponent.onEnter.value)
+      onEnterArray[i] = newEvent
+      setPropertyOnSelectionEntities(
+        {
+          component: ColliderComponent,
+          properties: [
+            {
+              onEnter: onEnterArray
+            }
+          ]
+        },
+        false
+      )
+    }
+
+    const onChangeExit = (newEvent: string) => {
+      const onExitArray = cloneDeep(colliderComponent.onExit.value)
+      onExitArray[i] = newEvent
+      setPropertyOnSelectionEntities(
+        {
+          component: ColliderComponent,
+          properties: [
+            {
+              onExit: onExitArray
+            }
+          ]
+        },
+        false
+      )
+    }
+
+    const targetOption = options.find((o) => o.value === colliderComponent.target.value[i])
     const target = targetOption ? targetOption.value : 'Self'
 
     return (
-      <>
+      <NodeEditor {...props} description={t('editor:properties.triggereVolume.eventDescription')}>
         <InputGroup name="Target" label={t('editor:properties.triggereVolume.lbl-target')}>
           <SelectInput
             key={props.node.entity}
-            value={colliderComponent.target ?? 'Self'}
+            value={colliderComponent.target.value[i] == '' ? 'Self' : colliderComponent.target.value[i]}
             onChange={onChangeTarget}
             options={options}
             disabled={props.multiEdit}
           />
         </InputGroup>
-        <InputGroup name="On Enter" label={t('editor:properties.triggereVolume.lbl-onenter')}>
-          {targetOption?.callbacks.length == 0 ? (
+        <InputGroup name="OnEnter" label={t('editor:properties.triggereVolume.lbl-onenter')}>
+          {targetOption?.callbacks.length == 0 || colliderComponent.target.value[i] == '' ? (
             <StringInput
-              value={colliderComponent.onEnter}
-              onChange={updateProperty(ColliderComponent, 'onEnter')}
-              disabled={props.multiEdit || !target}
+              value={colliderComponent.onEnter.value[i]}
+              onChange={onChangeEnter}
+              disabled={props.multiEdit}
             />
           ) : (
             <SelectInput
               key={props.node.entity}
-              value={colliderComponent.onEnter}
-              onChange={updateProperty(ColliderComponent, 'onEnter')}
+              value={colliderComponent.onEnter.value[i]}
+              onChange={onChangeEnter}
               options={targetOption?.callbacks ? targetOption.callbacks : []}
               disabled={props.multiEdit || !target}
             />
@@ -131,24 +222,35 @@ export const ColliderNodeEditor: EditorComponentType = (props) => {
         </InputGroup>
 
         <InputGroup name="On Exit" label={t('editor:properties.triggereVolume.lbl-onexit')}>
-          {targetOption?.callbacks.length == 0 ? (
-            <StringInput
-              value={colliderComponent.onExit}
-              onChange={updateProperty(ColliderComponent, 'onExit')}
-              disabled={props.multiEdit || !target}
-            />
+          {targetOption?.callbacks.length == 0 || colliderComponent.target.value[i] == '' ? (
+            <StringInput value={colliderComponent.onExit.value[i]} onChange={onChangeExit} disabled={props.multiEdit} />
           ) : (
             <SelectInput
               key={props.node.entity}
-              value={colliderComponent.onExit}
-              onChange={updateProperty(ColliderComponent, 'onExit')}
+              value={colliderComponent.onExit.value[i]}
+              onChange={onChangeExit}
               options={targetOption?.callbacks ? targetOption.callbacks : []}
               disabled={props.multiEdit || !target}
             />
           )}
         </InputGroup>
-      </>
+      </NodeEditor>
     )
+  }
+
+  const onChangeScale = (scale: Vector3) => {
+    setPropertyOnSelectionEntities(
+      {
+        component: ColliderComponent,
+        properties: [
+          {
+            scaleMultiplier: { x: scale.x, y: scale.y, z: scale.z } as Vector3
+          }
+        ]
+      },
+      false
+    )
+    updateCollider(props.node.entity)
   }
 
   return (
@@ -156,21 +258,38 @@ export const ColliderNodeEditor: EditorComponentType = (props) => {
       <InputGroup name="Type" label={t('editor:properties.collider.lbl-type')}>
         <SelectInput
           options={bodyTypeOptions}
-          value={colliderComponent.bodyType}
+          value={colliderComponent.bodyType.value}
           onChange={updateProperty(ColliderComponent, 'bodyType')}
         />
       </InputGroup>
       <InputGroup name="Shape" label={t('editor:properties.collider.lbl-shape')}>
         <SelectInput
           options={shapeTypeOptions}
-          value={colliderComponent.shapeType}
+          value={colliderComponent.shapeType.value}
           onChange={updateProperty(ColliderComponent, 'shapeType')}
         />
       </InputGroup>
-      <InputGroup name="Trigger" label={t('editor:properties.collider.lbl-isTrigger')}>
-        <BooleanInput value={colliderComponent.isTrigger} onChange={updateIsTrigger} />
+      <InputGroup name="Scale" label={t('editor:properties.collider.lbl-scale')}>
+        <Vector3Input
+          key={props.node.entity}
+          value={colliderComponent.scaleMultiplier.value}
+          onChange={onChangeScale}
+        />
       </InputGroup>
-      {colliderComponent.isTrigger && triggerProps()}
+      <InputGroup name="Trigger" label={t('editor:properties.collider.lbl-events')}>
+        <NumericInput
+          value={colliderComponent.triggerCount.value}
+          onChange={updateIsTrigger}
+          smallStep={1}
+          mediumStep={1}
+          largeStep={1}
+          min={0}
+          max={9}
+          precision={1}
+          displayPrecision={1}
+        />
+      </InputGroup>
+      {colliderComponent.triggerCount.value > 0 && React.Children.toArray(events.map((e, i) => triggerProps(e, i)))}
     </NodeEditor>
   )
 }

--- a/packages/engine/src/physics/classes/Physics.ts
+++ b/packages/engine/src/physics/classes/Physics.ts
@@ -167,7 +167,6 @@ function createColliderDesc(
 
   // If custom size has been provided use that else use mesh scale
   const colliderSize = colliderDescOptions.size ? colliderDescOptions.size : mesh.scale
-
   let colliderDesc: ColliderDesc
   switch (shapeType as ShapeType) {
     case ShapeType.Cuboid:
@@ -245,6 +244,7 @@ function createRigidBodyForGroup(entity: Entity, world: World, colliderDescOptio
     obj.traverse((mesh: Mesh) => {
       // todo: our mesh collider userdata should probably be namespaced, e.g., mesh['XRE_collider'] or something
       const args = { ...colliderDescOptions, ...mesh.userData } as ColliderDescOptions
+      args.size = args.size ? new Vector3().copy(args.size).multiply(mesh.scale) : mesh.scale
       const colliderDesc = createColliderDesc(mesh, args)
       if (colliderDesc) {
         if (typeof args.removeMesh === 'undefined' || args.removeMesh === true) meshesToRemove.push(mesh)

--- a/packages/engine/src/scene/components/CallbackComponent.ts
+++ b/packages/engine/src/scene/components/CallbackComponent.ts
@@ -7,6 +7,8 @@ export const enum StandardCallbacks {
   STOP = 'xre.stop'
 }
 
+export const EmptyCallback = 'Empty'
+
 export const CallbackComponent = createMappedComponent<Map<string, (...params: any) => void>>('CallbackComponent')
 
 export function setCallback(entity: Entity, key: string, callback: (...params: any) => void) {

--- a/packages/engine/src/scene/components/ColliderComponent.ts
+++ b/packages/engine/src/scene/components/ColliderComponent.ts
@@ -1,45 +1,119 @@
-import { RigidBodyType, ShapeType } from '@dimforge/rapier3d-compat'
+import { Collider, RigidBodyType, ShapeType } from '@dimforge/rapier3d-compat'
+import { subscribable } from '@hookstate/subscribable'
+import { Component } from 'bitecs'
+import { Vector3 } from 'three'
 
-import { createMappedComponent } from '../../ecs/functions/ComponentFunctions'
+import { hookstate, StateMethodsDestroy } from '@xrengine/hyperflux/functions/StateFunctions'
+
+import { Entity } from '../../ecs/classes/Entity'
+import {
+  createMappedComponent,
+  defineComponent,
+  getComponent,
+  updateComponent
+} from '../../ecs/functions/ComponentFunctions'
 import { CollisionGroups, DefaultCollisionMask } from '../../physics/enums/CollisionGroups'
+import { updateCollider } from '../functions/loaders/ColliderFunctions'
+import { EmptyCallback } from './CallbackComponent'
 
-export type ColliderComponentType = {
-  bodyType: RigidBodyType
-  shapeType: ShapeType
-  isTrigger: boolean
-  /**
-   * removeMesh will clean up any objects in the scene hierarchy after the collider bodies have been processed.
-   *   This can be used to reduce CPU load by only persisting colliders in the physics simulation.
-   */
-  removeMesh: boolean
-  collisionLayer: number
-  collisionMask: number
-  /**
-   * The function to call on the CallbackComponent of the targetEntity when the trigger volume is entered.
-   */
-  onEnter?: string
-  /**
-   * The function to call on the CallbackComponent of the targetEntity when the trigger volume is exited.
-   */
-  onExit?: string
-  /**
-   * uuid (string)
-   *
-   * empty string represents self
-   *
-   * TODO: how do we handle non-scene entities?
-   */
-  target?: string
-}
+export const ColliderComponent = defineComponent({
+  name: 'ColliderComponent',
 
-export const ColliderComponent = createMappedComponent<ColliderComponentType>('ColliderComponent')
+  onAdd: (entity: Entity) => {
+    const state = hookstate(
+      {
+        bodyType: RigidBodyType.Fixed,
+        shapeType: ShapeType.Cuboid,
+        scaleMultiplier: { x: 1, y: 1, z: 1 } as Vector3,
+        triggerCount: 0,
+        /**
+         * removeMesh will clean up any objects in the scene hierarchy after the collider bodies have been processed.
+         *   This can be used to reduce CPU load by only persisting colliders in the physics simulation.
+         */
+        removeMesh: false,
+        collisionLayer: CollisionGroups.Default,
+        collisionMask: DefaultCollisionMask,
+        /**
+         * The function to call on the CallbackComponent of the targetEntity when the trigger volume is entered.
+         */
+        onEnter: [EmptyCallback],
+        /**
+         * The function to call on the CallbackComponent of the targetEntity when the trigger volume is exited.
+         */
+        onExit: [EmptyCallback],
+        /**
+         * uuid (string)
+         *
+         * empty string represents self
+         *
+         * TODO: how do we handle non-scene entities?
+         */
+        target: ['']
+      },
+      subscribable()
+    )
+    return state as typeof state & StateMethodsDestroy
+  },
 
-export const SCENE_COMPONENT_COLLIDER = 'collider'
+  toJSON(entity, component) {
+    return {
+      bodyType: component.bodyType.value,
+      shapeType: component.shapeType.value,
+      scaleMultiplier: component.scaleMultiplier.value,
+      triggerCount: component.triggerCount.value,
+
+      removeMesh: component.removeMesh.value,
+      collisionLayer: component.collisionLayer.value,
+      collisionMask: component.collisionMask.value,
+
+      onEnter: component.onEnter.value,
+      onExit: component.onExit.value,
+
+      target: component.target.value
+    }
+  },
+
+  onUpdate: (entity, component, json) => {
+    if (json.bodyType != undefined) component.bodyType.set(json.bodyType)
+    if (json.shapeType != undefined) component.shapeType.set(json.shapeType)
+    if (json.scaleMultiplier != undefined) component.scaleMultiplier.set(json.scaleMultiplier)
+    if (json.triggerCount != undefined) component.triggerCount.set(json.triggerCount)
+
+    if (json.removeMesh != undefined) component.removeMesh.set(json.removeMesh)
+    if (json.collisionLayer != undefined) component.collisionLayer.set(json.collisionLayer)
+
+    if (json.onEnter != undefined) {
+      for (let i = 0; i < json.onEnter.length; i++) {
+        component.onEnter[i].set(json.onEnter[i])
+      }
+    }
+
+    if (json.onExit != undefined) {
+      for (let i = 0; i < json.onExit.length; i++) {
+        component.onExit[i].set(json.onExit[i])
+      }
+    }
+
+    if (json.target != undefined) {
+      for (let i = 0; i < json.target.length; i++) {
+        component.target[i].set(json.target[i])
+      }
+    }
+
+    updateCollider(entity)
+  },
+
+  onRemove: (entity, component) => {
+    component.destroy()
+  }
+})
 export const SCENE_COMPONENT_COLLIDER_DEFAULT_VALUES = {
   bodyType: RigidBodyType.Fixed,
   shapeType: ShapeType.Cuboid,
-  isTrigger: false,
+  scaleMultiplier: { x: 1, y: 1, z: 1 } as Vector3,
+  triggerCount: 0,
   removeMesh: false,
   collisionLayer: CollisionGroups.Default,
   collisionMask: DefaultCollisionMask
 }
+export const SCENE_COMPONENT_COLLIDER = 'collider'

--- a/packages/engine/src/scene/components/ModelComponent.ts
+++ b/packages/engine/src/scene/components/ModelComponent.ts
@@ -58,6 +58,7 @@ export const ModelComponent = defineComponent({
                 uuid
               })) as GLTF
               scene = gltf.scene as Scene
+              scene.animations = gltf.animations
               break
             case '.fbx':
             case '.usdz':

--- a/packages/engine/src/scene/components/PortalComponent.ts
+++ b/packages/engine/src/scene/components/PortalComponent.ts
@@ -3,7 +3,8 @@ import { Mesh, MeshBasicMaterial, Quaternion, SphereGeometry, Vector3 } from 'th
 
 import { createMappedComponent } from '../../ecs/functions/ComponentFunctions'
 import { CollisionGroups } from '../../physics/enums/CollisionGroups'
-import { ColliderComponentType } from './ColliderComponent'
+import { EmptyCallback } from './CallbackComponent'
+import { ColliderComponent } from './ColliderComponent'
 
 export type PortalComponentType = {
   location: string
@@ -41,10 +42,11 @@ export const SCENE_COMPONENT_PORTAL_DEFAULT_VALUES = {
 export const SCENE_COMPONENT_PORTAL_COLLIDER_VALUES = {
   bodyType: RigidBodyType.Fixed,
   shapeType: ShapeType.Cuboid,
-  isTrigger: true,
+  isTrigger: 1,
   removeMesh: true,
   collisionLayer: CollisionGroups.Trigger,
   collisionMask: CollisionGroups.Avatars,
-  target: '',
-  onEnter: 'teleport'
-} as ColliderComponentType
+  target: [''],
+  onEnter: ['teleport'],
+  onExit: [EmptyCallback]
+}

--- a/packages/engine/src/scene/systems/TriggerSystem.ts
+++ b/packages/engine/src/scene/systems/TriggerSystem.ts
@@ -5,34 +5,39 @@ import { CollisionComponent } from '../../physics/components/CollisionComponent'
 import { ColliderHitEvent, CollisionEvents } from '../../physics/types/PhysicsTypes'
 import { CallbackComponent } from '../components/CallbackComponent'
 import { ColliderComponent } from '../components/ColliderComponent'
+import { NameComponent } from '../components/NameComponent'
 
 export const triggerEnter = (world: World, entity: Entity, triggerEntity: Entity, hit: ColliderHitEvent) => {
   const triggerComponent = getComponent(triggerEntity, ColliderComponent)
-  if (!triggerComponent?.onEnter) return
-  if (triggerComponent.target && !world.entityTree.uuidNodeMap.has(triggerComponent.target)) return
+  for (let i = 0; i < triggerComponent.target.value.length; i++) {
+    if (!triggerComponent?.onEnter.value[i]) return
+    if (triggerComponent.target.value[i] && !world.entityTree.uuidNodeMap.has(triggerComponent.target.value[i])) return
 
-  const targetEntity = triggerComponent.target
-    ? world.entityTree.uuidNodeMap.get(triggerComponent.target)!.entity
-    : triggerEntity
+    const targetEntity = triggerComponent.target.value[i]
+      ? world.entityTree.uuidNodeMap.get(triggerComponent.target.value[i])!.entity
+      : triggerEntity
 
-  if (targetEntity) {
-    const callbacks = getComponent(targetEntity, CallbackComponent)
-    callbacks.get(triggerComponent.onEnter)?.(triggerEntity)
+    if (targetEntity) {
+      const callbacks = getComponent(targetEntity, CallbackComponent)
+      callbacks.get(triggerComponent.onEnter.value[i])?.(triggerEntity)
+    }
   }
 }
 
 export const triggerExit = (world: World, entity: Entity, triggerEntity: Entity, hit: ColliderHitEvent) => {
   const triggerComponent = getComponent(triggerEntity, ColliderComponent)
-  if (!triggerComponent?.onExit) return
-  if (triggerComponent.target && !world.entityTree.uuidNodeMap.has(triggerComponent.target)) return
+  for (let i = 0; i < triggerComponent.target.value.length; i++) {
+    if (!triggerComponent?.onExit.value[i]) return
+    if (triggerComponent.target.value[i] && !world.entityTree.uuidNodeMap.has(triggerComponent.target.value[i])) return
 
-  const targetEntity = triggerComponent.target
-    ? world.entityTree.uuidNodeMap.get(triggerComponent.target)!.entity
-    : triggerEntity
+    const targetEntity = triggerComponent.target.value[i]
+      ? world.entityTree.uuidNodeMap.get(triggerComponent.target.value[i])!.entity
+      : triggerEntity
 
-  if (targetEntity) {
-    const callbacks = getComponent(targetEntity, CallbackComponent)
-    callbacks.get(triggerComponent.onExit)?.(triggerEntity)
+    if (targetEntity) {
+      const callbacks = getComponent(targetEntity, CallbackComponent)
+      callbacks.get(triggerComponent.onExit.value[i])?.(triggerEntity)
+    }
   }
 }
 

--- a/packages/engine/src/xr/XRScenePlacementShader.ts
+++ b/packages/engine/src/xr/XRScenePlacementShader.ts
@@ -47,7 +47,9 @@ export default async function XRScenePlacementShader(world: World) {
           }
           obj.material.transparent = true
           obj.material.opacity = 0.4
-        } else if (userData.ScenePlacement) {
+          //add an extra check to prevent reading properties of undefined errors
+          //not sure of the root cause of userdata being undefined
+        } else if (userData && userData.ScenePlacement) {
           obj.material.transparent = userData.ScenePlacement.previouslyTransparent
           obj.material.opacity = userData.ScenePlacement.previousOpacity
           delete userData.ScenePlacement


### PR DESCRIPTION
Refactored the collider component to include arrays of events that can be set via the node editor, and added scaling separate from the transform component.

This refactor does impact other components that reference the collider component and minor refactors for those components must be included.

Additionally added a fix for animations not populating the model component, necessary to combine in one comit to demo animations with xr's default callbacks.