### PR TITLE
Made install-projects re-upload default-project files

### DIFF
--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -194,7 +194,8 @@
       "hours": "hours",
       "day": "day",
       "commitSHACopied": "Commit SHA copied",
-      "buildStatus": "Build Status"
+      "buildStatus": "Build Status",
+      "defaultProjectUpdateTooltip": "default-project is updated when engine is updated"
     },
     "instance": {
       "confirmInstanceDelete": "Do you want to delete instance",

--- a/packages/client-core/src/admin/components/Project/ProjectTable.tsx
+++ b/packages/client-core/src/admin/components/Project/ProjectTable.tsx
@@ -254,15 +254,24 @@ const ProjectTable = ({ className }: Props) => {
       ),
       update: (
         <>
-          {isAdmin && (
+          {isAdmin && name !== 'default-project' && (
             <IconButton
               className={styles.iconButton}
               name="update"
-              disabled={el.repositoryPath === null && name !== 'default-project'}
+              disabled={el.repositoryPath === null}
               onClick={() => handleOpenProjectDrawer(el)}
             >
               <Download />
             </IconButton>
+          )}
+          {isAdmin && name === 'default-project' && (
+            <Tooltip title={t('admin:components.project.defaultProjectUpdateTooltip')} arrow>
+              <span>
+                <IconButton className={styles.iconButton} name="update" disabled={true}>
+                  <Download />
+                </IconButton>
+              </span>
+            </Tooltip>
           )}
         </>
       ),
@@ -282,7 +291,12 @@ const ProjectTable = ({ className }: Props) => {
       ),
       link: (
         <>
-          <IconButton className={styles.iconButton} name="update" onClick={() => handleOpenProjectDrawer(el, true)}>
+          <IconButton
+            className={styles.iconButton}
+            name="update"
+            disabled={name === 'default-project'}
+            onClick={() => handleOpenProjectDrawer(el, true)}
+          >
             {!el.repositoryPath && <LinkOffIcon />}
             {el.repositoryPath && <LinkIcon />}
           </IconButton>

--- a/scripts/install-projects.js
+++ b/scripts/install-projects.js
@@ -26,7 +26,7 @@ db.url = process.env.MYSQL_URL ??
 
 async function installAllProjects() {
   try {
-      const app = createFeathersExpressApp(ServerMode.API)
+    const app = createFeathersExpressApp(ServerMode.API)
     createDefaultStorageProvider()
     const localProjectDirectory = path.join(appRootPath.path, 'packages/projects/projects')
     if (!fs.existsSync(localProjectDirectory)) fs.mkdirSync(localProjectDirectory, { recursive: true })
@@ -56,6 +56,7 @@ async function installAllProjects() {
     const projects = await Projects.findAll()
     logger.info('found projects', projects)
     await Promise.all(projects.map((project) => download(project.name)))
+    await app.service('project').update({ sourceURL: 'default-project' })
     const projectConfig = (await getProjectConfig('default-project')) ?? {}
     if (projectConfig.onEvent) await onProjectEvent(app, 'default-project', projectConfig.onEvent, 'onUpdate')
     process.exit(0)


### PR DESCRIPTION
## Summary

Updated project table so that default-project cannot have a repo link added, and the update button is always disable, with a tooltip that says its update is linked to updating the engine.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

