### PR TITLE
Fixed avatar issues.

### DIFF
--- a/packages/client-core/src/admin/components/Avatars/AvatarDrawer.tsx
+++ b/packages/client-core/src/admin/components/Avatars/AvatarDrawer.tsx
@@ -321,7 +321,8 @@ const AvatarDrawerContent = ({ open, mode, selectedAvatar, onClose }: Props) => 
           avatarBlob,
           thumbnailBlob,
           state.name + '_' + selectedAvatar.id,
-          selectedAvatar.isPublic
+          selectedAvatar.isPublic,
+          selectedAvatar.id
         )
         const removalPromises = [] as any
         if (uploadResponse[0].id !== selectedAvatar.modelResourceId)

--- a/packages/client-core/src/components/World/LoadEngineWithScene.tsx
+++ b/packages/client-core/src/components/World/LoadEngineWithScene.tsx
@@ -25,6 +25,7 @@ import {
 import { addActionReceptor, dispatchAction, getState, removeActionReceptor, useHookEffect } from '@xrengine/hyperflux'
 
 import { AppLoadingAction, AppLoadingStates, useLoadingState } from '../../common/services/AppLoadingService'
+import { NotificationService } from '../../common/services/NotificationService'
 import { useRouter } from '../../common/services/RouterService'
 import { useLocationState } from '../../social/services/LocationService'
 import { SocketWebRTCClientNetwork } from '../../transports/SocketWebRTCClientNetwork'
@@ -73,22 +74,29 @@ export const useLocationSpawnAvatar = () => {
 
     // the avatar should only be spawned once, after user auth and scene load
 
-    const user = authState.user.value
-    const avatarDetails = user.avatar
+    const user = authState.user
+    const avatarDetails = user.avatar.value
     const spawnPoint = getSearchParamFromURL('spawnPoint')
 
     const avatarSpawnPose = spawnPoint
       ? getSpawnPoint(spawnPoint, Engine.instance.userId)
       : getRandomSpawnPoint(Engine.instance.userId)
 
-    spawnLocalAvatarInWorld({
-      avatarSpawnPose,
-      avatarDetail: {
-        avatarURL: avatarDetails.modelResource?.url!,
-        thumbnailURL: avatarDetails.thumbnailResource?.url!
-      },
-      name: user.name
-    })
+    if (avatarDetails.modelResource?.url)
+      spawnLocalAvatarInWorld({
+        avatarSpawnPose,
+        avatarDetail: {
+          avatarURL: avatarDetails.modelResource?.url!,
+          thumbnailURL: avatarDetails.thumbnailResource?.url!
+        },
+        name: user.name.value
+      })
+    else {
+      NotificationService.dispatchNotify(
+        'Your avatar is missing its model. Please change your avatar from the user menu.',
+        { variant: 'error' }
+      )
+    }
   }, [engineState.sceneLoaded, authState.user, authState.user?.avatar, spectateParam])
 }
 

--- a/packages/client-core/src/systems/ui/ProfileDetailView/ReadyPlayerMenu.tsx
+++ b/packages/client-core/src/systems/ui/ProfileDetailView/ReadyPlayerMenu.tsx
@@ -26,6 +26,7 @@ import {
   validate
 } from '../../../user/components/UserMenu/menus/helperFunctions'
 import { AvatarService } from '../../../user/services/AvatarService'
+import { AVATAR_ID_REGEX, generateAvatarId } from '../../../util/avatarIdFunctions'
 import styleString from './index.scss'
 
 const logger = multiLogger.child({ component: 'client-core:ReadyPlayerMenu' })
