### PR TITLE
Fixed some bugs with projects

### DIFF
--- a/packages/client-core/src/admin/services/ProjectUpdateService.ts
+++ b/packages/client-core/src/admin/services/ProjectUpdateService.ts
@@ -44,7 +44,7 @@ const initializeProjectUpdateReceptor = (action: typeof ProjectUpdateActions.ini
     selectedSHA: '',
     projectName: '',
     submitDisabled: true,
-    triggerSetDestination: false,
+    triggerSetDestination: '',
     updateType: 'none' as ProjectUpdateType,
     updateSchedule: DefaultUpdateSchedule
   })

--- a/packages/client-core/src/common/components/InputText/index.tsx
+++ b/packages/client-core/src/common/components/InputText/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import IconButton from '@xrengine/client-core/src/common/components/IconButton'
@@ -69,6 +69,24 @@ const InputText = ({
   placeholder = placeholder ? placeholder : `${t('common:components.enter')} ${label}`
   placeholder = disabled ? undefined : placeholder
 
+  const [cursor, setCursor] = useState(null)
+  const ref = useRef(null)
+
+  useEffect(() => {
+    let input
+    for (const child of (ref.current as any)?.children) {
+      if (child.tagName === 'INPUT') {
+        input = child
+      }
+    }
+    if (input) input.setSelectionRange(cursor, cursor)
+  }, [ref, cursor, value])
+
+  const handleChange = (e) => {
+    setCursor(e.target.selectionStart)
+    onChange && onChange(e)
+  }
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', mb: 2, ...sx }}>
       <Box sx={{ display: 'flex' }}>
@@ -83,6 +101,7 @@ const InputText = ({
           <InputLabel sx={{ zIndex: 999 }}>{capitalizeFirstLetter(label)}</InputLabel>
 
           <OutlinedInput
+            ref={ref}
             disabled={disabled}
             error={!!error}
             fullWidth
@@ -124,7 +143,7 @@ const InputText = ({
               </>
             }
             onBlur={onBlur}
-            onChange={onChange}
+            onChange={handleChange}
             onKeyDown={onKeyDown}
           />
         </FormControl>

--- a/packages/client-core/src/common/services/ProjectService.ts
+++ b/packages/client-core/src/common/services/ProjectService.ts
@@ -179,7 +179,7 @@ export const ProjectService = {
       // })
 
       const projectPatchedListener = (params) => {
-        dispatchAction(ProjectAction.patchedProject({ project: params.project }))
+        dispatchAction(ProjectAction.patchedProject({ project: params }))
       }
 
       API.instance.client.service('project').on('patched', projectPatchedListener)

--- a/packages/common/src/constants/GitHubConstants.ts
+++ b/packages/common/src/constants/GitHubConstants.ts
@@ -1,3 +1,3 @@
-export const GITHUB_URL_REGEX = /(?:git@|https:\/\/)github.com[:/](.*)[.git]?/
+export const GITHUB_URL_REGEX = /(?:git@|https:\/\/)([a-zA-Z0-9\-]+:[a-zA-Z0-9_]+@)?github.com[:/](.*)[.git]?/
 export const GITHUB_PER_PAGE = 100
 export const PUBLIC_SIGNED_REGEX = /https:\/\/[\w\d\s\-_]+:[\w\d\s\-_]+@github.com\/([\w\d\s\-_]+)\/([\w\d\s\-_]+).git/

--- a/packages/server-core/src/hooks/project-permission-authenticate.ts
+++ b/packages/server-core/src/hooks/project-permission-authenticate.ts
@@ -44,7 +44,7 @@ export default (writeAccess) => {
       if (!githubIdentityProvider) throw new Forbidden('You are not authorized to access this project')
       const githubPathRegexExec = GITHUB_URL_REGEX.exec(projectRepoPath)
       if (!githubPathRegexExec) throw new BadRequest('Invalid project URL')
-      const split = githubPathRegexExec[1].split('/')
+      const split = githubPathRegexExec[2].split('/')
       const owner = split[0]
       const repo = split[1].replace('.git', '')
       const userRepoWriteStatus = await checkUserRepoWriteStatus(owner, repo, githubIdentityProvider.oauthToken)

--- a/packages/server-core/src/projects/project/github-helper.ts
+++ b/packages/server-core/src/projects/project/github-helper.ts
@@ -133,7 +133,7 @@ export const getUserOrgs = async (token: string): Promise<any[]> => {
 export const getRepo = async (owner: string, repo: string, token: string): Promise<any> => {
   const octoKit = new Octokit({ auth: token })
   const repoResponse = await octoKit.rest.repos.get({ owner, repo })
-  return repoResponse.data.svn_url
+  return repoResponse.data.html_url
 }
 
 export const pushProjectToGithub = async (
@@ -174,7 +174,7 @@ export const pushProjectToGithub = async (
     })
     const githubPathRegexExec = GITHUB_URL_REGEX.exec(repoPath)
     if (!githubPathRegexExec) throw new BadRequest('Invalid Github URL')
-    const split = githubPathRegexExec[1].split('/')
+    const split = githubPathRegexExec[2].split('/')
     const owner = split[0]
     const repo = split[1].replace('.git', '')
     const repos = await getUserRepos(githubIdentityProvider.oauthToken)
@@ -335,7 +335,7 @@ export const getGithubOwnerRepo = (url: string) => {
       error: 'invalidUrl',
       text: 'Project URL is not a valid GitHub URL, or the GitHub repo is private'
     }
-  const split = githubPathRegexExec[1].split('/')
+  const split = githubPathRegexExec[2].split('/')
   if (!split[0] || !split[1])
     return {
       error: 'invalidUrl',

--- a/packages/server-core/src/projects/project/project.service.ts
+++ b/packages/server-core/src/projects/project/project.service.ts
@@ -332,9 +332,7 @@ export default (app: Application): void => {
       targetIds = _.uniq(targetIds)
       return Promise.all(
         targetIds.map((userId: string) => {
-          return app.channel(`userIds/${userId}`).send({
-            project: data
-          })
+          return app.channel(`userIds/${userId}`).send(data)
         })
       )
     } catch (err) {


### PR DESCRIPTION
## Summary

Some projects were not showing up as pushable even if the user had GH access to them. This was caused by not being the owner of the project and the project being saved with the '.git' suffix on the URL; the check for whether a user had push access solely through GH was not checking for projects that had the '.git' suffix on them. Made allowedRepos add a copy of the URL with the '.git' suffix before doing the findAll on projects.

Updated GITHUB_URL_REGEX to include a signature on the URL. This only really came up with projects that were present locally after a database reset, but it was breaking in that case. Since the signature is a capture group, everything that uses this regex now looks for data on index '2' from the exec instead of '1'.

Fixed an inconsistency in project patching return data. Client-side listener now expects params to be the project data, instead of an object with a 'project' child.

Fixed a bug with input text controlled by service state data. React's behavior is to set the selector to the end of an input if its value changes. This was causing some instances, like in project updating, to be very annoying to update through manual typing, since every character typed or deleted would jump to the end. Updated InputText to use a useEffect to reset the selector back to where it started.

_A summary of changes being made in this PR_


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

