### PR TITLE
Fixed a bug in instance connection logic.

### DIFF
--- a/packages/instanceserver/src/channels.ts
+++ b/packages/instanceserver/src/channels.ts
@@ -75,7 +75,7 @@ const createNewInstance = async (app: Application, newInstance: InstanceMetadata
   logger.info('Creating new instance: %o %s, %s', newInstance, locationId, channelId)
   const instanceResult = (await app.service('instance').create(newInstance)) as Instance
   if (!channelId) {
-    const channelResult = await app.service('channel').create({
+    await app.service('channel').create({
       channelType: 'instance',
       instanceId: instanceResult.id
     })
@@ -207,6 +207,8 @@ const initializeInstance = async (
         })
       }
     }
+    await app.agonesSDK.allocate()
+    if (!app.instance) app.instance = instance
     if (userId && !(await authorizeUserToJoinServer(app, instance, userId))) return
     await assignExistingInstance(app, instance, channelId, locationId)
   }
@@ -333,7 +335,7 @@ const createOrUpdateInstance = async (
 ) => {
   logger.info('Creating new instance server or updating current one.')
   logger.info(`agones state is ${status.state}`)
-  logger.info('app instance is %o, app.instance')
+  logger.info('app instance is %o', app.instance)
   logger.info(`instanceLocationId: ${app.instance?.locationId}, locationId: ${locationId}`)
 
   const isReady = status.state === 'Ready'


### PR DESCRIPTION
## Summary

If an instance had been pre-generated, initializeInstance was not setting app.instance to the instance. This could cause bugs where loadEngine was being called and failing since app.instance had not been set to anything. Also calls agonesSDK.allocate() in case that has not been called.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

