### PR TITLE
Fix Loop Animation Component / GLTF Imported Animations

### DIFF
--- a/packages/engine/src/avatar/AnimationSystem.ts
+++ b/packages/engine/src/avatar/AnimationSystem.ts
@@ -53,6 +53,7 @@ export default async function AnimationSystem(world: World) {
       const animationComponent = getComponent(entity, AnimationComponent)
       const modifiedDelta = deltaSeconds * animationComponent.animationSpeed
       animationComponent.mixer.update(modifiedDelta)
+      world.dirtyTransforms[entity] = true
     }
   }
 

--- a/packages/engine/src/common/proxies/createThreejsProxy.ts
+++ b/packages/engine/src/common/proxies/createThreejsProxy.ts
@@ -58,7 +58,7 @@ export const proxifyVector3 = (
 export const proxifyVector3WithDirty = (
   store: Vector3Store,
   entity: Entity,
-  dirty: Record<Entity, true>,
+  dirty: Record<Entity, boolean>,
   vector3 = new Vector3()
 ): Vector3 & ProxyExtensions => {
   // Set the initial values
@@ -157,7 +157,7 @@ export const proxifyQuaternion = (
 export const proxifyQuaternionWithDirty = (
   store: QuaternionStore,
   entity: Entity,
-  dirty: Record<Entity, true>,
+  dirty: Record<Entity, boolean>,
   quaternion = new Quaternion()
 ): Quaternion & ProxyExtensions => {
   // Set the initial values

--- a/packages/engine/src/ecs/classes/World.ts
+++ b/packages/engine/src/ecs/classes/World.ts
@@ -248,7 +248,7 @@ export class World {
     return this.getOwnedNetworkObjectWithComponent(Engine.instance.userId, LocalInputTagComponent) || UndefinedEntity
   }
 
-  readonly dirtyTransforms = {} as Record<Entity, true>
+  readonly dirtyTransforms = {} as Record<Entity, boolean>
 
   inputSources: Readonly<XRInputSourceArray> = []
 

--- a/packages/engine/src/networking/serialization/DataReader.ts
+++ b/packages/engine/src/networking/serialization/DataReader.ts
@@ -185,7 +185,7 @@ export const readBodyRotation = readCompressedRotation(RigidBodyComponent.rotati
 export const readBodyLinearVelocity = readVector3(RigidBodyComponent.linearVelocity)
 export const readBodyAngularVelocity = readVector3(RigidBodyComponent.angularVelocity)
 
-export const readTransform = (v: ViewCursor, entity: Entity, dirtyTransforms: Record<Entity, true>) => {
+export const readTransform = (v: ViewCursor, entity: Entity, dirtyTransforms: Record<Entity, boolean>) => {
   const changeMask = readUint8(v)
   let b = 0
   if (checkBitflag(changeMask, 1 << b++)) readPosition(v, entity)

--- a/packages/engine/src/scene/components/ModelComponent.ts
+++ b/packages/engine/src/scene/components/ModelComponent.ts
@@ -101,12 +101,12 @@ function ModelReactor({ root }: EntityReactorProps) {
           case '.gltf':
           case '.fbx':
           case '.usdz':
-            scene = (
-              await AssetLoader.loadAsync(model.src, {
-                ignoreDisposeGeometry: model.generateBVH,
-                uuid
-              })
-            ).scene as Scene
+            const loadedAsset = await AssetLoader.loadAsync(model.src, {
+              ignoreDisposeGeometry: model.generateBVH,
+              uuid
+            })
+            scene = loadedAsset.scene
+            scene.animations = loadedAsset.animations
             break
           default:
             throw new Error(`Model type '${fileExtension}' not supported`)

--- a/packages/engine/src/transform/systems/TransformSystem.ts
+++ b/packages/engine/src/transform/systems/TransformSystem.ts
@@ -303,8 +303,7 @@ export default async function TransformSystem(world: World) {
         world.dirtyTransforms[entity] ||
         world.dirtyTransforms[getOptionalComponent(entity, LocalTransformComponent)?.parentEntity ?? 0] ||
         world.dirtyTransforms[getOptionalComponent(entity, ComputedTransformComponent)?.referenceEntity ?? 0] ||
-        hasComponent(entity, ComputedTransformComponent) ||
-        (hasComponent(entity, AnimationComponent) && getComponent(entity, AnimationComponent).animations.length > 0)
+        hasComponent(entity, ComputedTransformComponent)
 
       world.dirtyTransforms[entity] = makeDirty
     }

--- a/packages/engine/src/transform/systems/TransformSystem.ts
+++ b/packages/engine/src/transform/systems/TransformSystem.ts
@@ -303,7 +303,7 @@ export default async function TransformSystem(world: World) {
         world.dirtyTransforms[getOptionalComponent(entity, LocalTransformComponent)?.parentEntity ?? 0] ||
         world.dirtyTransforms[getOptionalComponent(entity, ComputedTransformComponent)?.referenceEntity ?? 0] ||
         hasComponent(entity, ComputedTransformComponent)
-      if (makeDirty) world.dirtyTransforms[entity] = true
+      world.dirtyTransforms[entity] = makeDirty
     }
 
     const dirtyNonDynamicLocalTransformEntities = nonDynamicLocalTransformQuery().filter(isDirty)
@@ -324,7 +324,7 @@ export default async function TransformSystem(world: World) {
       viewCamera.projectionMatrixInverse.copy(camera.projectionMatrixInverse)
     }
 
-    for (const entity in world.dirtyTransforms) delete world.dirtyTransforms[entity]
+    for (const entity in world.dirtyTransforms) world.dirtyTransforms[entity] = false
 
     for (const entity of staticBoundingBoxQuery.enter()) computeBoundingBox(entity)
     for (const entity of dynamicBoundingBoxQuery()) updateBoundingBox(entity)

--- a/packages/engine/src/transform/systems/TransformSystem.ts
+++ b/packages/engine/src/transform/systems/TransformSystem.ts
@@ -5,6 +5,7 @@ import { Camera, Frustum, Matrix4, Mesh, Skeleton, SkinnedMesh, Vector3 } from '
 import { insertionSort } from '@xrengine/common/src/utils/insertionSort'
 import { createActionQueue, getState, removeActionQueue } from '@xrengine/hyperflux'
 
+import { AnimationComponent } from '../../avatar/components/AnimationComponent'
 import { V_000 } from '../../common/constants/MathConstants'
 import { Engine } from '../../ecs/classes/Engine'
 import { EngineActions, EngineState } from '../../ecs/classes/EngineState'
@@ -302,8 +303,10 @@ export default async function TransformSystem(world: World) {
         world.dirtyTransforms[entity] ||
         world.dirtyTransforms[getOptionalComponent(entity, LocalTransformComponent)?.parentEntity ?? 0] ||
         world.dirtyTransforms[getOptionalComponent(entity, ComputedTransformComponent)?.referenceEntity ?? 0] ||
-        hasComponent(entity, ComputedTransformComponent)
-      if (makeDirty) world.dirtyTransforms[entity] = true
+        hasComponent(entity, ComputedTransformComponent) ||
+        (hasComponent(entity, AnimationComponent) && getComponent(entity, AnimationComponent).animations.length > 0)
+
+      world.dirtyTransforms[entity] = makeDirty
     }
 
     const dirtyNonDynamicLocalTransformEntities = nonDynamicLocalTransformQuery().filter(isDirty)

--- a/packages/engine/src/transform/systems/TransformSystem.ts
+++ b/packages/engine/src/transform/systems/TransformSystem.ts
@@ -5,7 +5,6 @@ import { Camera, Frustum, Matrix4, Mesh, Skeleton, SkinnedMesh, Vector3 } from '
 import { insertionSort } from '@xrengine/common/src/utils/insertionSort'
 import { createActionQueue, getState, removeActionQueue } from '@xrengine/hyperflux'
 
-import { AnimationComponent } from '../../avatar/components/AnimationComponent'
 import { V_000 } from '../../common/constants/MathConstants'
 import { Engine } from '../../ecs/classes/Engine'
 import { EngineActions, EngineState } from '../../ecs/classes/EngineState'
@@ -304,8 +303,7 @@ export default async function TransformSystem(world: World) {
         world.dirtyTransforms[getOptionalComponent(entity, LocalTransformComponent)?.parentEntity ?? 0] ||
         world.dirtyTransforms[getOptionalComponent(entity, ComputedTransformComponent)?.referenceEntity ?? 0] ||
         hasComponent(entity, ComputedTransformComponent)
-
-      world.dirtyTransforms[entity] = makeDirty
+      if (makeDirty) world.dirtyTransforms[entity] = true
     }
 
     const dirtyNonDynamicLocalTransformEntities = nonDynamicLocalTransformQuery().filter(isDirty)

--- a/packages/engine/src/transform/updateWorldOrigin.ts
+++ b/packages/engine/src/transform/updateWorldOrigin.ts
@@ -23,7 +23,7 @@ export const updateWorldOriginFromViewerHit = (
   originTransform.scale.copy(scale ?? V_111)
   originTransform.matrix.compose(originTransform.position, originTransform.rotation, originTransform.scale)
   originTransform.matrixInverse.copy(originTransform.matrix).invert()
-  delete world.dirtyTransforms[world.originEntity]
+  world.dirtyTransforms[world.originEntity] = false
   const xrRigidTransform = new XRRigidTransform(originTransform.position, originTransform.rotation)
   ReferenceSpace.origin = ReferenceSpace.localFloor!.getOffsetReferenceSpace(xrRigidTransform)
 }
@@ -40,7 +40,7 @@ export const updateWorldOrigin = () => {
 export const computeAndUpdateWorldOrigin = () => {
   const world = Engine.instance.currentWorld
   computeTransformMatrix(world.originEntity, world)
-  delete world.dirtyTransforms[world.originEntity]
+  world.dirtyTransforms[world.originEntity] = false
   updateWorldOrigin()
 }
 

--- a/packages/engine/src/xrui/functions/ObjectFitFunctions.ts
+++ b/packages/engine/src/xrui/functions/ObjectFitFunctions.ts
@@ -89,7 +89,7 @@ export const ObjectFitFunctions = {
     transform.matrix.multiplyMatrices(Engine.instance.currentWorld.camera.matrixWorld, _mat4)
     transform.matrix.decompose(transform.position, transform.rotation, transform.scale)
     transform.matrixInverse.copy(transform.matrix).invert()
-    delete Engine.instance.currentWorld.dirtyTransforms[entity]
+    Engine.instance.currentWorld.dirtyTransforms[entity] = false
   },
 
   attachObjectToHand: (container: WebContainer3D, scale: number) => {


### PR DESCRIPTION
Small changes. Any imported models now have animations set, and transforms are marked as dirty when animations are present. 

Also, changed `if (makeDirty) world.dirtyTransforms[entity] = true` to directly set the dirtyTransforms to the value of makeDirty, the extra logic just didn't make sense to me. 