### PR TITLE
Simplify group reactors

### DIFF
--- a/packages/client-core/src/systems/AvatarUISystem.tsx
+++ b/packages/client-core/src/systems/AvatarUISystem.tsx
@@ -13,6 +13,7 @@ import { World } from '@xrengine/engine/src/ecs/classes/World'
 import {
   defineQuery,
   getComponent,
+  hasComponent,
   removeQuery,
   setComponent
 } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
@@ -112,10 +113,12 @@ export default async function AvatarUISystem(world: World) {
       const hit = hits[0]
       const hitEntity = (hit.body?.userData as any)?.entity as Entity
       if (typeof hitEntity !== 'undefined' && hitEntity !== Engine.instance.currentWorld.localClientEntity) {
-        const userId = getComponent(hitEntity, NetworkObjectComponent).ownerId
-        AvatarContextMenuUI.state.id.set(userId)
-        setVisibleComponent(AvatarContextMenuUI.entity, true)
-        return
+        if (hasComponent(hitEntity, NetworkObjectComponent)) {
+          const userId = getComponent(hitEntity, NetworkObjectComponent).ownerId
+          AvatarContextMenuUI.state.id.set(userId)
+          setVisibleComponent(AvatarContextMenuUI.entity, true)
+          return // successful hit
+        }
       }
     }
 

--- a/packages/client-core/src/systems/ui/SettingDetailView/index.tsx
+++ b/packages/client-core/src/systems/ui/SettingDetailView/index.tsx
@@ -63,11 +63,11 @@ const SettingDetailView = () => {
     const avatar = getComponent(entity, AvatarComponent)
     if (!avatar) return
     if (showAvatar) {
-      if (avatar.modelContainer.visible) return
-      avatar.modelContainer.visible = showAvatar
+      if (avatar.model.visible) return
+      avatar.model.visible = showAvatar
     } else {
-      if (!avatar.modelContainer.visible) return
-      avatar.modelContainer.visible = showAvatar
+      if (!avatar.model.visible) return
+      avatar.model.visible = showAvatar
     }
   }, [showAvatar])
 

--- a/packages/client-core/src/systems/ui/SettingDetailView/index.tsx
+++ b/packages/client-core/src/systems/ui/SettingDetailView/index.tsx
@@ -63,11 +63,11 @@ const SettingDetailView = () => {
     const avatar = getComponent(entity, AvatarComponent)
     if (!avatar) return
     if (showAvatar) {
-      if (avatar.model.visible) return
-      avatar.model.visible = showAvatar
+      if (avatar.model!.visible) return
+      avatar.model!.visible = showAvatar
     } else {
-      if (!avatar.model.visible) return
-      avatar.model.visible = showAvatar
+      if (!avatar.model!.visible) return
+      avatar.model!.visible = showAvatar
     }
   }, [showAvatar])
 

