### PR TITLE
Updated installing avatars from projects.

### DIFF
--- a/packages/common/src/dbmodels/AvatarResource.ts
+++ b/packages/common/src/dbmodels/AvatarResource.ts
@@ -6,4 +6,5 @@ export interface AvatarInterface {
   thumbnailResourceId: string
   isPublic: boolean
   userId: string
+  project?: string
 }

--- a/packages/common/src/dbmodels/StaticResource.ts
+++ b/packages/common/src/dbmodels/StaticResource.ts
@@ -5,4 +5,5 @@ export interface StaticResourceInterface {
   key: string
   mimeType: string
   metadata: any
+  project?: string
 }

--- a/packages/common/src/interfaces/AvatarInterface.ts
+++ b/packages/common/src/interfaces/AvatarInterface.ts
@@ -10,4 +10,5 @@ export type AvatarInterface = {
   identifierName: string
   modelResource?: StaticResourceInterface
   thumbnailResource?: StaticResourceInterface
+  project?: string
 }

--- a/packages/common/src/interfaces/StaticResourceInterface.ts
+++ b/packages/common/src/interfaces/StaticResourceInterface.ts
@@ -7,4 +7,5 @@ export interface StaticResourceInterface {
   mimeType: string
   staticResourceType: string
   userId: string
+  project?: string
 }

