### PR TITLE
Fix Visemes

### DIFF
--- a/packages/client-core/src/media/webcam/WebcamInput.ts
+++ b/packages/client-core/src/media/webcam/WebcamInput.ts
@@ -47,10 +47,11 @@ export const stopLipsyncTracking = () => {
 
 export const startFaceTracking = async () => {
   if (!faceWorker) {
-    // @ts-ignore - for some reason, the worker file path is not being resolved correctly
     const workerPath = isDev
-      ? import.meta.url.replace('.ts', 'Worker.js')
-      : new URL('./WebcamInputWorker.js', import.meta.url).href
+      ? // @ts-ignore - for some reason, the worker file path is not being resolved correctly
+        import.meta.url.replace('.ts', 'Worker.js')
+      : // @ts-ignore
+        new URL('./WebcamInputWorker.js', import.meta.url).href
     const worker = createWorkerFromCrossOriginURL(workerPath, true, {
       name: 'Face API Worker'
     })

--- a/packages/engine/src/avatar/AvatarBoneMatching.ts
+++ b/packages/engine/src/avatar/AvatarBoneMatching.ts
@@ -494,7 +494,7 @@ function findHandBones(handBone: Object3D) {
 }
 
 export function findSkinnedMeshes(model: Object3D) {
-  let meshes: SkinnedMesh[] = []
+  const meshes: SkinnedMesh[] = []
   model.traverse((obj: SkinnedMesh) => {
     if (obj.isSkinnedMesh) {
       meshes.push(obj)

--- a/packages/engine/src/avatar/components/AvatarAnimationComponent.ts
+++ b/packages/engine/src/avatar/components/AvatarAnimationComponent.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { SkeletonHelper, Vector3 } from 'three'
+import { SkeletonHelper, SkinnedMesh, Vector3 } from 'three'
 
 import { getState, none, useHookstate } from '@xrengine/hyperflux'
 
@@ -53,7 +53,9 @@ export const AvatarRigComponent = defineComponent({
       /** The length of the lower leg in a t-pose, from the knee joint to the ankle joint */
       lowerLegLength: 0,
       /** The height of the foot in a t-pose, from the ankle joint to the bottom of the avatar's model */
-      footHeight: 0
+      footHeight: 0,
+      /** Cache of the skinned meshes currently on the rig */
+      skinnedMeshes: [] as SkinnedMesh[]
     }
   },
 
@@ -65,6 +67,8 @@ export const AvatarRigComponent = defineComponent({
     if (matches.number.test(json.upperLegLength)) component.upperLegLength.set(json.upperLegLength)
     if (matches.number.test(json.lowerLegLength)) component.lowerLegLength.set(json.lowerLegLength)
     if (matches.number.test(json.footHeight)) component.footHeight.set(json.footHeight)
+    if (matches.array.test(json.skinnedMeshes)) component.skinnedMeshes.set(json.skinnedMeshes as SkinnedMesh[])
+    console.log(component.skinnedMeshes.value)
   },
 
   onRemove: (entity, component) => {

--- a/packages/engine/src/avatar/components/AvatarAnimationComponent.ts
+++ b/packages/engine/src/avatar/components/AvatarAnimationComponent.ts
@@ -68,7 +68,6 @@ export const AvatarRigComponent = defineComponent({
     if (matches.number.test(json.lowerLegLength)) component.lowerLegLength.set(json.lowerLegLength)
     if (matches.number.test(json.footHeight)) component.footHeight.set(json.footHeight)
     if (matches.array.test(json.skinnedMeshes)) component.skinnedMeshes.set(json.skinnedMeshes as SkinnedMesh[])
-    console.log(component.skinnedMeshes.value)
   },
 
   onRemove: (entity, component) => {

--- a/packages/engine/src/avatar/functions/avatarFunctions.ts
+++ b/packages/engine/src/avatar/functions/avatarFunctions.ts
@@ -177,7 +177,6 @@ export const rigAvatarModel = (entity: Entity) => (model: Object3D) => {
   retargetSkeleton(targetSkeleton, sourceSkeleton)
   syncModelSkeletons(model, targetSkeleton)
 
-  console.log(skinnedMeshes)
   setComponent(entity, AvatarRigComponent, {
     rig,
     bindRig: avatarBoneMatching(SkeletonUtils.clone(rootBone)),

--- a/packages/engine/src/avatar/functions/avatarFunctions.ts
+++ b/packages/engine/src/avatar/functions/avatarFunctions.ts
@@ -162,12 +162,13 @@ export const rigAvatarModel = (entity: Entity) => (model: Object3D) => {
   const rootBone = rig.Root || rig.Hips
   rootBone.updateWorldMatrix(true, true)
 
+  const skinnedMeshes = findSkinnedMeshes(model)
+
   /**@todo replace check for loop aniamtion component with ensuring tpose is only handled once */
   // Try converting to T pose
   if (!hasComponent(entity, LoopAnimationComponent) && !isSkeletonInTPose(rig)) {
     makeTPose(rig)
-    const meshes = findSkinnedMeshes(model)
-    meshes.forEach(applySkeletonPose)
+    skinnedMeshes.forEach(applySkeletonPose)
   }
 
   const targetSkeleton = createSkeletonFromBone(rootBone)
@@ -176,7 +177,12 @@ export const rigAvatarModel = (entity: Entity) => (model: Object3D) => {
   retargetSkeleton(targetSkeleton, sourceSkeleton)
   syncModelSkeletons(model, targetSkeleton)
 
-  setComponent(entity, AvatarRigComponent, { rig, bindRig: avatarBoneMatching(SkeletonUtils.clone(rootBone)) })
+  console.log(skinnedMeshes)
+  setComponent(entity, AvatarRigComponent, {
+    rig,
+    bindRig: avatarBoneMatching(SkeletonUtils.clone(rootBone)),
+    skinnedMeshes
+  })
 
   const sourceHips = sourceSkeleton.bones[0]
   avatarAnimationComponent.rootYRatio = rig.Hips.position.y / sourceHips.position.y

--- a/packages/engine/src/avatar/functions/spawnAvatarReceptor.ts
+++ b/packages/engine/src/avatar/functions/spawnAvatarReceptor.ts
@@ -20,7 +20,6 @@ import {
 } from '../../ecs/functions/ComponentFunctions'
 import { LocalAvatarTagComponent } from '../../input/components/LocalAvatarTagComponent'
 import { LocalInputTagComponent } from '../../input/components/LocalInputTagComponent'
-import { WebcamInputComponent } from '../../input/components/WebcamInputComponent'
 import { NetworkObjectAuthorityTag } from '../../networking/components/NetworkObjectComponent'
 import { NetworkPeerFunctions } from '../../networking/functions/NetworkPeerFunctions'
 import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
@@ -85,14 +84,6 @@ export const spawnAvatarReceptor = (spawnAction: typeof WorldNetworkAction.spawn
 
   setComponent(entity, DistanceFromCameraComponent)
   setComponent(entity, FrustumCullCameraComponent)
-
-  setComponent(entity, WebcamInputComponent, {
-    expressionValue: 0,
-    expressionIndex: 0,
-    pucker: 0,
-    widen: 0,
-    open: 0
-  })
 
   addComponent(entity, AnimationComponent, {
     mixer: new AnimationMixer(new Object3D()),

--- a/packages/engine/src/input/components/WebcamInputComponent.ts
+++ b/packages/engine/src/input/components/WebcamInputComponent.ts
@@ -1,11 +1,24 @@
-import { createMappedComponent } from '../../ecs/functions/ComponentFunctions'
+import { Types } from 'bitecs'
+
+import { defineComponent } from '../../ecs/functions/ComponentFunctions'
 
 export type WebcamInputComponentType = {
   expressionValue: number
   expressionIndex: number
-  pucker: number
-  widen: number
-  open: number
 }
 
-export const WebcamInputComponent = createMappedComponent<WebcamInputComponentType>('WebcamInputComponent')
+export const WebcamInputComponent = defineComponent({
+  name: 'WebcamInputComponent',
+
+  schema: {
+    expressionValue: Types.f32,
+    expressionIndex: Types.ui8
+  },
+
+  onInit(entity) {
+    return {
+      expressionValue: 0,
+      expressionIndex: 0
+    }
+  }
+})


### PR DESCRIPTION
## Summary

Visemes have been broken for a few reasons:

The webworker was not being loaded properly locally, vite seems to have a bug with relative URL imports.

A flipped larger than check was causing data to never populate.

There was a bit of awkwardness an inefficiency around the previous implementation. Avatar skinned meshes are now cached on the AvatarRigComponent for easy access, rather than having to traverse down the avatar's object heirarchy.

The WebcamInputComponent has also been updated to the new component definition, as well as using bitecs under the hood for future network serialization.

## References

partially addresses https://github.com/XRFoundation/XREngine/issues/7495


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

