### PR TITLE
Small optimizations to three proxies

### DIFF
--- a/packages/engine/src/common/proxies/createThreejsProxy.ts
+++ b/packages/engine/src/common/proxies/createThreejsProxy.ts
@@ -25,6 +25,7 @@ export const proxifyVector3 = (
   return defineProperties(vector3 as Vector3 & ProxyExtensions, {
     entity: { value: entity, configurable: true, writable: true },
     store: { value: store, configurable: true, writable: true },
+    dirtyRecord: { value: {}, configurable: true, writable: true },
     x: {
       get() {
         return this.store.x[this.entity]
@@ -69,12 +70,13 @@ export const proxifyVector3WithDirty = (
   return defineProperties(vector3 as Vector3 & ProxyExtensions, {
     entity: { value: entity, configurable: true, writable: true },
     store: { value: store, configurable: true, writable: true },
+    dirtyRecord: { value: dirty, configurable: true, writable: true },
     x: {
       get() {
         return this.store.x[this.entity]
       },
       set(n) {
-        dirty[this.entity] = true
+        this.dirtyRecord[this.entity] = true
         return (this.store.x[this.entity] = n)
       },
       configurable: true
@@ -84,7 +86,7 @@ export const proxifyVector3WithDirty = (
         return this.store.y[this.entity]
       },
       set(n) {
-        dirty[this.entity] = true
+        this.dirtyRecord[this.entity] = true
         return (this.store.y[this.entity] = n)
       },
       configurable: true
@@ -94,7 +96,7 @@ export const proxifyVector3WithDirty = (
         return this.store.z[this.entity]
       },
       set(n) {
-        dirty[this.entity] = true
+        this.dirtyRecord[this.entity] = true
         return (this.store.z[this.entity] = n)
       },
       configurable: true
@@ -115,6 +117,7 @@ export const proxifyQuaternion = (
   return defineProperties(quaternion as Quaternion & ProxyExtensions, {
     entity: { value: entity, configurable: true, writable: true },
     store: { value: store, configurable: true, writable: true },
+    dirtyRecord: { value: {}, configurable: true, writable: true },
     _x: {
       get() {
         return this.store.x[this.entity]
@@ -169,12 +172,13 @@ export const proxifyQuaternionWithDirty = (
   return defineProperties(quaternion as Quaternion & ProxyExtensions, {
     entity: { value: entity, configurable: true, writable: true },
     store: { value: store, configurable: true, writable: true },
+    dirtyRecord: { value: dirty, configurable: true, writable: true },
     _x: {
       get() {
         return this.store.x[this.entity]
       },
       set(n) {
-        dirty[this.entity] = true
+        this.dirtyRecord[this.entity] = true
         return (this.store.x[this.entity] = n)
       },
       configurable: true
@@ -184,7 +188,7 @@ export const proxifyQuaternionWithDirty = (
         return this.store.y[this.entity]
       },
       set(n) {
-        dirty[this.entity] = true
+        this.dirtyRecord[this.entity] = true
         return (this.store.y[this.entity] = n)
       },
       configurable: true
@@ -194,7 +198,7 @@ export const proxifyQuaternionWithDirty = (
         return this.store.z[this.entity]
       },
       set(n) {
-        dirty[this.entity] = true
+        this.dirtyRecord[this.entity] = true
         return (this.store.z[this.entity] = n)
       },
       configurable: true
@@ -204,7 +208,7 @@ export const proxifyQuaternionWithDirty = (
         return this.store.w[this.entity]
       },
       set(n) {
-        dirty[this.entity] = true
+        this.dirtyRecord[this.entity] = true
         return (this.store.w[this.entity] = n)
       },
       configurable: true


### PR DESCRIPTION
Ensure three proxies have consistent shapes (to facilitate monomorphic call sites), and ensure getter/setter functions do not access context variables to ensure that they can be inlined by the JIT compiler.