### PR TITLE
Fix renderer state

### DIFF
--- a/packages/engine/src/renderer/EngineRendererState.ts
+++ b/packages/engine/src/renderer/EngineRendererState.ts
@@ -91,8 +91,6 @@ export class EngineRendererReceptor {
   static setDebug(action: typeof EngineRendererAction.setDebug.matches._TYPE) {
     const s = getState(EngineRendererState)
     s.debugEnable.set(action.debugEnable)
-    if (action.debugEnable) Engine.instance.currentWorld.camera.layers.enable(ObjectLayers.PhysicsHelper)
-    else Engine.instance.currentWorld.camera.layers.disable(ObjectLayers.PhysicsHelper)
   }
 
   static changedRenderMode(action: typeof EngineRendererAction.changedRenderMode.matches._TYPE) {
@@ -104,8 +102,6 @@ export class EngineRendererReceptor {
   static changeNodeHelperVisibility(action: typeof EngineRendererAction.changeNodeHelperVisibility.matches._TYPE) {
     const s = getState(EngineRendererState)
     s.nodeHelperVisibility.set(action.visibility)
-    if (action.visibility) Engine.instance.currentWorld.camera.layers.enable(ObjectLayers.NodeHelper)
-    else Engine.instance.currentWorld.camera.layers.disable(ObjectLayers.NodeHelper)
   }
 
   static changeGridToolHeight(action: typeof EngineRendererAction.changeGridToolHeight.matches._TYPE) {
@@ -116,8 +112,6 @@ export class EngineRendererReceptor {
   static changeGridToolVisibility(action: typeof EngineRendererAction.changeGridToolVisibility.matches._TYPE) {
     const s = getState(EngineRendererState)
     s.gridVisibility.set(action.visibility)
-    if (action.visibility) Engine.instance.currentWorld.camera.layers.enable(ObjectLayers.Gizmos)
-    else Engine.instance.currentWorld.camera.layers.disable(ObjectLayers.Gizmos)
   }
 }
 

--- a/packages/engine/src/renderer/WebGLRendererSystem.ts
+++ b/packages/engine/src/renderer/WebGLRendererSystem.ts
@@ -48,11 +48,17 @@ import { EngineActions, getEngineState } from '../ecs/classes/EngineState'
 import { World } from '../ecs/classes/World'
 import { getComponent } from '../ecs/functions/ComponentFunctions'
 import { GroupComponent } from '../scene/components/GroupComponent'
+import { ObjectLayers } from '../scene/constants/ObjectLayers'
 import { defaultPostProcessingSchema } from '../scene/constants/PostProcessing'
 import { createWebXRManager, WebXRManager } from '../xr/WebXRManager'
 import { isHeadset, useIsHeadset, XRState } from '../xr/XRState'
 import { LinearTosRGBEffect } from './effects/LinearTosRGBEffect'
-import { accessEngineRendererState, EngineRendererAction, EngineRendererReceptor } from './EngineRendererState'
+import {
+  accessEngineRendererState,
+  EngineRendererAction,
+  EngineRendererReceptor,
+  EngineRendererState
+} from './EngineRendererState'
 import { configureEffectComposer } from './functions/configureEffectComposer'
 import { updateShadowMap } from './functions/RenderSettingsFunction'
 import WebGL from './THREE.WebGL'
@@ -342,6 +348,7 @@ export default async function WebGLRendererSystem(world: World) {
 
   const reactor = startReactor(() => {
     const renderSettings = useHookstate(getRendererSceneMetadataState(world))
+    const engineRendererSettings = useHookstate(getState(EngineRendererState))
     const postprocessing = useHookstate(getPostProcessingSceneMetadataState(world))
 
     useEffect(() => {
@@ -359,6 +366,24 @@ export default async function WebGLRendererSystem(world: World) {
     useEffect(() => {
       configureEffectComposer()
     }, [postprocessing])
+
+    useEffect(() => {
+      if (engineRendererSettings.debugEnable.value)
+        Engine.instance.currentWorld.camera.layers.enable(ObjectLayers.PhysicsHelper)
+      else Engine.instance.currentWorld.camera.layers.disable(ObjectLayers.PhysicsHelper)
+    }, [engineRendererSettings.debugEnable])
+
+    useEffect(() => {
+      if (engineRendererSettings.gridVisibility.value)
+        Engine.instance.currentWorld.camera.layers.enable(ObjectLayers.Gizmos)
+      else Engine.instance.currentWorld.camera.layers.disable(ObjectLayers.Gizmos)
+    }, [engineRendererSettings.gridVisibility])
+
+    useEffect(() => {
+      if (engineRendererSettings.nodeHelperVisibility.value)
+        Engine.instance.currentWorld.camera.layers.enable(ObjectLayers.NodeHelper)
+      else Engine.instance.currentWorld.camera.layers.disable(ObjectLayers.NodeHelper)
+    }, [engineRendererSettings.nodeHelperVisibility])
 
     return null
   })


### PR DESCRIPTION
## Summary

Reloading the page with debug/gizmo/helper camera layers enabled was not setting this upon starting, since hyperflux state does not dispatch an action when syncing state. Moving this logic to a reactor fixes this.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

