### PR TITLE
Made primus reconnect reauthenticate feathers client.

### DIFF
--- a/packages/client-core/src/API.ts
+++ b/packages/client-core/src/API.ts
@@ -33,6 +33,8 @@ export class API {
       })
     )
 
+    primus.on('reconnected', () => API.instance.client.reAuthenticate(true))
+
     API.instance = new API()
     API.instance.client = feathersClient as any
   }


### PR DESCRIPTION
## Summary

feathersjs/authentication-client is built around socket.io. It has code to re-authenticate when a socket disconnects and reconnects, but it is hard-coded to socket.io's terminology. Added listener to primus to trigger re-authentication when it reconnects.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

