### PR TITLE
Fixed multiple issues with projects.

### DIFF
--- a/packages/client-core/src/admin/components/Project/ProjectFields.tsx
+++ b/packages/client-core/src/admin/components/Project/ProjectFields.tsx
@@ -148,7 +148,7 @@ const ProjectFields = ({ inputProject, existingProject = false, changeDestinatio
       ProjectUpdateService.setCommitsProcessing(project, false)
       if (projectResponse.error) {
         ProjectUpdateService.setShowCommitSelector(project, false)
-        ProjectUpdateService.setCommitError(project, projectResponse.text)
+        ProjectUpdateService.setBranchError(project, projectResponse.text)
       } else {
         ProjectUpdateService.setShowCommitSelector(project, true)
         ProjectUpdateService.setCommitData(project, projectResponse)
@@ -156,7 +156,7 @@ const ProjectFields = ({ inputProject, existingProject = false, changeDestinatio
     } catch (err) {
       ProjectUpdateService.setCommitsProcessing(project, false)
       ProjectUpdateService.setShowCommitSelector(project, false)
-      ProjectUpdateService.setCommitError(project, err.message)
+      ProjectUpdateService.setBranchError(project, err.message)
       console.log('projectResponse error', err)
     }
   }

--- a/packages/client-core/src/common/components/AutoCompleteSingle/index.tsx
+++ b/packages/client-core/src/common/components/AutoCompleteSingle/index.tsx
@@ -46,9 +46,11 @@ const AutoComplete = ({ data, label, disabled, error, onChange, value = '', free
       options: data,
       onInputChange: handleInputChange,
       getOptionLabel: (option) => option.label || '',
+      blurOnSelect: true,
       onChange: (event: React.ChangeEvent<{}>, value: any, reason: string) => {
         if (value?.value != null) {
           setLocalValue(value.value)
+          ;(getInputProps() as any).ref.current.value = value.value
           if (onChange) onChange({ target: { value: value.value } })
         }
       },

--- a/packages/client-core/src/common/services/ProjectService.ts
+++ b/packages/client-core/src/common/services/ProjectService.ts
@@ -204,7 +204,7 @@ export const ProjectService = {
         }
       })
     } catch (err) {
-      logger.error('Error with fetching branches for a project', err)
+      logger.error('Error with fetching commits for a project', err)
       throw err
     }
   },

--- a/packages/common/src/interfaces/ProjectCommitInterface.ts
+++ b/packages/common/src/interfaces/ProjectCommitInterface.ts
@@ -5,4 +5,5 @@ export interface ProjectCommitInterface {
   commitSHA: string
   datetime: string
   matchesEngineVersion: boolean
+  discard?: boolean
 }

--- a/packages/editor/src/components/projects/ProjectsPage.tsx
+++ b/packages/editor/src/components/projects/ProjectsPage.tsx
@@ -581,15 +581,13 @@ const ProjectsPage = () => {
           removePermission={onRemovePermission}
         />
       )}
-      {activeProject && (
-        <ProjectDrawer
-          open={projectDrawerOpen}
-          inputProject={activeProject}
-          existingProject={true}
-          onClose={handleCloseProjectDrawer}
-          changeDestination={changeDestination}
-        />
-      )}
+      <ProjectDrawer
+        open={projectDrawerOpen}
+        inputProject={activeProject}
+        existingProject={activeProject != null}
+        onClose={handleCloseProjectDrawer}
+        changeDestination={changeDestination}
+      />
       <DeleteDialog
         open={isDeleteDialogOpen}
         isProjectMenu

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -596,7 +596,7 @@ export const getProjectCommits = async (
       per_page: COMMIT_PER_PAGE
     })
     const commits = headResponse.data
-    return (await Promise.all(
+    const mappedCommits = (await Promise.all(
       commits.map(
         (commit) =>
           new Promise(async (resolve, reject) => {
@@ -622,11 +622,14 @@ export const getProjectCommits = async (
               })
             } catch (err) {
               logger.error("Error getting commit's package.json %s/%s:%s %s", owner, repo, branchName, err.toString())
-              reject(err)
+              resolve({
+                discard: true
+              })
             }
           })
       )
     )) as ProjectCommitInterface[]
+    return mappedCommits.filter((commit) => !commit.discard)
   } catch (err) {
     logger.error('error getting repo commits %o', err)
     if (err.status === 404)


### PR DESCRIPTION
## Summary

Install project button on editor project page wasn't working because page assumed only an active project would make the drawer be open. Now ProjectDrawer renders all the time.

When fetching project commits, commits that didn't have a package.json were throwing errors, which would cause the whole request to error. This was not useful behavior, so now commits without a package.json are discarded.

Errors on commit fetching after selecting a branch were setting the wrong error, which was causing those errors to not be displayed.

Made selecting a commit from the menu blur the input, so that you don't have to click again to blur it and trigger the commit check.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