--- a/packages/engine/src/assets/csm/CSM.ts
+++ b/packages/engine/src/assets/csm/CSM.ts
@@ -304,6 +304,7 @@ export class CSM {
 
   setupMaterial(mesh: Mesh): void {
     const material = mesh.material as Material
+    if (!material.userData) material.userData = {}
     if (material.userData.IGNORE_CSM || material.userData.CSMPlugin) return
     material.defines = material.defines || {}
     material.defines.USE_CSM = 1
@@ -319,7 +320,8 @@ export class CSM {
     material.userData.CSMPlugin = {
       id: OBCType.CSM,
       compile: function (shader: ShaderType) {
-        if (!self.camera) return
+        if (shaders.has(material)) return
+        console.log(material)
         const far = Math.min(self.camera.far, self.maxFar)
         self.getExtendedBreaks(breaksVec2)
 
@@ -333,7 +335,7 @@ export class CSM {
 
     addOBCPlugin(material, material.userData.CSMPlugin)
 
-    shaders.set(material, null!)
+    shaders.delete(material)
   }
 
   updateUniforms(): void {

--- a/packages/engine/src/audio/systems/PositionalAudioSystem.ts
+++ b/packages/engine/src/audio/systems/PositionalAudioSystem.ts
@@ -13,7 +13,6 @@ import {
   ComponentType,
   defineQuery,
   getComponent,
-  getOptionalComponentState,
   hasComponent,
   removeQuery,
   useOptionalComponent
@@ -110,7 +109,6 @@ export default async function PositionalAudioSystem(world: World) {
     [PositionalAudioComponent, TransformComponent],
     function (props) {
       const entity = props.root.entity
-      if (!hasComponent(entity, PositionalAudioComponent)) throw props.root.stop()
 
       const mediaElement = useOptionalComponent(entity, MediaElementComponent)
       const panner = useHookstate(null as ReturnType<typeof addPannerNode> | null)
@@ -129,6 +127,8 @@ export default async function PositionalAudioSystem(world: World) {
           }
         }
       }, [mediaElement])
+
+      if (!hasComponent(entity, PositionalAudioComponent)) throw props.root.stop()
 
       return null
     }

--- a/packages/engine/src/avatar/components/AvatarComponent.ts
+++ b/packages/engine/src/avatar/components/AvatarComponent.ts
@@ -1,13 +1,10 @@
-import { Group } from 'three'
+import { Object3D } from 'three'
 
 import { createMappedComponent } from '../../ecs/functions/ComponentFunctions'
 
 export type AvatarComponentType = {
-  /**
-   * @property {Group} modelContainer is a group that holds the model such that the animations & IK can move seperate from the transform & collider
-   * It's center is at the center of the collider, except with y sitting at the bottom of the collider, flush with the ground
-   */
-  modelContainer: Group
+  /** @todo move this to AvatarRigComponent */
+  model: Object3D | null
   avatarHeight: number
   avatarHalfHeight: number
 }

--- a/packages/engine/src/avatar/functions/avatarFunctions.ts
+++ b/packages/engine/src/avatar/functions/avatarFunctions.ts
@@ -22,7 +22,7 @@ import {
 import { createEntity } from '../../ecs/functions/EntityFunctions'
 import UpdateableObject3D from '../../scene/classes/UpdateableObject3D'
 import { setCallback } from '../../scene/components/CallbackComponent'
-import { GroupComponent } from '../../scene/components/GroupComponent'
+import { addObjectToGroup, GroupComponent, removeObjectFromGroup } from '../../scene/components/GroupComponent'
 import { UpdatableCallback, UpdatableComponent } from '../../scene/components/UpdatableComponent'
 import { ObjectLayers } from '../../scene/constants/ObjectLayers'
 import { setObjectLayers } from '../../scene/functions/setObjectLayers'
@@ -102,7 +102,7 @@ export const loadAvatarForUser = async (
 
   if (isClient && loadingEffect) {
     const avatar = getComponent(entity, AvatarComponent)
-    const avatarMaterials = setupAvatarMaterials(entity, avatar.modelContainer)
+    const avatarMaterials = setupAvatarMaterials(entity, avatar.model)
     const effectEntity = createEntity()
     addComponent(effectEntity, AvatarEffectComponent, {
       sourceEntity: entity,
@@ -116,12 +116,14 @@ export const loadAvatarForUser = async (
 
 export const setupAvatarForUser = (entity: Entity, model: Object3D) => {
   const avatar = getComponent(entity, AvatarComponent)
-  avatar.modelContainer.clear()
+  if (avatar.model) removeObjectFromGroup(entity, avatar.model)
 
   setupAvatarModel(entity)(model)
   setupAvatarHeight(entity, model)
 
-  model.children.forEach((child) => avatar.modelContainer.add(child))
+  addObjectToGroup(entity, model)
+  setObjectLayers(model, ObjectLayers.Avatar)
+  avatar.model = model
 }
 
 export const setupAvatarModel = (entity: Entity) =>

--- a/packages/engine/src/avatar/functions/spawnAvatarReceptor.ts
+++ b/packages/engine/src/avatar/functions/spawnAvatarReceptor.ts
@@ -1,5 +1,5 @@
 import { Collider, ColliderDesc, RigidBody, RigidBodyDesc } from '@dimforge/rapier3d-compat'
-import { AnimationClip, AnimationMixer, Group, Quaternion, Vector3 } from 'three'
+import { AnimationClip, AnimationMixer, Group, Object3D, Quaternion, Vector3 } from 'three'
 
 import { Engine } from '../../ecs/classes/Engine'
 import { Entity } from '../../ecs/classes/Entity'
@@ -64,20 +64,10 @@ export const spawnAvatarReceptor = (spawnAction: typeof WorldNetworkAction.spawn
   const entity = world.getNetworkObject(spawnAction.$from, spawnAction.networkId)!
   const transform = getComponent(entity, TransformComponent)
 
-  // The visuals group is centered for easy actor tilting
-  const tiltContainer = new Group()
-  tiltContainer.name = 'Actor (tiltContainer)' + entity
-  // tiltContainer.position.setY(defaultAvatarHalfHeight)
-
-  // // Model container is used to reliably ground the actor, as animation can alter the position of the model itself
-  const modelContainer = new Group()
-  modelContainer.name = 'Actor (modelContainer)' + entity
-  tiltContainer.add(modelContainer)
-
   addComponent(entity, AvatarComponent, {
     avatarHalfHeight: defaultAvatarHalfHeight,
     avatarHeight: defaultAvatarHeight,
-    modelContainer
+    model: null
   })
 
   addComponent(entity, NameComponent, 'avatar_' + userId)
@@ -96,7 +86,7 @@ export const spawnAvatarReceptor = (spawnAction: typeof WorldNetworkAction.spawn
   })
 
   addComponent(entity, AnimationComponent, {
-    mixer: new AnimationMixer(modelContainer),
+    mixer: new AnimationMixer(new Object3D()),
     animations: [] as AnimationClip[],
     animationSpeed: 1
   })
@@ -116,9 +106,6 @@ export const spawnAvatarReceptor = (spawnAction: typeof WorldNetworkAction.spawn
     leftHand: false,
     rightHand: false
   })
-
-  addObjectToGroup(entity, tiltContainer)
-  setObjectLayers(tiltContainer, ObjectLayers.Avatar)
 
   addComponent(entity, SpawnPoseComponent, {
     position: new Vector3().copy(transform.position),

--- a/packages/engine/src/common/functions/OnBeforeCompilePlugin.ts
+++ b/packages/engine/src/common/functions/OnBeforeCompilePlugin.ts
@@ -14,6 +14,7 @@ import {
   MeshToonMaterial,
   PointsMaterial,
   RawShaderMaterial,
+  Shader,
   ShaderMaterial,
   ShadowMaterial,
   SpriteMaterial
@@ -31,6 +32,7 @@ export type PluginObjectType = {
 export type PluginType = PluginObjectType | typeof Material.prototype.onBeforeCompile
 
 export type CustomMaterial = Material & {
+  shader: Shader
   plugins?: PluginType[]
   _onBeforeCompile: typeof Material.prototype.onBeforeCompile
   onBeforeCompile: PluginType
@@ -150,6 +152,7 @@ export function overrideOnBeforeCompile() {
 
     ;(Material.prototype as any)._onBeforeCompile = function (shader, renderer) {
       if (!this.plugins) return
+      if (!this.shader) this.shader = shader
 
       for (let i = 0, l = this.plugins.length; i < l; i++) {
         const plugin = this.plugins[i]

--- a/packages/engine/src/ecs/classes/World.ts
+++ b/packages/engine/src/ecs/classes/World.ts
@@ -85,7 +85,6 @@ export class World {
     addComponent(this.cameraEntity, NameComponent, 'camera')
     addComponent(this.cameraEntity, CameraComponent)
     addComponent(this.cameraEntity, VisibleComponent, true)
-    setTransformComponent(this.cameraEntity)
     setLocalTransformComponent(this.cameraEntity, this.originEntity)
 
     this.camera.matrixAutoUpdate = false

--- a/packages/engine/src/ecs/functions/EntityTree.ts
+++ b/packages/engine/src/ecs/functions/EntityTree.ts
@@ -75,7 +75,6 @@ export function initializeEntityTree(world = Engine.instance.currentWorld): void
   setComponent(world.sceneEntity, VisibleComponent, true)
   setComponent(world.sceneEntity, SceneTagComponent, true)
   setTransformComponent(world.sceneEntity)
-  // addObjectToGroup(world.sceneEntity, world.scene)
 
   world.entityTree = {
     rootNode: createEntityNode(world.sceneEntity),

--- a/packages/engine/src/input/systems/ClientInputSystem.ts
+++ b/packages/engine/src/input/systems/ClientInputSystem.ts
@@ -128,7 +128,7 @@ export const addClientInputListeners = (world: World) => {
     const down = event.type === 'keydown'
 
     if (down) world.buttons[code] = createInitialButtonState()
-    else world.buttons[code].up = true
+    else if (world.buttons[code]) world.buttons[code].up = true
   }
   addListener(document, 'keyup', onKeyEvent)
   addListener(document, 'keydown', onKeyEvent)

--- a/packages/engine/src/scene/components/GroupComponent.ts
+++ b/packages/engine/src/scene/components/GroupComponent.ts
@@ -1,5 +1,7 @@
 import { BufferGeometry, Camera, Material, Mesh, Object3D } from 'three'
 
+import { none } from '@xrengine/hyperflux'
+
 import {
   proxifyQuaternion,
   proxifyQuaternionWithDirty,
@@ -12,6 +14,7 @@ import {
   addComponent,
   defineComponent,
   getComponent,
+  getComponentState,
   hasComponent,
   removeComponent,
   setComponent
@@ -45,7 +48,7 @@ export function addObjectToGroup(entity: Entity, object: Object3D) {
   if (!hasComponent(entity, GroupComponent)) addComponent(entity, GroupComponent, [])
   if (!hasComponent(entity, TransformComponent)) setTransformComponent(entity)
 
-  getComponent(entity, GroupComponent).push(obj)
+  getComponentState(entity, GroupComponent).merge([obj])
 
   const transform = getComponent(entity, TransformComponent)
   const world = Engine.instance.currentWorld
@@ -78,7 +81,9 @@ export function removeObjectFromGroup(entity: Entity, object: Object3D) {
 
   if (hasComponent(entity, GroupComponent)) {
     const group = getComponent(entity, GroupComponent)
-    if (group.includes(obj)) group.splice(group.indexOf(obj), 1)
+    if (group.includes(obj)) {
+      getComponentState(entity, GroupComponent)[group.indexOf(obj)].set(none)
+    }
     if (!group.length) removeComponent(entity, GroupComponent)
   }
 

--- a/packages/engine/src/scene/components/GroupComponent.tsx
+++ b/packages/engine/src/scene/components/GroupComponent.tsx
@@ -51,6 +51,8 @@ export function addObjectToGroup(entity: Entity, object: Object3D) {
   obj.entity = entity
 
   if (!hasComponent(entity, GroupComponent)) addComponent(entity, GroupComponent, [])
+  if (getComponent(entity, GroupComponent).includes(obj))
+    return console.warn('[addObjectToGroup]: Tried to add an object that is already included', entity, object)
   if (!hasComponent(entity, TransformComponent)) setTransformComponent(entity)
 
   getComponentState(entity, GroupComponent).merge([obj])
@@ -88,6 +90,8 @@ export function removeObjectFromGroup(entity: Entity, object: Object3D) {
     const group = getComponent(entity, GroupComponent)
     if (group.includes(obj)) {
       getComponentState(entity, GroupComponent)[group.indexOf(obj)].set(none)
+    } else {
+      console.warn('[removeObjectFromGroup]: Tried to remove an obejct from a group it is not in', entity, object)
     }
     if (!group.length) removeComponent(entity, GroupComponent)
   }
@@ -97,12 +101,12 @@ export function removeObjectFromGroup(entity: Entity, object: Object3D) {
 
 export const SCENE_COMPONENT_GROUP = 'group'
 
-type GroupReactorProps = {
+export type GroupReactorProps = {
   entity: Entity
-  obj: Object3D
+  obj: Object3DWithEntity
 }
 
-export const createGroupQueryReactor = (
+export const startGroupQueryReactor = (
   GroupChildReactor: React.FC<GroupReactorProps>,
   components: (bitECS.Component | bitECS.QueryModifier)[] = []
 ) =>
@@ -115,7 +119,7 @@ export const createGroupQueryReactor = (
     return (
       <>
         {groupComponent?.value?.map((obj, i) => (
-          <GroupChildReactor key={obj.uuid + i} entity={entity} obj={obj} />
+          <GroupChildReactor key={obj.uuid} entity={entity} obj={obj} />
         ))}
       </>
     )

--- a/packages/engine/src/scene/components/GroupComponent.tsx
+++ b/packages/engine/src/scene/components/GroupComponent.tsx
@@ -4,12 +4,7 @@ import { BufferGeometry, Camera, Material, Mesh, Object3D } from 'three'
 
 import { none } from '@xrengine/hyperflux'
 
-import {
-  proxifyQuaternion,
-  proxifyQuaternionWithDirty,
-  proxifyVector3,
-  proxifyVector3WithDirty
-} from '../../common/proxies/createThreejsProxy'
+import { proxifyQuaternionWithDirty, proxifyVector3WithDirty } from '../../common/proxies/createThreejsProxy'
 import { Engine } from '../../ecs/classes/Engine'
 import { Entity } from '../../ecs/classes/Entity'
 import {
@@ -19,10 +14,8 @@ import {
   getComponentState,
   hasComponent,
   removeComponent,
-  setComponent,
   useOptionalComponent
 } from '../../ecs/functions/ComponentFunctions'
-import { EntityReactorProps } from '../../ecs/functions/EntityFunctions'
 import { startQueryReactor } from '../../ecs/functions/SystemFunctions'
 import { setTransformComponent, TransformComponent } from '../../transform/components/TransformComponent'
 

--- a/packages/engine/src/scene/systems/FogSystem.ts
+++ b/packages/engine/src/scene/systems/FogSystem.ts
@@ -120,6 +120,8 @@ export default async function FogSystem(world: World) {
     // material.needsUpdate is not working. Therefore have to invalidate the cache manually
     const key = Math.random()
     obj.material.customProgramCacheKey = () => key.toString()
+    const shader = (obj.material as any).shader // todo add typings somehow
+    world.fogShaders.splice(world.fogShaders.indexOf(shader), 1)
   }
 
   function FogGroupReactor({ obj }: GroupReactorProps) {
@@ -132,9 +134,14 @@ export default async function FogSystem(world: World) {
         obj.traverse(addFogShaderPlugin)
       } else {
         obj.traverse(removeFogShaderPlugin)
-        world.fogShaders = []
       }
     }, [type])
+
+    useEffect(() => {
+      return () => {
+        obj.traverse(removeFogShaderPlugin)
+      }
+    }, [])
 
     return null
   }

--- a/packages/engine/src/scene/systems/SceneObjectSystem.tsx
+++ b/packages/engine/src/scene/systems/SceneObjectSystem.tsx
@@ -61,10 +61,7 @@ export default async function SceneObjectSystem(world: World) {
   const groupQuery = defineQuery([GroupComponent])
   const updatableQuery = defineQuery([GroupComponent, UpdatableComponent, CallbackComponent])
 
-  function setupObject(
-    obj: Object3DWithEntity,
-    shadowComponent: ReturnType<typeof useOptionalComponent<typeof ShadowComponent>>
-  ) {
+  function setupObject(obj: Object3DWithEntity) {
     const mesh = obj as any as Mesh<any, any>
     mesh.traverse((child: Mesh<any, any>) => {
       if (child.material) {
@@ -90,8 +87,7 @@ export default async function SceneObjectSystem(world: World) {
     const shadowComponent = useOptionalComponent(entity, ShadowComponent)
 
     useEffect(() => {
-      setupObject(obj, shadowComponent)
-
+      setupObject(obj)
       return () => {
         const layers = Object.values(Engine.instance.currentWorld.objectLayerList)
         for (const layer of layers) {

--- a/packages/engine/src/scene/systems/SceneObjectSystem.tsx
+++ b/packages/engine/src/scene/systems/SceneObjectSystem.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 import {
   Color,
   Material,
@@ -22,19 +22,15 @@ import { World } from '../../ecs/classes/World'
 import {
   defineQuery,
   getComponent,
-  getOptionalComponent,
-  getOptionalComponentState,
   hasComponent,
   removeQuery,
   useOptionalComponent
 } from '../../ecs/functions/ComponentFunctions'
-import { startQueryReactor } from '../../ecs/functions/SystemFunctions'
 import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { DistanceFromCameraComponent, FrustumCullCameraComponent } from '../../transform/components/DistanceComponents'
 import { CallbackComponent } from '../components/CallbackComponent'
 import { GroupComponent, Object3DWithEntity, startGroupQueryReactor } from '../components/GroupComponent'
-import { SceneTagComponent } from '../components/SceneTagComponent'
-import { ShadowComponent, ShadowComponentType } from '../components/ShadowComponent'
+import { ShadowComponent } from '../components/ShadowComponent'
 import { UpdatableCallback, UpdatableComponent } from '../components/UpdatableComponent'
 import { VisibleComponent } from '../components/VisibleComponent'
 import FogSystem from './FogSystem'

--- a/packages/engine/src/scene/systems/SceneObjectUpdateSystem.ts
+++ b/packages/engine/src/scene/systems/SceneObjectUpdateSystem.ts
@@ -398,7 +398,6 @@ export default async function SceneObjectUpdateSystem(world: World) {
     serialize: serializeSpline
   })
 
-  const cameraQuery = defineQuery([CameraComponent])
   const envmapQuery = defineQuery([GroupComponent, EnvmapComponent])
   const imageQuery = defineQuery([ImageComponent])
   const sceneEnvmapQuery = defineQuery([SceneTagComponent, EnvmapComponent])
@@ -430,7 +429,6 @@ export default async function SceneObjectUpdateSystem(world: World) {
       }
     }
 
-    for (const entity of cameraQuery.enter()) addObjectToGroup(entity, getComponent(entity, CameraComponent).camera)
     for (const entity of envmapQuery.enter()) updateEnvMap(entity)
     for (const entity of loopableAnimationQuery.enter()) updateLoopAnimation(entity)
     for (const entity of skyboxQuery.enter()) updateSkybox(entity)
@@ -566,7 +564,6 @@ export default async function SceneObjectUpdateSystem(world: World) {
     world.sceneComponentRegistry.delete(SplineComponent.name)
     world.sceneLoadingRegistry.delete(SCENE_COMPONENT_SPLINE)
 
-    removeQuery(world, cameraQuery)
     removeQuery(world, envmapQuery)
     removeQuery(world, imageQuery)
     removeQuery(world, sceneEnvmapQuery)

--- a/packages/engine/src/xr/XRDepthOcclusion.ts
+++ b/packages/engine/src/xr/XRDepthOcclusion.ts
@@ -252,10 +252,19 @@ export default async function XRDepthOcclusionSystem(world: World) {
         const mesh = obj as any as Mesh<any, Material>
         if (mesh.material) {
           if (depthDataTexture && depthSupported)
-            XRDepthOcclusion.addDepthOBCPlugin(mesh.material, depthDataTexture.value!)
-          else XRDepthOcclusion.removeDepthOBCPlugin(mesh.material)
+            mesh.traverse((o: Mesh<any, Material>) =>
+              XRDepthOcclusion.addDepthOBCPlugin(o.material, depthDataTexture.value!)
+            )
+          else mesh.traverse((o: Mesh<any, Material>) => XRDepthOcclusion.removeDepthOBCPlugin(o.material))
         }
       }, [depthDataTexture])
+
+      useEffect(() => {
+        return () => {
+          const mesh = obj as any as Mesh<any, Material>
+          mesh.traverse((o: Mesh<any, Material>) => XRDepthOcclusion.removeDepthOBCPlugin(o.material))
+        }
+      }, [])
 
       return null
     },

--- a/packages/engine/src/xr/XRDepthOcclusion.ts
+++ b/packages/engine/src/xr/XRDepthOcclusion.ts
@@ -11,15 +11,7 @@ import { createActionQueue, getState, removeActionQueue, useHookstate } from '@x
 import { addOBCPlugin, removeOBCPlugin } from '../common/functions/OnBeforeCompilePlugin'
 import { Engine } from '../ecs/classes/Engine'
 import { World } from '../ecs/classes/World'
-import {
-  defineQuery,
-  getComponent,
-  getOptionalComponent,
-  hasComponent,
-  removeQuery
-} from '../ecs/functions/ComponentFunctions'
-import { startQueryReactor } from '../ecs/functions/SystemFunctions'
-import { EngineRenderer } from '../renderer/WebGLRendererSystem'
+import { defineQuery, removeQuery } from '../ecs/functions/ComponentFunctions'
 import { GroupComponent, startGroupQueryReactor } from '../scene/components/GroupComponent'
 import { SceneTagComponent } from '../scene/components/SceneTagComponent'
 import { VisibleComponent } from '../scene/components/VisibleComponent'

--- a/packages/engine/src/xr/XRScenePlacementShader.ts
+++ b/packages/engine/src/xr/XRScenePlacementShader.ts
@@ -8,7 +8,7 @@ import { Entity } from '../ecs/classes/Entity'
 import { World } from '../ecs/classes/World'
 import { getComponent, hasComponent } from '../ecs/functions/ComponentFunctions'
 import { startQueryReactor } from '../ecs/functions/SystemFunctions'
-import { GroupComponent } from '../scene/components/GroupComponent'
+import { GroupComponent, Object3DWithEntity, startGroupQueryReactor } from '../scene/components/GroupComponent'
 import { SceneTagComponent } from '../scene/components/SceneTagComponent'
 import { VisibleComponent } from '../scene/components/VisibleComponent'
 import { XRState } from './XRState'
@@ -22,38 +22,31 @@ type ScenePlacementMaterialType = {
   }
 }
 
-const addShaderToObject = (entity: Entity) => {
-  /** always check if the component exists, since this is potentially scheduled across multiple frames */
-  if (!hasComponent(entity, GroupComponent)) return
-  for (const object of getComponent(entity, GroupComponent))
-    object.traverse((obj: Mesh<any, Material & ScenePlacementMaterialType>) => {
-      if (obj.material) {
-        const userData = obj.material.userData
-        if (!userData.ScenePlacement) {
-          userData.ScenePlacement = {
-            previouslyTransparent: obj.material.transparent,
-            previousOpacity: obj.material.opacity
-          }
-        }
-        obj.material.transparent = true
-        obj.material.opacity = 0.4
+const addShaderToObject = (object: Object3DWithEntity) => {
+  const obj = object as any as Mesh<any, Material & ScenePlacementMaterialType>
+  if (obj.material) {
+    const userData = obj.material.userData
+    if (!userData.ScenePlacement) {
+      userData.ScenePlacement = {
+        previouslyTransparent: obj.material.transparent,
+        previousOpacity: obj.material.opacity
       }
-    })
+    }
+    obj.material.transparent = true
+    obj.material.opacity = 0.4
+  }
 }
 
-const removeShaderFromObject = (entity: Entity) => {
-  if (!hasComponent(entity, GroupComponent)) return
-  for (const object of getComponent(entity, GroupComponent))
-    object.traverse((obj: Mesh<any, Material & ScenePlacementMaterialType>) => {
-      if (obj.material) {
-        const userData = obj.material.userData
-        if (userData?.ScenePlacement) {
-          obj.material.transparent = userData.ScenePlacement.previouslyTransparent
-          obj.material.opacity = userData.ScenePlacement.previousOpacity
-          delete userData.ScenePlacement
-        }
-      }
-    })
+const removeShaderFromObject = (object: Object3DWithEntity) => {
+  const obj = object as any as Mesh<any, Material & ScenePlacementMaterialType>
+  if (obj.material) {
+    const userData = obj.material.userData
+    if (userData?.ScenePlacement) {
+      obj.material.transparent = userData.ScenePlacement.previouslyTransparent
+      obj.material.opacity = userData.ScenePlacement.previousOpacity
+      delete userData.ScenePlacement
+    }
+  }
 }
 
 /**
@@ -64,24 +57,30 @@ const removeShaderFromObject = (entity: Entity) => {
 export default async function XRScenePlacementShader(world: World) {
   const xrState = getState(XRState)
 
-  startQueryReactor([GroupComponent, Not(SceneTagComponent), VisibleComponent], function (props) {
-    const entity = props.root.entity
-    if (!hasComponent(entity, GroupComponent)) throw props.root.stop()
+  const xrScenePlacementReactor = startGroupQueryReactor(
+    function ({ obj }) {
+      const scenePlacementMode = useHookstate(xrState.scenePlacementMode)
+      const sessionActive = useHookstate(xrState.sessionActive)
 
-    const scenePlacementMode = useHookstate(xrState.scenePlacementMode)
-    const sessionActive = useHookstate(xrState.sessionActive)
+      useEffect(() => {
+        const useShader = xrState.sessionActive.value && xrState.scenePlacementMode.value
+        if (useShader) {
+          addShaderToObject(obj)
+        } else {
+          removeShaderFromObject(obj)
+        }
+      }, [scenePlacementMode, sessionActive])
 
-    useEffect(() => {
-      const useShader = xrState.sessionActive.value && xrState.scenePlacementMode.value
-      if (useShader) {
-        addShaderToObject(entity)
-      } else {
-        removeShaderFromObject(entity)
-      }
-    }, [scenePlacementMode, sessionActive])
+      return null
+    },
+    [Not(SceneTagComponent), VisibleComponent]
+  )
 
-    return null
-  })
+  const execute = () => {}
 
-  return { execute: () => {}, cleanup: async () => {} }
+  const cleanup = async () => {
+    xrScenePlacementReactor.stop()
+  }
+
+  return { execute, cleanup }
 }

--- a/packages/engine/src/xr/XRScenePlacementShader.ts
+++ b/packages/engine/src/xr/XRScenePlacementShader.ts
@@ -65,15 +65,21 @@ export default async function XRScenePlacementShader(world: World) {
       useEffect(() => {
         const useShader = xrState.sessionActive.value && xrState.scenePlacementMode.value
         if (useShader) {
-          addShaderToObject(obj)
+          obj.traverse(addShaderToObject)
         } else {
-          removeShaderFromObject(obj)
+          obj.traverse(removeShaderFromObject)
         }
       }, [scenePlacementMode, sessionActive])
 
+      useEffect(() => {
+        return () => {
+          obj.traverse(removeShaderFromObject)
+        }
+      }, [])
+
       return null
     },
-    [Not(SceneTagComponent), VisibleComponent]
+    [VisibleComponent]
   )
 
   const execute = () => {}

--- a/packages/engine/src/xr/XRScenePlacementShader.ts
+++ b/packages/engine/src/xr/XRScenePlacementShader.ts
@@ -1,15 +1,10 @@
-import { Not } from 'bitecs'
 import { useEffect } from 'react'
 import { Material, Mesh } from 'three'
 
 import { getState, useHookstate } from '@xrengine/hyperflux'
 
-import { Entity } from '../ecs/classes/Entity'
 import { World } from '../ecs/classes/World'
-import { getComponent, hasComponent } from '../ecs/functions/ComponentFunctions'
-import { startQueryReactor } from '../ecs/functions/SystemFunctions'
-import { GroupComponent, Object3DWithEntity, startGroupQueryReactor } from '../scene/components/GroupComponent'
-import { SceneTagComponent } from '../scene/components/SceneTagComponent'
+import { Object3DWithEntity, startGroupQueryReactor } from '../scene/components/GroupComponent'
 import { VisibleComponent } from '../scene/components/VisibleComponent'
 import { XRState } from './XRState'
 

--- a/packages/hyperflux/functions/ReactorFunctions.tsx
+++ b/packages/hyperflux/functions/ReactorFunctions.tsx
@@ -76,12 +76,14 @@ export function startReactor(Reactor: React.FC<ReactorProps>): ReactorRoot {
     fiber: fiberRoot,
     isRunning: false,
     run() {
+      if (reactorRoot.isRunning) return Promise.resolve()
       reactorRoot.isRunning = true
       return new Promise<void>((resolve) => {
         ReactorReconciler.updateContainer(<Reactor root={reactorRoot} />, fiberRoot, null, () => resolve())
       })
     },
     stop() {
+      if (!reactorRoot.isRunning) return Promise.resolve()
       return Promise.resolve().then(() => {
         ReactorReconciler.updateContainer(null, fiberRoot, null, () => {})
         reactorRoot.isRunning = false


### PR DESCRIPTION
## Summary

Fixes issues with group reactors not responding to objects added to an existing group component. It now statefully updates upon object addition and removal via addObjectToGroup and removeObjectFromGroup.

Reactors have been modified to properly account for all states, such as objects being removed from groups, group size changes and queries entering & exiting.

startGroupQueryReactor is a new helper function that allows for easily iterating all objects in a group component such that each one has it's own reactor.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

