### PR TITLE
Improved error checking in record-build-error.ts

### DIFF
--- a/scripts/record-build-error.ts
+++ b/scripts/record-build-error.ts
@@ -86,21 +86,24 @@ cli.main(async () => {
             } else
                 cli.exit(0)
         } else {
-            const combinedLogs =
-                `Task that errored: ${options.service}\n\nError logs:\n\n${buildErrors}\n\nTask logs:\n\n${buildLogs}`
-            await BuildStatus.update(
-                {
-                    status: 'failed',
-                    logs: combinedLogs,
-                    dateEnded: dateNow
-                },
-                {
-                    where: {
-                        id: builderRun
+            const hasError = /error/i.test(buildErrors) || /fail/i.test(buildErrors)
+            if (hasError) {
+                const combinedLogs =
+                    `Task that errored: ${options.service}\n\nError logs:\n\n${buildErrors}\n\nTask logs:\n\n${buildLogs}`
+                await BuildStatus.update(
+                    {
+                        status: 'failed',
+                        logs: combinedLogs,
+                        dateEnded: dateNow
+                    },
+                    {
+                        where: {
+                            id: builderRun
+                        }
                     }
-                }
-            )
-            cli.exit(1)
+                )
+                cli.exit(1)
+            } else cli.exit(0)
         }
     } catch (err) {
         console.log(err)


### PR DESCRIPTION
## Summary

A builder was found to be "failing" when all that was being output to stderr was some 'Long system execution detected' warnings. Non-Docker checks now see if case-insensitive 'error' or 'fail' are detected in stderr, and if not, exits as a success.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