@@ -83,9 +84,12 @@ const ReadyPlayerMenu = () => {
   const handleMessageEvent = async (event, entity) => {
     const url = event.data
 
+    const avatarIdRegexExec = AVATAR_ID_REGEX.exec(url)
+
     if (url && url.toString().toLowerCase().startsWith('http')) {
       setShowLoading(true)
       setAvatarUrl(url)
+      setAvatarName(avatarIdRegexExec ? avatarIdRegexExec[1] : generateAvatarId())
       try {
         const assetType = AssetLoader.getAssetType(url)
         if (assetType) {
@@ -134,7 +138,7 @@ const ReadyPlayerMenu = () => {
     const newContext = canvas.getContext('2d')
     newContext?.drawImage(renderer.domElement, 0, 0)
 
-    var thumbnailName = avatarUrl.substring(0, avatarUrl.lastIndexOf('.')) + '.png'
+    const thumbnailName = avatarUrl.substring(0, avatarUrl.lastIndexOf('.')) + '.png'
 
     canvas.toBlob(async (blob) => {
       await AvatarService.createAvatar(selectedFile, new File([blob!], thumbnailName), avatarName, false)

--- a/packages/client-core/src/user/components/UserMenu/menus/ReadyPlayerMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ReadyPlayerMenu.tsx
@@ -15,6 +15,7 @@ import { getOrbitControls } from '@xrengine/engine/src/input/functions/loadOrbit
 import { ArrowBack, Check } from '@mui/icons-material'
 import CircularProgress from '@mui/material/CircularProgress'
 
+import { AVATAR_ID_REGEX, generateAvatarId } from '../../../../util/avatarIdFunctions'
 import { AvatarService } from '../../../services/AvatarService'
 import styles from '../index.module.scss'
 import { Views } from '../util'
@@ -67,8 +68,11 @@ const ReadyPlayerMenu = ({ changeActiveMenu }: Props) => {
   const handleMessageEvent = async (event, entity) => {
     const url = event.data
 
+    const avatarIdRegexExec = AVATAR_ID_REGEX.exec(url)
+
     if (url && url.toString().toLowerCase().startsWith('http')) {
       setAvatarUrl(url)
+      setAvatarName(avatarIdRegexExec ? avatarIdRegexExec[1] : generateAvatarId())
       try {
         const assetType = AssetLoader.getAssetType(url)
         if (assetType) {
@@ -112,7 +116,7 @@ const ReadyPlayerMenu = ({ changeActiveMenu }: Props) => {
     const newContext = canvas.getContext('2d')
     newContext?.drawImage(renderer.domElement, 0, 0)
 
-    var thumbnailName = avatarUrl.substring(0, avatarUrl.lastIndexOf('.')) + '.png'
+    const thumbnailName = avatarUrl.substring(0, avatarUrl.lastIndexOf('.')) + '.png'
 
     canvas.toBlob(async (blob) => {
       setShowLoading(true)

--- a/packages/client-core/src/user/services/AvatarService.ts
+++ b/packages/client-core/src/user/services/AvatarService.ts
@@ -47,14 +47,13 @@ export const AvatarService = {
       isPublic
     })
 
-    const uploadResponse = await AvatarService.uploadAvatarModel(model, thumbnail, newAvatar.identifierName, isPublic)
-
-    const patchedAvatar = (await AvatarService.patchAvatar(
-      newAvatar.id,
-      uploadResponse[0].id,
-      uploadResponse[1].id,
-      newAvatar.name
-    )) as AvatarInterface
+    const uploadResponse = await AvatarService.uploadAvatarModel(
+      model,
+      thumbnail,
+      newAvatar.identifierName,
+      isPublic,
+      newAvatar.id
+    )
 
     if (!isPublic) {
       const selfUser = accessAuthState().user
@@ -62,8 +61,8 @@ export const AvatarService = {
       await AvatarService.updateUserAvatarId(
         userId,
         newAvatar.id,
-        patchedAvatar.modelResource?.url || '',
-        patchedAvatar.thumbnailResource?.url || ''
+        uploadResponse[0]?.url || '',
+        uploadResponse[1]?.url || ''
       )
     }
   },
@@ -130,11 +129,12 @@ export const AvatarService = {
     dispatchAction(AuthAction.avatarUpdatedAction({ url: result.url }))
   },
 
-  async uploadAvatarModel(avatar: Blob, thumbnail: Blob, avatarName: string, isPublic: boolean) {
+  async uploadAvatarModel(avatar: Blob, thumbnail: Blob, avatarName: string, isPublic: boolean, avatarId?: string) {
     return uploadToFeathersService('upload-asset', [avatar, thumbnail], {
       type: 'user-avatar-upload',
       args: {
         avatarName,
+        avatarId,
         isPublic
       }
     }).promise as Promise<StaticResourceInterface[]>

--- a/packages/client-core/src/util/avatarIdFunctions.ts
+++ b/packages/client-core/src/util/avatarIdFunctions.ts
@@ -1,0 +1,8 @@
+export const AVATAR_CHARACTERS = '123456789abcdef'
+export const AVATAR_ID_REGEX = /\/([a-fA-F0-9]+).glb$/
+
+export const generateAvatarId = () => {
+  let id = ''
+  for (let i = 0; i < 24; i++) id += AVATAR_CHARACTERS.charAt(Math.floor(Math.random() * AVATAR_CHARACTERS.length))
+  return id
+}

--- a/packages/client-core/src/util/upload.tsx
+++ b/packages/client-core/src/util/upload.tsx
@@ -11,11 +11,10 @@ export type CancelableUploadPromiseArrayReturnType<T = any> = { cancel: () => vo
 /**
  * upload used to upload image as blob data.
  *
- * @param  {any}  blobs
+ * @param  {any}  service
  * @param  {any}  onUploadProgress
- * @param  {any}  signal
- * @param  {any}  projectId
- * @param  {string}  fileIdentifier
+ * @param  {any}  files
+ * @param  {any}  params
  * @return {Promise}
  */
 

--- a/packages/engine/src/avatar/functions/avatarFunctions.ts
+++ b/packages/engine/src/avatar/functions/avatarFunctions.ts
@@ -1,6 +1,7 @@
 import { pipe } from 'bitecs'
 import { AnimationClip, AnimationMixer, Bone, Box3, Group, Object3D, Skeleton, SkinnedMesh, Vector3 } from 'three'
 
+import { NotificationService } from '@xrengine/client-core/src/common/services/NotificationService'
 import { dispatchAction, getState } from '@xrengine/hyperflux'
 
 import { AssetLoader } from '../../assets/classes/AssetLoader'
@@ -44,6 +45,11 @@ const tempVec3ForHeight = new Vector3()
 const tempVec3ForCenter = new Vector3()
 
 export const loadAvatarModelAsset = async (avatarURL: string) => {
+  if (!avatarURL)
+    return NotificationService.dispatchNotify(
+      'Your avatar is missing a a model. Please change your avatar from the user menu.',
+      { variant: 'error' }
+    )
   const model = await AssetLoader.loadAsync(avatarURL)
   const scene = model.scene || model // FBX files does not have 'scene' property
   if (!scene) return
@@ -91,7 +97,7 @@ export const loadAvatarForUser = async (
 
   removeComponent(entity, AvatarPendingComponent)
 
-  setupAvatarForUser(entity, parent)
+  if (parent) setupAvatarForUser(entity, parent)
 
   if (isClient && loadingEffect) {
     const avatar = getComponent(entity, AvatarComponent)

--- a/packages/server-core/src/media/upload-asset/upload-asset.hooks.ts
+++ b/packages/server-core/src/media/upload-asset/upload-asset.hooks.ts
@@ -1,4 +1,5 @@
 import { disallow } from 'feathers-hooks-common'
+import { SYNC } from 'feathers-sync'
 
 import logRequest from '@xrengine/server-core/src/hooks/log-request'
 import setLoggedInUser from '@xrengine/server-core/src/hooks/set-loggedin-user-in-body'
@@ -22,7 +23,12 @@ export default {
     all: [],
     find: [],
     get: [],
-    create: [],
+    create: [
+      (context) => {
+        context[SYNC] = false
+        return context
+      }
+    ],
     update: [],
     patch: [],
     remove: []

--- a/packages/server-core/src/user/avatar/avatar-helper.ts
+++ b/packages/server-core/src/user/avatar/avatar-helper.ts
@@ -29,6 +29,7 @@ export type AvatarUploadArguments = {
   avatarName: string
   isPublic: boolean
   avatarFileType?: string
+  avatarId?: string
 }
 
 // todo: move this somewhere else
@@ -106,6 +107,15 @@ export const uploadAvatarStaticResource = async (
   const [modelResource, thumbnailResource] = await Promise.all([modelPromise, thumbnailPromise])
 
   logger.info('Successfully uploaded avatar %o %o', modelResource, thumbnailResource)
+
+  if (data.avatarId) {
+    try {
+      await app.service('avatar').patch(data.avatarId, {
+        modelResourceId: modelResource.id,
+        thumbnailResourceId: thumbnailResource.id
+      })
+    } catch (err) {}
+  }
 
   return [modelResource, thumbnailResource]
 }

--- a/packages/server-core/src/user/user/user.hooks.ts
+++ b/packages/server-core/src/user/user/user.hooks.ts
@@ -245,9 +245,9 @@ export default {
     all: [],
     find: [parseAllUserSettings(), addAvatarResources()],
     get: [parseUserSettings(), addAvatarResources()],
-    create: [],
-    update: [],
-    patch: [parseUserSettings(), addAvatarResources],
+    create: [parseUserSettings(), addAvatarResources()],
+    update: [parseUserSettings, addAvatarResources()],
+    patch: [parseUserSettings(), addAvatarResources()],
     remove: []
   },
 


### PR DESCRIPTION
## Summary

Added checks for avatar model URL being present, to account for bad state where an avatar doesn't have a static resource for the model somehow. Error notifications are shown to prompt the user to change their avatar.

Fixed a bug where user patches weren't adding avatar details onto returned data.

Disabled feathers-sync on upload-asset.create. The data being sent through redis was sometimes causing most api/instanceservers' feathers-client instances to crash, likely due to the size of the models being sent.

Fixed a bug where ReadyPlayerMe avatar uploads didn't have an avatar name. This has been set to the returned RPM id, or a random 24-character string if that's missing for some reason.

Updated uploadAvatarStaticResource to accept avatarId. If present, it will patch that avatar with the model and thumbnail resourceIds automatically, so that an existing avatar isn't left dangling without linked resources if the user refreshes.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

