### PR TITLE
'isHMD' check improvements

### DIFF
--- a/packages/engine/src/common/functions/isMobile.ts
+++ b/packages/engine/src/common/functions/isMobile.ts
@@ -20,8 +20,11 @@ export const iOS =
 export const isSafari =
   typeof navigator !== 'undefined' && /^((?!chrome|android).)*safari/i.test(navigator.userAgent.toLowerCase())
 
-export const isHMD = typeof navigator?.userAgent === 'string' && /Oculus/i.test(navigator.userAgent)
+/** Detect HMDs via the presence of the XR module in the navigator and not the WebXR Emulator */
+export const isHMD =
+  !mobileOrTablet && typeof navigator.xr !== 'undefined' && typeof globalThis.CustomWebXRPolyfill === 'undefined'
+//typeof navigator?.userAgent === 'string' && /Oculus/i.test(navigator.userAgent)
 
-export const isMobile = mobileOrTablet && !isHMD
+export const isMobile = mobileOrTablet
 
 export const isMobileOrHMD = isHMD || isMobile


### PR DESCRIPTION
## Summary

`isHMD` previously was only true for navigator user agents that contain 'Quest', this creates a somewhat more robust check that should enable this heuristic for a wider range of HMDs. Specifically, it checks for the presence of `navigator.xr`, and against mobiles, and the WebXR Emulator.

In the future, we should find a better heuristic that is more deterministic, that ideally doesn't require promises, and without entering a session.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