--- a/packages/common/src/interfaces/UploadAssetInterface.ts
+++ b/packages/common/src/interfaces/UploadAssetInterface.ts
@@ -14,6 +14,7 @@ export type AdminAssetUploadArgumentsType = {
   staticResourceType?: string
   userId?: string
   name?: string
+  project?: string
 }
 
 export type AdminAssetUploadType = {

--- a/packages/projects/default-project/projectEventHooks.ts
+++ b/packages/projects/default-project/projectEventHooks.ts
@@ -76,6 +76,9 @@ const config = {
   onInstall: (app: Application) => {
     return installAvatarsFromProject(app, avatarsFolder)
   },
+  onUpdate: (app: Application) => {
+    return installAvatarsFromProject(app, avatarsFolder)
+  },
   onOEmbedRequest: handleOEmbedRequest
   // TODO: remove avatars
   // onUninstall: (app: Application) => {

--- a/packages/server-core/src/media/static-resource/static-resource.model.ts
+++ b/packages/server-core/src/media/static-resource/static-resource.model.ts
@@ -33,6 +33,10 @@ export default (app: Application) => {
       metadata: {
         type: DataTypes.JSON,
         allowNull: true
+      },
+      project: {
+        type: DataTypes.STRING,
+        allowNull: true
       }
     },
     {

--- a/packages/server-core/src/media/storageprovider/local.storage.ts
+++ b/packages/server-core/src/media/storageprovider/local.storage.ts
@@ -84,7 +84,8 @@ export class LocalStorage implements StorageProviderInterface {
     const filePath = path.join(this.PATH_PREFIX, prefix)
     if (!fs.existsSync(filePath)) return { Contents: [] }
     // glob all files and directories
-    const globResult = glob.sync(path.join(filePath, '**'))
+    let globResult = glob.sync(path.join(filePath, '**'))
+    globResult = globResult.filter((item) => /[a-zA-Z0-9]+\.[a-zA-Z0-9]+$/.test(item))
     return {
       Contents: globResult.map((result) => {
         return { Key: result.replace(path.join(this.PATH_PREFIX), '') }

--- a/packages/server-core/src/media/upload-asset/upload-asset.service.ts
+++ b/packages/server-core/src/media/upload-asset/upload-asset.service.ts
@@ -43,10 +43,12 @@ export const addGenericAssetToS3AndStaticResources = async (
   // make userId optional and safe for feathers create
   const userIdQuery = args.userId ? { userId: args.userId } : {}
   const key = processFileName(args.key)
+  const whereArgs = {
+    [Op.or]: [{ key: key }, { id: args.id ?? '' }]
+  } as any
+  if (args.project) whereArgs.project = args.project
   const existingAsset = await app.service('static-resource').Model.findAndCountAll({
-    where: {
-      [Op.or]: [{ key: key }, { id: args.id ?? '' }]
-    }
+    where: whereArgs
   })
 
   let returned: Promise<StaticResourceInterface>
@@ -87,7 +89,8 @@ export const addGenericAssetToS3AndStaticResources = async (
             url: assetURL,
             key: key,
             mimeType: mimeType,
-            staticResourceType: args.staticResourceType
+            staticResourceType: args.staticResourceType,
+            project: args.project
           },
           { isInternal: true }
         )
@@ -102,6 +105,7 @@ export const addGenericAssetToS3AndStaticResources = async (
                 key: key,
                 mimeType: mimeType,
                 staticResourceType: args.staticResourceType,
+                project: args.project,
                 ...userIdQuery
               },
               { isInternal: true }

--- a/packages/server-core/src/user/avatar/avatar.class.ts
+++ b/packages/server-core/src/user/avatar/avatar.class.ts
@@ -96,7 +96,8 @@ export class Avatar extends Service<AvatarInterface> {
       isPublic: data.isPublic ?? true,
       userId: params?.user!.id,
       modelResourceId: data.modelResourceId,
-      thumbnailResourceId: data.thumbnailResourceId
+      thumbnailResourceId: data.thumbnailResourceId,
+      project: data.project
     })) as AvatarInterface
     avatar = await this.patch(avatar.id, {
       identifierName: avatar.name + '_' + avatar.id
@@ -134,7 +135,9 @@ export class Avatar extends Service<AvatarInterface> {
     const avatar = await this.get(id, params)
     try {
       await this.app.service('static-resource').remove(avatar.modelResourceId)
-    } catch (err) {}
+    } catch (err) {
+      logger.error(err)
+    }
     try {
       await this.app.service('static-resource').remove(avatar.thumbnailResourceId)
     } catch (err) {}

--- a/packages/server-core/src/user/avatar/avatar.model.ts
+++ b/packages/server-core/src/user/avatar/avatar.model.ts
@@ -35,6 +35,10 @@ export default (app: Application) => {
       },
       userId: {
         type: DataTypes.UUID
+      },
+      project: {
+        type: DataTypes.STRING,
+        allowNull: true
       }
     },
     {

--- a/scripts/install-projects.js
+++ b/scripts/install-projects.js
@@ -6,6 +6,9 @@ import path from "path";
 import fs from "fs";
 import appRootPath from 'app-root-path'
 import logger from '@xrengine/server-core/src/ServerLogger'
+import { createFeathersExpressApp } from '@xrengine/server-core/src/createApp'
+import { ServerMode } from '@xrengine/server-core/declarations'
+import { getProjectConfig, onProjectEvent } from '@xrengine/server-core/src/projects/project/project-helper'
 
 dotenv.config();
 const db = {
@@ -23,6 +26,7 @@ db.url = process.env.MYSQL_URL ??
 
 async function installAllProjects() {
   try {
+      const app = createFeathersExpressApp(ServerMode.API)
     createDefaultStorageProvider()
     const localProjectDirectory = path.join(appRootPath.path, 'packages/projects/projects')
     if (!fs.existsSync(localProjectDirectory)) fs.mkdirSync(localProjectDirectory, { recursive: true })
@@ -52,6 +56,8 @@ async function installAllProjects() {
     const projects = await Projects.findAll()
     logger.info('found projects', projects)
     await Promise.all(projects.map((project) => download(project.name)))
+    const projectConfig = (await getProjectConfig('default-project')) ?? {}
+    if (projectConfig.onEvent) await onProjectEvent(app, 'default-project', projectConfig.onEvent, 'onUpdate')
     process.exit(0)
   } catch (e) {
     logger.fatal(e)


### PR DESCRIPTION
## Summary

avatar and static-resource tables now have a column to link them to a project. When a installAvatarsFromProject is called, it makes new avatars and their associated static-resources linked to that project.

installAvatarsFromProject also now checks if each avatar with that name, and associated with that project, exists before inserting it. This allows avatars to be added or changed without creating duplicates.

When a project is deleted, it now deletes all avatars and static-resources associated with that project.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

