### PR TITLE
Fix attached mode when hasMovementControls() === false

### DIFF
--- a/packages/engine/src/avatar/functions/moveAvatar.ts
+++ b/packages/engine/src/avatar/functions/moveAvatar.ts
@@ -16,7 +16,7 @@ import { CollisionGroups } from '../../physics/enums/CollisionGroups'
 import { SceneQueryType } from '../../physics/types/PhysicsTypes'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { computeAndUpdateWorldOrigin, updateWorldOrigin } from '../../transform/updateWorldOrigin'
-import { getCameraMode, ReferenceSpace, XRState } from '../../xr/XRState'
+import { getCameraMode, hasMovementControls, ReferenceSpace, XRState } from '../../xr/XRState'
 import { AvatarComponent } from '../components/AvatarComponent'
 import { AvatarControllerComponent } from '../components/AvatarControllerComponent'
 import { AvatarHeadDecapComponent } from '../components/AvatarIKComponents'
@@ -81,6 +81,12 @@ export function updateLocalAvatarPosition(additionalMovement?: Vector3) {
     // desiredMovement.y = 0 // Math.max(desiredMovement.y, 0)
   } else {
     viewerMovement.copy(V_000)
+  }
+
+  if (!hasMovementControls()) {
+    rigidbody.targetKinematicPosition.copy(rigidbody.position).add(desiredMovement)
+    updateLocalAvatarPositionAttachedMode()
+    return
   }
 
   if (controller.movementEnabled && additionalMovement) desiredMovement.add(additionalMovement)


### PR DESCRIPTION
## Summary

When avatar is attached to the viewer, and there are no movement controls, we can simply assume that the avatar should be where the viewer is, and avoid the character controller entirely. This eliminates jitter in AR, and improves performance. 

TODO: 
For VR, we need to have a deadzone within the avatar pill body in which the viewer can move freely, to also eliminate jitter
