### PR TITLE
Updated instance-provisioning to support private instances.

### DIFF
--- a/packages/client-core/src/common/services/LocationInstanceConnectionService.ts
+++ b/packages/client-core/src/common/services/LocationInstanceConnectionService.ts
@@ -94,7 +94,7 @@ export const LocationInstanceConnectionService = {
     instanceId?: string,
     sceneId?: string,
     roomCode?: string,
-    createNewRoom?: boolean
+    createPrivateRoom?: boolean
   ) => {
     logger.info({ locationId, instanceId, sceneId }, 'Provision World Server')
     const token = accessAuthState().authUser.accessToken.value
@@ -116,7 +116,7 @@ export const LocationInstanceConnectionService = {
         sceneId,
         roomCode,
         token,
-        createNewRoom
+        createPrivateRoom
       }
     })
     if (provisionResult.ipAddress && provisionResult.port) {

--- a/packages/client-core/src/common/services/MediaInstanceConnectionService.ts
+++ b/packages/client-core/src/common/services/MediaInstanceConnectionService.ts
@@ -102,14 +102,14 @@ export const useMediaInstanceConnectionState = () => useState(accessMediaInstanc
 
 //Service
 export const MediaInstanceConnectionService = {
-  provisionServer: async (channelId?: string, createNewRoom = false) => {
+  provisionServer: async (channelId?: string, createPrivateRoom = false) => {
     logger.info(`Provision Media Server, channelId: "${channelId}".`)
     const token = accessAuthState().authUser.accessToken.value
     const provisionResult = await API.instance.client.service('instance-provision').find({
       query: {
         channelId,
         token,
-        createNewRoom
+        createPrivateRoom
       }
     })
     if (provisionResult.ipAddress && provisionResult.port) {

--- a/packages/server-core/src/hooks/matchmaking-create-instance.ts
+++ b/packages/server-core/src/hooks/matchmaking-create-instance.ts
@@ -34,7 +34,7 @@ export default (): Hook => {
       throw new Error(`Location for match type '${gameMode}'(${locationName}) is not found.`)
     }
 
-    const freeInstance = await getFreeInstanceserver(app, 0, location.data[0].id, null!, null!)
+    const freeInstance = await getFreeInstanceserver({ app, iteration: 0, locationId: location.data[0].id })
     try {
       const existingInstance = (await app.service('instance').find({
         query: {

--- a/packages/server-core/src/networking/instance-provision/instance-provision.class.ts
+++ b/packages/server-core/src/networking/instance-provision/instance-provision.class.ts
@@ -1,5 +1,5 @@
 import { BadRequest, NotAuthenticated } from '@feathersjs/errors'
-import { Id, NullableId, Params, ServiceMethods } from '@feathersjs/feathers'
+import { Id, NullableId, Paginated, Params, ServiceMethods } from '@feathersjs/feathers'
 import https from 'https'
 import _ from 'lodash'
 import fetch from 'node-fetch'
@@ -12,6 +12,7 @@ import { Application } from '../../../declarations'
 import config from '../../appconfig'
 import logger from '../../ServerLogger'
 import getLocalServerIp from '../../util/get-local-server-ip'
+import { InstanceAuthorizedUserDataType } from '../instance-authorized-user/instance-authorized-user.class'
 
 const releaseRegex = /^([a-zA-Z0-9]+)-/
 
@@ -19,15 +20,25 @@ const isNameRegex = /instanceserver-([a-zA-Z0-9]{5}-[a-zA-Z0-9]{5})/
 const pressureThresholdPercent = 0.8
 
 /**
- * An method which start server for instance
+ * Gets an instanceserver that is not in use or reserved
  */
-export async function getFreeInstanceserver(
-  app: Application,
-  iteration: number,
-  locationId: string,
-  channelId: string,
-  roomCode = undefined as undefined | string
-): Promise<InstanceServerProvisionResult> {
+export async function getFreeInstanceserver({
+  app,
+  iteration,
+  locationId,
+  channelId,
+  roomCode,
+  userId,
+  createPrivateRoom
+}: {
+  app: Application
+  iteration: number
+  locationId?: string
+  channelId?: string
+  roomCode?: string
+  userId?: string
+  createPrivateRoom?: boolean
+}): Promise<InstanceServerProvisionResult> {
   await app.service('instance').Model.destroy({
     where: {
       assigned: true,
@@ -42,7 +53,16 @@ export async function getFreeInstanceserver(
     logger.info('Local server spinning up new instance')
     const localIp = await getLocalServerIp(channelId != null)
     const stringIp = `${localIp.ipAddress}:${localIp.port}`
-    return checkForDuplicatedAssignments(app, stringIp, iteration, locationId, channelId, roomCode)
+    return checkForDuplicatedAssignments({
+      app,
+      ipAddress: stringIp,
+      iteration,
+      locationId,
+      channelId,
+      roomCode,
+      userId,
+      createPrivateRoom
+    })
   }
   logger.info('Getting free instanceserver')
   const serverResult = await app.k8AgonesClient.listNamespacedCustomObject('agones.dev', 'v1', 'default', 'gameservers')
@@ -77,26 +97,40 @@ export async function getFreeInstanceserver(
     (server) => server.status.address === split[0] && server.status.ports[0].port == split[1]
   )
 
-  return checkForDuplicatedAssignments(
+  return checkForDuplicatedAssignments({
     app,
-    instanceIpAddress,
+    ipAddress: instanceIpAddress,
     iteration,
     locationId,
     channelId,
     roomCode,
-    pod.metadata.name
-  )
+    userId,
+    createPrivateRoom,
+    podName: pod.metadata.name
+  })
 }
 
-export async function checkForDuplicatedAssignments(
-  app: Application,
-  ipAddress: string,
-  iteration: number,
-  locationId: string,
-  channelId: string,
-  roomCode = undefined as undefined | string,
-  podName = undefined as undefined | string
-): Promise<InstanceServerProvisionResult> {
+export async function checkForDuplicatedAssignments({
+  app,
+  ipAddress,
+  iteration,
+  locationId,
+  channelId,
+  roomCode,
+  createPrivateRoom,
+  userId,
+  podName
+}: {
+  app: Application
+  ipAddress: string
+  iteration: number
+  locationId?: string
+  channelId?: string
+  roomCode?: string | undefined
+  createPrivateRoom?: boolean
+  userId?: string
+  podName?: string
+}): Promise<InstanceServerProvisionResult> {
   //Create an assigned instance at this IP
   const assignResult: any = await app.service('instance').create({
     ipAddress: ipAddress,
@@ -156,7 +190,7 @@ export async function checkForDuplicatedAssignments(
       //If this is the 10th or more attempt to get a free instanceserver, then there probably aren't any free ones,
       //
       if (iteration < 10) {
-        return getFreeInstanceserver(app, iteration + 1, locationId, channelId, roomCode)
+        return getFreeInstanceserver({ app, iteration: iteration + 1, locationId, channelId, roomCode, userId })
       } else {
         logger.info('Made 10 attempts to get free instanceserver without success, returning null')
         return {
@@ -256,8 +290,22 @@ export async function checkForDuplicatedAssignments(
     await app.service('instance').remove(assignResult.id)
     if (config.kubernetes.enabled) app.k8DefaultClient.deleteNamespacedPod(assignResult.podName, 'default')
     else await new Promise((resolve) => setTimeout(() => resolve(null), 500))
-    return getFreeInstanceserver(app, iteration + 1, locationId, channelId, roomCode)
+    return getFreeInstanceserver({
+      app,
+      iteration: iteration + 1,
+      locationId,
+      channelId,
+      roomCode,
+      createPrivateRoom,
+      userId
+    })
   }
+
+  if (createPrivateRoom && userId)
+    await app.service('instance-authorized-user').create({
+      instanceId: assignResult.id,
+      userId
+    })
 
   const split = ipAddress.split(':')
   return {
@@ -289,15 +337,23 @@ export class InstanceProvision implements ServiceMethods<any> {
    * @param locationId
    * @param channelId
    * @param roomCode
+   * @param userId
    * @returns id, ipAddress and port
    */
 
-  async getISInService(
+  async getISInService({
     availableLocationInstances,
-    locationId: string,
-    channelId: string,
-    roomCode = undefined as undefined | string
-  ): Promise<InstanceServerProvisionResult> {
+    locationId,
+    channelId,
+    roomCode,
+    userId
+  }: {
+    availableLocationInstances: Instance[]
+    locationId?: string
+    channelId?: string
+    roomCode?: undefined | string
+    userId?: undefined | string
+  }): Promise<InstanceServerProvisionResult> {
     await this.app.service('instance').Model.destroy({
       where: {
         assigned: true,
@@ -326,8 +382,13 @@ export class InstanceProvision implements ServiceMethods<any> {
     if (isCleanup) {
       logger.info('IS did not exist and was cleaned up')
       if (availableLocationInstances.length > 1)
-        return this.getISInService(availableLocationInstances.slice(1), locationId, channelId, roomCode)
-      else return getFreeInstanceserver(this.app, 0, locationId, channelId, roomCode)
+        return this.getISInService({
+          availableLocationInstances: availableLocationInstances.slice(1),
+          locationId,
+          channelId,
+          roomCode
+        })
+      else return getFreeInstanceserver({ app: this.app, iteration: 0, locationId, channelId, roomCode, userId })
     }
     logger.info('IS existed, using it %o', instance)
     const ipAddressSplit = instance.ipAddress.split(':')
@@ -414,7 +475,7 @@ export class InstanceProvision implements ServiceMethods<any> {
       const instanceId = params?.query?.instanceId
       const channelId = params?.query?.channelId
       const roomCode = params?.query?.roomCode
-      const createNewRoom = params?.query?.createNewRoom
+      const createPrivateRoom = params?.query?.createPrivateRoom
       const token = params?.query?.token
       logger.info('instance-provision find %s %s %s %s', locationId, instanceId, channelId, roomCode)
       if (!token) throw new NotAuthenticated('No token provided')
@@ -439,11 +500,12 @@ export class InstanceProvision implements ServiceMethods<any> {
             ended: false
           }
         })
-        if (channelInstance == null) return getFreeInstanceserver(this.app, 0, null!, channelId, roomCode)
+        if (channelInstance == null)
+          return getFreeInstanceserver({ app: this.app, iteration: 0, channelId, roomCode, userId })
         else {
           if (config.kubernetes.enabled) {
             const isCleanup = await this.isCleanup(channelInstance)
-            if (isCleanup) return getFreeInstanceserver(this.app, 0, null!, channelId, roomCode)
+            if (isCleanup) return getFreeInstanceserver({ app: this.app, iteration: 0, channelId, roomCode, userId })
           }
           const ipAddressSplit = channelInstance.ipAddress.split(':')
           return {
@@ -472,8 +534,8 @@ export class InstanceProvision implements ServiceMethods<any> {
           instance = instances.length > 0 ? instances[0] : null
         }
 
-        if ((roomCode && (instance == null || instance.ended === true)) || createNewRoom)
-          return getFreeInstanceserver(this.app, 0, locationId, null!, roomCode)
+        if ((roomCode && (instance == null || instance.ended === true)) || createPrivateRoom)
+          return getFreeInstanceserver({ app: this.app, iteration: 0, locationId, roomCode, userId, createPrivateRoom })
 
         let isCleanup
 
@@ -483,6 +545,19 @@ export class InstanceProvision implements ServiceMethods<any> {
             (!config.kubernetes.enabled || (config.kubernetes.enabled && !isCleanup)) &&
             instance.currentUsers < location.maxUsersPerInstance
           ) {
+            if (roomCode) {
+              const existingInstanceAuthorizedUser = (await this.app.service('instance-authorized-user').find({
+                query: {
+                  instanceId: instance.id,
+                  userId
+                }
+              })) as Paginated<InstanceAuthorizedUserDataType>
+              if (existingInstanceAuthorizedUser.total === 0)
+                await this.app.service('instance-authorized-user').create({
+                  instanceId: instance.id,
+                  userId
+                })
+            }
             const ipAddressSplit = instance.ipAddress.split(':')
             return {
               id: instance.id,
@@ -545,24 +620,24 @@ export class InstanceProvision implements ServiceMethods<any> {
         //     }
         //   }
         // }
-        const friendsAtLocationResult = await this.app.service('user').Model.findAndCountAll({
-          include: [
-            {
-              model: this.app.service('user-relationship').Model,
-              where: {
-                relatedUserId: userId,
-                userRelationshipType: 'friend'
-              }
-            },
-            {
-              model: this.app.service('instance').Model,
-              where: {
-                locationId: locationId,
-                ended: false
-              }
-            }
-          ]
-        })
+        // const friendsAtLocationResult = await this.app.service('user').Model.findAndCountAll({
+        //   include: [
+        //     {
+        //       model: this.app.service('user-relationship').Model,
+        //       where: {
+        //         relatedUserId: userId,
+        //         userRelationshipType: 'friend'
+        //       }
+        //     },
+        //     {
+        //       model: this.app.service('instance').Model,
+        //       where: {
+        //         locationId: locationId,
+        //         ended: false
+        //       }
+        //     }
+        //   ]
+        // })
         // if (friendsAtLocationResult.count > 0) {
         //   const instances = {}
         //   friendsAtLocationResult.rows.forEach((friend) => {
@@ -630,8 +705,15 @@ export class InstanceProvision implements ServiceMethods<any> {
             )
         )
         if (allowedLocationInstances.length === 0)
-          return getFreeInstanceserver(this.app, 0, locationId, null!, roomCode)
-        else return this.getISInService(allowedLocationInstances, locationId, channelId, roomCode)
+          return getFreeInstanceserver({ app: this.app, iteration: 0, locationId, roomCode, userId })
+        else
+          return this.getISInService({
+            availableLocationInstances: allowedLocationInstances,
+            locationId,
+            channelId,
+            roomCode,
+            userId
+          })
       }
     } catch (err) {
       logger.error(err)

--- a/packages/server-core/src/networking/instance-provision/instance-provision.class.ts
+++ b/packages/server-core/src/networking/instance-provision/instance-provision.class.ts
@@ -545,7 +545,7 @@ export class InstanceProvision implements ServiceMethods<any> {
             (!config.kubernetes.enabled || (config.kubernetes.enabled && !isCleanup)) &&
             instance.currentUsers < location.maxUsersPerInstance
           ) {
-            if (roomCode) {
+            if (roomCode && roomCode === instance.roomCode) {
               const existingInstanceAuthorizedUser = (await this.app.service('instance-authorized-user').find({
                 query: {
                   instanceId: instance.id,

--- a/packages/server-core/src/networking/instanceserver-provision/instanceserver-provision-helper.ts
+++ b/packages/server-core/src/networking/instanceserver-provision/instanceserver-provision-helper.ts
@@ -27,7 +27,7 @@ export const patchInstanceserverLocation =
       }
 
       const patchServer = async () => {
-        const freeInstance = await getFreeInstanceserver(app, 0, locationId, null!)
+        const freeInstance = await getFreeInstanceserver({ app, iteration: 0, locationId })
         await app.service('instanceserver-load').patch({
           id: freeInstance.id,
           ipAddress: freeInstance.ipAddress,

--- a/scripts/build_minikube.sh
+++ b/scripts/build_minikube.sh
@@ -39,14 +39,14 @@ fi
 
 if [ -z "$VITE_CLIENT_HOST" ]
 then
-  VITE_CLIENT_HOST=local.theoverlay.io
+  VITE_CLIENT_HOST=local.etherealengine.com
 else
   VITE_CLIENT_HOST=$VITE_CLIENT_HOST
 fi
 
 if [ -z "$VITE_SERVER_HOST" ]
 then
-  VITE_SERVER_HOST=api-local.theoverlay.io
+  VITE_SERVER_HOST=api-local.etherealengine.com
 else
   VITE_SERVER_HOST=$VITE_SERVER_HOST
 fi
@@ -67,7 +67,7 @@ fi
 
 if [ -z "$VITE_INSTANCESERVER_HOST" ]
 then
-  VITE_INSTANCESERVER_HOST=instanceserver-local.theoverlay.io
+  VITE_INSTANCESERVER_HOST=instanceserver-local.etherealengine.com
 else
   VITE_INSTANCESERVER_HOST=$VITE_INSTANCESERVER_HOST
 fi


### PR DESCRIPTION
## Summary

Changed input query param 'createNewRoom' to 'createPrivateRoom'. If this is passed, then it mostly works as before, forcing a new instance to be provisioned, but it will also make the requesting user be added as an instance_authorized_user. This will prevent ordinary instance provision requests from putting users on this instance.

Changed params in most instance-provision.class.ts functions to be objects, as a long list of input variables when many of them are optional becomes unwieldy. If a user provisions with a room code and that instance exists, an instance_authorized_user will be made for them if it does not exist.

Changed default domain on minikube build from theoverlay.io to etherealengine.com


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

