### PR TITLE
Hide canvas only when a true WebXR session

### DIFF
--- a/packages/engine/src/xr/XRSessionFunctions.ts
+++ b/packages/engine/src/xr/XRSessionFunctions.ts
@@ -104,6 +104,12 @@ export const setupXRSession = async (requestedMode) => {
 
   await xrManager.setSession(xrSession, framebufferScaleFactor)
 
+  /** Hide the canvas - do not do this for the WebXR emulator */
+  /** @todo currently, XRSession.visibilityState is undefined in the webxr emulator - we need a better check*/
+  if (typeof xrSession.visibilityState === 'string') {
+    EngineRenderer.instance.renderer.domElement.style.display = 'none'
+  }
+
   xrState.session.set(xrSession)
 
   xrState.requestingSession.set(false)
@@ -188,8 +194,6 @@ export const xrSessionChanged = createHookableFunction((action: typeof XRAction.
 export const setupVRSession = (world = Engine.instance.currentWorld) => {}
 
 export const setupARSession = (world = Engine.instance.currentWorld) => {
-  EngineRenderer.instance.renderer.domElement.style.display = 'none'
-
   const session = getState(XRState).session.value!
 
   /**


### PR DESCRIPTION
## Summary

Support showing the canvas for emulated AR sessions


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

