### PR TITLE
Configurable webmanifest path

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "validate": "npm run lint && lerna run validate",
     "version-increment": "lerna version --conventional-commits --yes",
     "version-increment-no-tag": "lerna version --conventional-commits --yes --no-git-tag-version",
-    "bump-project-versions": "cross-env ts-node --swc scripts/bump-project-versions.js"
+    "bump-project-versions": "cross-env ts-node --swc scripts/bump-project-versions.js",
+    "update-site-manifest": "cross-env ts-node --swc scripts/update-site-manifest.ts"
   },
   "types": "lib/",
   "pre-commit": [

--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -324,7 +324,11 @@
       "theme": "Theme",
       "editor": "Editor",
       "admin": "Admin",
-      "key8thWall": "8th Wall Key"
+      "key8thWall": "8th Wall Key",
+      "shortTitle": "PWA Short Title",
+      "startPath": "PWA Start Path",
+      "shortTitleTooltip": "The displayed title of a PWA-installed copy of this app if 'title' is too long; recommended max 12 characters",
+      "startPathTooltip": "The path that a PWA-installed copy of this app will direct to"
     },
     "avatar": {
       "source": "Source",

--- a/packages/client-core/src/admin/components/Setting/Client.tsx
+++ b/packages/client-core/src/admin/components/Setting/Client.tsx
@@ -3,7 +3,9 @@ import { useTranslation } from 'react-i18next'
 
 import AddIcon from '@mui/icons-material/Add'
 import DeleteIcon from '@mui/icons-material/Delete'
+import HelpIcon from '@mui/icons-material/Help'
 import { Box, Button, Grid, IconButton, Typography } from '@mui/material'
+import Tooltip from '@mui/material/Tooltip'
 
 import { useAuthState } from '../../../user/services/AuthService'
 import InputText from '../../common/InputText'
@@ -17,10 +19,12 @@ const Client = () => {
   const user = authState.user
 
   const clientSettingState = useClientSettingState()
-  const [clientSetting] = clientSettingState?.client?.value || []
+  const [clientSetting] = clientSettingState?.client?.value || {}
   const id = clientSetting?.id
   const [logo, setLogo] = useState(clientSetting?.logo)
   const [title, setTitle] = useState(clientSetting?.title)
+  const [shortTitle, setShortTitle] = useState(clientSetting?.shortTitle)
+  const [startPath, setStartPath] = useState(clientSetting?.startPath || '/')
   const [appTitle, setAppTitle] = useState(clientSetting?.appTitle)
   const [appSubtitle, setAppSubtitle] = useState(clientSetting?.appSubtitle)
   const [appDescription, setAppDescription] = useState(clientSetting?.appDescription)
@@ -43,6 +47,8 @@ const Client = () => {
     if (clientSetting) {
       setLogo(clientSetting?.logo)
       setTitle(clientSetting?.title)
+      setShortTitle(clientSetting?.shortTitle)
+      setStartPath(clientSetting?.startPath || '/')
       setAppTitle(clientSetting?.appTitle)
       setAppSubtitle(clientSetting?.appSubtitle)
       setAppDescription(clientSetting?.appDescription)
@@ -88,15 +94,17 @@ const Client = () => {
       {
         logo: logo,
         title: title,
+        shortTitle: shortTitle,
+        startPath: startPath,
         icon192px: icon192px,
         icon512px: icon512px,
         favicon16px: favicon16px,
         favicon32px: favicon32px,
         siteDescription: siteDescription,
+        appBackground: appBackground,
         appTitle: appTitle,
         appSubtitle: appSubtitle,
         appDescription: appDescription,
-        appBackground: appBackground,
         appSocialLinks: JSON.stringify(appSocialLinks),
         themeSettings: JSON.stringify(clientSetting?.themeSettings),
         themeModes: JSON.stringify(clientSetting?.themeModes),
@@ -198,6 +206,30 @@ const Client = () => {
             value={title || ''}
             onChange={(e) => setTitle(e.target.value)}
           />
+
+          <div className={styles.tooltipRow}>
+            <InputText
+              name="shortTitle"
+              label={t('admin:components.setting.shortTitle')}
+              value={shortTitle || ''}
+              onChange={(e) => setShortTitle(e.target.value)}
+            />
+            <Tooltip title={t('admin:components.setting.shortTitleTooltip')} arrow>
+              <HelpIcon />
+            </Tooltip>
+          </div>
+
+          <div className={styles.tooltipRow}>
+            <InputText
+              name="startPath"
+              label={t('admin:components.setting.startPath')}
+              value={startPath || '/'}
+              onChange={(e) => setStartPath(e.target.value)}
+            />
+            <Tooltip title={t('admin:components.setting.startPathTooltip')} arrow>
+              <HelpIcon />
+            </Tooltip>
+          </div>
 
           <InputText
             name="description"

--- a/packages/client-core/src/admin/components/Setting/ClientTheme/index.tsx
+++ b/packages/client-core/src/admin/components/Setting/ClientTheme/index.tsx
@@ -72,6 +72,8 @@ const ClientTheme = () => {
       {
         logo: clientSetting?.logo,
         title: clientSetting?.title,
+        shortTitle: clientSetting?.shortTitle,
+        startPath: clientSetting?.startPath,
         icon192px: clientSetting?.icon192px,
         icon512px: clientSetting?.icon512px,
         favicon16px: clientSetting?.favicon16px,

--- a/packages/client-core/src/admin/styles/settings.module.scss
+++ b/packages/client-core/src/admin/styles/settings.module.scss
@@ -244,3 +244,16 @@
 .iconButton {
   color: var(--iconButtonColor);
 }
+
+.tooltipRow {
+  display: flex;
+
+  & > :first-child {
+    flex-grow: 1;
+  }
+
+  & > :last-child {
+    margin-left: 6px;
+    margin-top: 6px;
+  }
+}

--- a/packages/client/public/site.webmanifest
+++ b/packages/client/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
     "name": "Ethereal Engine",
-    "short_name": "EtherealEng",
+    "short_name": "Ethereal Eng",
     "start_url": "/",
     "icons": [
         {

--- a/packages/common/src/dbmodels/ClientSetting.ts
+++ b/packages/common/src/dbmodels/ClientSetting.ts
@@ -2,6 +2,8 @@ export interface ClientSettingInterface {
   id: string
   logo: string
   title: string
+  shortTitle: string
+  startPath: string
   url: string
   releaseName: string
   siteDescription: string

--- a/packages/common/src/interfaces/ClientSetting.ts
+++ b/packages/common/src/interfaces/ClientSetting.ts
@@ -2,6 +2,8 @@ export interface ClientSetting {
   id: string
   logo: string
   title: string
+  shortTitle: string
+  startPath: string
   url: string
   releaseName?: string
   siteDescription: string
@@ -77,6 +79,8 @@ export interface ThemeOptions {
 export interface PatchClientSetting {
   logo: string
   title: string
+  shortTitle: string
+  startPath: string
   icon192px: string
   icon512px: string
   favicon16px: string

--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -197,9 +197,7 @@ export class S3Provider implements StorageProviderInterface {
 
     if (data.Metadata) (args as StorageObjectInterface).Metadata = data.Metadata
 
-    const result = await this.provider.putObject(args).promise()
-
-    return result
+    return this.provider.putObject(args).promise()
   }
 
   /**
@@ -209,7 +207,7 @@ export class S3Provider implements StorageProviderInterface {
   async createInvalidation(invalidationItems: any[]) {
     // for non-standard s3 setups, we don't use cloudfront
     if (config.server.storageProvider !== 'aws') return
-    const data = await this.cloudfront
+    return this.cloudfront
       .createInvalidation({
         DistributionId: config.aws.cloudfront.distributionId,
         InvalidationBatch: {
@@ -221,8 +219,6 @@ export class S3Provider implements StorageProviderInterface {
         }
       })
       .promise()
-
-    return data
   }
 
   /**

--- a/packages/server-core/src/setting/client-setting/client-setting.model.ts
+++ b/packages/server-core/src/setting/client-setting/client-setting.model.ts
@@ -6,7 +6,7 @@ import { Application } from '../../../declarations'
 
 export default (app: Application) => {
   const sequelizeClient: Sequelize = app.get('sequelizeClient')
-  const ClientSetting = sequelizeClient.define<Model<ClientSettingInterface>>(
+  return sequelizeClient.define<Model<ClientSettingInterface>>(
     'clientSetting',
     {
       id: {
@@ -23,9 +23,17 @@ export default (app: Application) => {
         type: DataTypes.STRING,
         allowNull: true
       },
+      shortTitle: {
+        type: DataTypes.STRING,
+        allowNull: true
+      },
       url: {
         type: DataTypes.STRING,
         allowNull: true
+      },
+      startPath: {
+        type: DataTypes.STRING,
+        allowNull: false
       },
       releaseName: {
         type: DataTypes.STRING,
@@ -92,6 +100,4 @@ export default (app: Application) => {
       }
     }
   )
-
-  return ClientSetting
 }

--- a/packages/server-core/src/setting/client-setting/client-setting.seed.ts
+++ b/packages/server-core/src/setting/client-setting/client-setting.seed.ts
@@ -6,6 +6,8 @@ export const clientSeed = {
     {
       logo: process.env.APP_LOGO,
       title: process.env.APP_TITLE,
+      shortTitle: process.env.APP_TITLE,
+      startPath: '/',
       releaseName: process.env.RELEASE_NAME || 'local',
       siteDescription: process.env.SITE_DESC,
       url:

--- a/scripts/run-builder.sh
+++ b/scripts/run-builder.sh
@@ -16,6 +16,7 @@ bash ./scripts/setup_aws.sh $AWS_ACCESS_KEY $AWS_SECRET $AWS_REGION $CLUSTER_NAM
 npm run check-db-exists
 npm run install-projects
 npm run prepare-database
+npm run update-site-manifest
 cd packages/client && npm run buildenv
 if [ -n "$TWA_LINK" ]
 then

--- a/scripts/update-site-manifest.ts
+++ b/scripts/update-site-manifest.ts
@@ -1,0 +1,178 @@
+import dotenv from 'dotenv-flow'
+import cli from 'cli'
+import fs from 'fs'
+import path from 'path'
+import { DataTypes, Sequelize } from 'sequelize'
+import appRootPath from 'app-root-path'
+import config from "@xrengine/server-core/src/appconfig";
+import {getContentType} from "@xrengine/server-core/src/util/fileUtils";
+import {
+  createDefaultStorageProvider,
+  getStorageProvider
+} from '@xrengine/server-core/src/media/storageprovider/storageprovider'
+import { getCacheDomain } from '@xrengine/server-core/src/media/storageprovider/getCacheDomain'
+
+const kubernetesEnabled = process.env.KUBERNETES === 'true'
+if (!kubernetesEnabled) {
+  dotenv.config({
+    path: appRootPath.path,
+    silent: true
+  })
+}
+
+const db = {
+  username: process.env.MYSQL_USER ?? 'server',
+  password: process.env.MYSQL_PASSWORD ?? 'password',
+  database: process.env.MYSQL_DATABASE ?? 'xrengine',
+  host: process.env.MYSQL_HOST ?? '127.0.0.1',
+  port: process.env.MYSQL_PORT ?? 3306,
+  dialect: 'mysql'
+} as any
+
+db.url = process.env.MYSQL_URL ?? `mysql://${db.username}:${db.password}@${db.host}:${db.port}/${db.database}`
+
+cli.enable('status')
+
+const sequelize = new Sequelize({
+  ...db,
+  logging: true,
+  define: {
+    freezeTableName: true
+  }
+})
+
+cli.main(async () => {
+  await sequelize.sync()
+
+  await createDefaultStorageProvider()
+  const storageProvider = getStorageProvider()
+
+  const ClientSettings = sequelize.define('clientSetting', {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV1,
+      allowNull: false,
+      primaryKey: true
+    },
+    logo: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    title: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    shortTitle: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    url: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    startPath: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    releaseName: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    siteDescription: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    favicon32px: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    favicon16px: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    icon192px: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    icon512px: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    appBackground: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    appTitle: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    appSubtitle: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    appDescription: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    appSocialLinks: {
+      type: DataTypes.JSON,
+      allowNull: true
+    },
+    themeSettings: {
+      type: DataTypes.JSON,
+      allowNull: true
+    },
+    themeModes: {
+      type: DataTypes.JSON,
+      allowNull: true
+    },
+    key8thWall: {
+      type: DataTypes.STRING,
+      allowNull: true
+    }
+  })
+
+  const [clientSettings] = await ClientSettings.findAll()
+
+  const manifestPath = path.join(appRootPath.path, 'packages/client/public/site.webmanifest')
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, { encoding: 'utf-8' }))
+
+  const icon192px = /https:\/\//.test(clientSettings.icon192px) ? clientSettings.icon192px : path.join('client', clientSettings.icon192px)
+  const icon512px = /https:\/\//.test(clientSettings.icon512px) ? clientSettings.icon512px : path.join('client', clientSettings.icon512px)
+  manifest.name = clientSettings.title
+  manifest.short_name = clientSettings.shortTitle
+  manifest.start_url =
+      config.client.url[config.client.url.length - 1] === '/' && clientSettings.startPath[0] === '/'
+          ? config.client.url + clientSettings.startPath.slice(1)
+          : config.client.url[config.client.url.length - 1] !== '/' && clientSettings.startPath[0] !== '/'
+              ? config.client.url + '/' + clientSettings.startPath
+              : config.client.url + clientSettings.startPath
+  const cacheDomain = getCacheDomain(storageProvider)
+  manifest.icons = [
+    {
+      src: /https:\/\//.test(icon192px)
+          ? icon192px
+          : cacheDomain[cacheDomain.length - 1] === '/' && icon192px[0] === '/'
+              ? `https://${cacheDomain}${icon192px.slice(1)}`
+              : cacheDomain[cacheDomain.length - 1] !== '/' && icon192px[0] !== '/'
+                  ? `https://${cacheDomain}/${icon192px}`
+                  : `https://${cacheDomain}${icon192px}`,
+      sizes: '192x192',
+      type: getContentType(icon192px)
+    },
+    {
+      src: /https:\/\//.test(icon512px)
+          ? icon512px
+          : cacheDomain[cacheDomain.length - 1] === '/' && icon512px[0] === '/'
+              ? `https://${cacheDomain}${icon512px.slice(1)}`
+              : cacheDomain[cacheDomain.length - 1] !== '/' && icon512px[0] !== '/'
+                  ? `https://${cacheDomain}/${icon512px}`
+                  : `https://${cacheDomain}${icon512px}`,
+      sizes: '512x512',
+      type: getContentType(icon512px)
+    }
+  ]
+  fs.writeFileSync(manifestPath, Buffer.from(JSON.stringify(manifest)))
+
+  process.exit(0)
+})

--- a/test-deploy.yml
+++ b/test-deploy.yml
@@ -1,0 +1,99 @@
+name: test-deploy
+
+on:
+  push:
+    branches:
+      [configurable-webmanifest-path]
+jobs:
+  secrets-gate-run:
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.check-secrets-run.outputs.ok }}
+    steps:
+      - name: check for secrets needed to run workflows
+        id: check-secrets-run
+        run: |
+          if [ ${{ secrets.DEPLOYMENTS_ENABLED }} == 'true' ]; then
+            echo "::set-output name=ok::enabled"
+          fi
+  secrets-gate-webhook:
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.check-secrets-webhook.outputs.ok }}
+    steps:
+      - name: check for secrets needed to run workflows
+        id: check-secrets-webhook
+        run: |
+          if [ ${{ secrets.SEND_FINISHED_WEBHOOK }} == 'true' ]; then
+            echo "::set-output name=ok::enabled"
+          fi
+  dev-deploy:
+    needs:
+      - secrets-gate-run
+    if: ${{ needs.secrets-gate-run.outputs.ok == 'enabled' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - name: Setup Helm
+        run: scripts/setup_helm_builder.sh
+      - name: Setup AWS
+        run: scripts/setup_aws_builder.sh $AWS_ACCESS_KEY $AWS_SECRET $AWS_REGION $CLUSTER_NAME
+        env:
+          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET: ${{ secrets.AWS_SECRET }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          CLUSTER_NAME: ${{ secrets.CLUSTER_NAME }}
+      - name: Space debug
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Build Docker Image
+        run: bash scripts/build_docker_builder.sh dev $DOCKER_LABEL $PRIVATE_ECR $AWS_REGION
+        env:
+          DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
+          REPO_NAME: ${{ secrets.DEV_REPO_NAME }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          ECR_URL: ${{ secrets.ECR_URL }}
+          PRIVATE_ECR: ${{ secrets.PRIVATE_ECR }}
+      - name: delete package.json
+        run: rm package.json
+      - name: npm-install 'cli' and 'aws-sdk'
+        run: npm install cli aws-sdk
+      - name: Publish to Elastic Container Registry
+        run: bash scripts/publish_ecr_builder.sh dev $GITHUB_SHA $DOCKER_LABEL $PRIVATE_ECR $AWS_REGION
+        env:
+          DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
+          REPO_NAME: ${{ secrets.DEV_REPO_NAME }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          ECR_URL: ${{ secrets.ECR_URL }}
+          PRIVATE_ECR: ${{ secrets.PRIVATE_ECR }}
+      - name: Deploy to EKS
+        run: bash scripts/deploy_builder.sh dev $GITHUB_SHA
+      - name: Publish to Docker Hub
+        run: bash scripts/publish_dockerhub_builder.sh $GITHUB_SHA $DOCKER_LABEL
+        env:
+          DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          PUBLISH_DOCKERHUB: ${{ secrets.PUBLISH_DOCKERHUB }}
+      - name: Job succeeded
+        if: ${{ needs.secrets-gate-webhook.outputs.ok == 'enabled' }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6 # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        env:
+          JOB_STATUS: ${{ job.status }}
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+          HOOK_OS_NAME: ${{ runner.os }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          run: |
+            git clone https://github.com/DiscordHooks/github-actions-discord-webhook.git webhook
+            bash webhook/send.sh $JOB_STATUS $WEBHOOK_URL
+          shell: bash


### PR DESCRIPTION
## Summary

Added configuration of site manifest and automatic reupload of manifest.
    
With the move to hosting client files from the storage provider, the site manifest file was
providing improper paths. The start_path was being read by the client as being under the
storage provider's domain, rather than the client domain, and the icon paths were not correct,
since the convention is to have client files under /client in the storage provider.

Most aspects of the site manifest are now configurable from clientSettings. 'name' uses
clientSettings.title; 'short_name' comes from a new field, clientSettings.shortTitle;
'start_url' explicitly adds a new field clientSettings.startPath onto config.client.url;
and the two icons are combined from clientSettings.icon192px and clientSettings.icon512px
with the cacheDomain.

client-setting.patch now pulls down the manifest from the storage provider, updates it with the
patched data, and pushes it back to the storage provider. The same basic thing is done during
run-builder.sh in a new script update-site-manifest.ts, but instead of pulling/pushing to the
storage provider, just updates the copy of the file in packages/client/public, as all of that
will be built and pushed to the storage provider in the client build process.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

