### PR TITLE
Added checks to deploy.sh to prevent errant helm upgrades.

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,6 +3,29 @@ set -x
 STAGE=$1
 TAG=$2
 
-kubectl delete job $STAGE-xrengine-testbot
+#kubectl delete job $STAGE-xrengine-testbot
 
-helm upgrade --reuse-values --set taskserver.image.repository=$ECR_URL/$REPO_NAME-taskserver,taskserver.image.tag=$TAG,api.image.repository=$ECR_URL/$REPO_NAME-api,api.image.tag=$TAG,instanceserver.image.repository=$ECR_URL/$REPO_NAME-instanceserver,instanceserver.image.tag=$TAG,testbot.image.repository=$ECR_URL/$REPO_NAME-testbot,testbot.image.tag=$TAG,client.image.repository=$ECR_URL/$REPO_NAME-client,client.image.tag=$TAG $STAGE xrengine/xrengine
+docker manifest inspect $ECR_URL/$REPO_NAME-api:$TAG >api-image.txt 2>&1
+docker manifest inspect $ECR_URL/$REPO_NAME-client:$TAG > client-image.txt  2>&1
+docker manifest inspect $ECR_URL/$REPO_NAME-instanceserver:$TAG > instanceserver-image.txt 2>&1
+docker manifest inspect $ECR_URL/$REPO_NAME-taskserver:$TAG > taskserver-image.txt 2>&1
+
+if [ ! -f "api-image.txt" ] || [ -z "$(grep -L "no such manifest" api-image.txt)" ]
+then
+  echo "API image was not built and uploaded properly"
+  exit 1
+elif [ ! -f "api-image.txt" ] || [ -z "$(grep -L "no such manifest" client-image.txt)" ]
+then
+  echo "client image was not built and uploaded properly"
+  exit 1
+elif [ ! -f "api-image.txt" ] || [ -z "$(grep -L "no such manifest" instanceserver-image.txt)" ]
+then
+  echo "Instanceserver image was not built and uploaded properly"
+  exit 1
+elif [ ! -f "api-image.txt" ] || [ -z "$(grep -L "no such manifest" taskserver-image.txt)" ]
+then
+  echo "Taskserver image was not built and uploaded properly"
+  exit 1
+else
+  helm upgrade --reuse-values --set taskserver.image.repository=$ECR_URL/$REPO_NAME-taskserver,taskserver.image.tag=$TAG,api.image.repository=$ECR_URL/$REPO_NAME-api,api.image.tag=$TAG,instanceserver.image.repository=$ECR_URL/$REPO_NAME-instanceserver,instanceserver.image.tag=$TAG,testbot.image.repository=$ECR_URL/$REPO_NAME-testbot,testbot.image.tag=$TAG,client.image.repository=$ECR_URL/$REPO_NAME-client,client.image.tag=$TAG $STAGE xrengine/xrengine
+fi


### PR DESCRIPTION
## Summary

Sometimes, several failed builds in a row are triggering the helm upgrade in deploy.sh. Added checks to try to prevent this from happening. deploy now calls `docker manifest inspect` on each image that should have been built, pipes the output to a file, and only does the helm upgrade if all expected files are present and do not contain 'no such manifest', which is what is returned if the image is missing.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] When this PR is ready, mark it as "Ready for review"
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

