### PR TITLE
Set camera theta, avatar rotation to point toward spawn point

### DIFF
--- a/packages/engine/src/avatar/AvatarSpawnSystem.ts
+++ b/packages/engine/src/avatar/AvatarSpawnSystem.ts
@@ -31,7 +31,7 @@ export function getRandomSpawnPoint(userId: UserId): { position: Vector3; rotati
       position: spawnTransform.position
         .clone()
         .add(randomPositionCentered(new Vector3(spawnTransform.scale.x, 0, spawnTransform.scale.z))),
-      rotation: new Quaternion() //spawnTransform.rotation.clone()
+      rotation: spawnTransform.rotation.clone()
     }
   }
 

--- a/packages/engine/src/avatar/AvatarSpawnSystem.ts
+++ b/packages/engine/src/avatar/AvatarSpawnSystem.ts
@@ -53,7 +53,7 @@ export function getSpawnPoint(spawnPointNodeId: string, userId: UserId): { posit
         position: spawnTransform.position
           .clone()
           .add(randomPositionCentered(new Vector3(spawnTransform.scale.x, 0, spawnTransform.scale.z))),
-        rotation: new Quaternion() //spawnTransform.rotation.clone()
+        rotation: spawnTransform.rotation.clone()
       }
     }
   }

--- a/packages/engine/src/avatar/functions/moveAvatar.ts
+++ b/packages/engine/src/avatar/functions/moveAvatar.ts
@@ -20,6 +20,7 @@ import { getCameraMode, ReferenceSpace, XRState } from '../../xr/XRState'
 import { AvatarComponent } from '../components/AvatarComponent'
 import { AvatarControllerComponent } from '../components/AvatarControllerComponent'
 import { AvatarHeadDecapComponent } from '../components/AvatarIKComponents'
+import { SpawnPoseComponent } from '../components/SpawnPoseComponent'
 import { AvatarMovementSettingsState } from '../state/AvatarMovementSettingsState'
 
 const avatarGroundRaycastDistanceIncrease = 0.5
@@ -356,7 +357,7 @@ const _slerpBodyTowardsVelocity = (entity: Entity, alpha: number) => {
 
   let prevVector = prevVectors.get(entity)!
   if (!prevVector) {
-    prevVector = new Vector3(0, 0, 1)
+    prevVector = new Vector3(0, 0, 1).applyQuaternion(getComponent(entity, SpawnPoseComponent).rotation)
     prevVectors.set(entity, prevVector)
   }
 

--- a/packages/engine/src/avatar/functions/spawnAvatarReceptor.ts
+++ b/packages/engine/src/avatar/functions/spawnAvatarReceptor.ts
@@ -163,6 +163,8 @@ export const createAvatarController = (entity: Entity) => {
   rigidbody.rotation.copy(transform.rotation)
   rigidbody.targetKinematicPosition.copy(transform.position)
   rigidbody.targetKinematicRotation.copy(transform.rotation)
+  rigidbody.linearVelocity.add(new Vector3(0, 0, 1).applyQuaternion(transform.rotation))
+  console.log(rigidbody.linearVelocity)
 
   addComponent(entity, AvatarControllerComponent, {
     cameraEntity: Engine.instance.currentWorld.cameraEntity,

--- a/packages/engine/src/avatar/functions/spawnAvatarReceptor.ts
+++ b/packages/engine/src/avatar/functions/spawnAvatarReceptor.ts
@@ -163,8 +163,6 @@ export const createAvatarController = (entity: Entity) => {
   rigidbody.rotation.copy(transform.rotation)
   rigidbody.targetKinematicPosition.copy(transform.position)
   rigidbody.targetKinematicRotation.copy(transform.rotation)
-  rigidbody.linearVelocity.add(new Vector3(0, 0, 1).applyQuaternion(transform.rotation))
-  console.log(rigidbody.linearVelocity)
 
   addComponent(entity, AvatarControllerComponent, {
     cameraEntity: Engine.instance.currentWorld.cameraEntity,

--- a/packages/engine/src/avatar/functions/spawnAvatarReceptor.ts
+++ b/packages/engine/src/avatar/functions/spawnAvatarReceptor.ts
@@ -9,6 +9,7 @@ import { AnimationClip, AnimationMixer, Group, Object3D, Quaternion, Vector3 } f
 
 import { getState } from '@xrengine/hyperflux'
 
+import { setTargetCameraRotation } from '../../camera/systems/CameraInputSystem'
 import { Engine } from '../../ecs/classes/Engine'
 import { Entity } from '../../ecs/classes/Entity'
 import {
@@ -176,6 +177,14 @@ export const createAvatarController = (entity: Entity) => {
     speedVelocity: { value: 0 },
     translationApplied: new Vector3()
   })
+
+  const CameraTransform = getComponent(Engine.instance.currentWorld.cameraEntity, TransformComponent)
+  const avatarForward = new Vector3(0, 0, -1).applyQuaternion(transform.rotation)
+  const cameraForward = new Vector3(0, 0, 1).applyQuaternion(CameraTransform.rotation)
+  let targetTheta = (cameraForward.angleTo(avatarForward) * 180) / Math.PI
+  const orientation = cameraForward.x * avatarForward.z - cameraForward.z * avatarForward.x
+  if (orientation > 0) targetTheta = 2 * Math.PI - targetTheta
+  setTargetCameraRotation(Engine.instance.currentWorld.cameraEntity, 0, targetTheta)
 
   const avatarControllerComponent = getComponent(entity, AvatarControllerComponent)
   avatarControllerComponent.bodyCollider = createAvatarCollider(entity)


### PR DESCRIPTION
## Summary

- Avatar rotation is set to the spawn transform.
- Camera theta is set to a value that always points towards the spawn direction

## References

closes #7525


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

