### PR TITLE
Fixed a bug with PREPARE_DATABASE re: unique columns.

### DIFF
--- a/packages/server-core/src/media/static-resource/static-resource.model.ts
+++ b/packages/server-core/src/media/static-resource/static-resource.model.ts
@@ -23,8 +23,7 @@ export default (app: Application) => {
       },
       url: {
         type: DataTypes.STRING,
-        allowNull: true,
-        unique: true
+        allowNull: true
       },
       key: DataTypes.STRING,
       mimeType: {

--- a/packages/server-core/src/sequelize.ts
+++ b/packages/server-core/src/sequelize.ts
@@ -62,7 +62,13 @@ export default (app: Application): void => {
               }
               if (columnKeys.indexOf(value.fieldName) >= 0 && !value.primaryKey) {
                 try {
-                  if (!value.references) await sequelize.getQueryInterface().changeColumn(model, value.fieldName, value)
+                  if (!value.references) {
+                    if (value.unique)
+                      try {
+                        await sequelize.getQueryInterface().removeIndex(model, value.fieldName)
+                      } catch (err) {}
+                    await sequelize.getQueryInterface().changeColumn(model, value.fieldName, value)
+                  }
                 } catch (err) {
                   logger.error(err)
                 }


### PR DESCRIPTION
## Summary

SQL's ALTER TABLE <table> CHANGE command, if changing a unique column, will create duplicate unique keys. After 60-odd runs of the builder, this will result in the maximum default number of keys in each table, and throw errors. Made unique columns remove the old unique index before calling changeColumn.

Removed static_resource.url unique constraint; multiple static_resources should be able to have the same URL.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

