### PR TITLE
Disabled feathers-sync on file-browser methods.

### DIFF
--- a/packages/client-core/src/common/services/FileBrowserService.ts
+++ b/packages/client-core/src/common/services/FileBrowserService.ts
@@ -42,6 +42,11 @@ export const FileBrowserServiceReceptor = (action) => {
         retrieving: true
       })
     })
+    .when(FileBrowserAction.setUpdateNeeded.matches, (action) => {
+      return s.merge({
+        updateNeeded: action.updateNeeded
+      })
+    })
 }
 
 export const accessFileBrowserState = () => getState(FileBrowserState)
@@ -61,6 +66,11 @@ export class FileBrowserAction {
   static filesDeleted = defineAction({
     type: 'xre.client.FileBrowser.FILES_DELETED' as const,
     contentPath: matches.any
+  })
+
+  static setUpdateNeeded = defineAction({
+    type: 'xre.editor.FileBrowser.SET_UPDATE_NEEDED' as const,
+    updateNeeded: matches.boolean
   })
 }
 

--- a/packages/client-core/src/util/upload.tsx
+++ b/packages/client-core/src/util/upload.tsx
@@ -1,7 +1,9 @@
 import i18n from 'i18next'
 
 import config from '@xrengine/common/src/config'
+import { dispatchAction } from '@xrengine/hyperflux'
 
+import { FileBrowserAction } from '../common/services/FileBrowserService'
 import { accessAuthState } from '../user/services/AuthService'
 import { RethrownError } from './errors'
 
@@ -78,6 +80,9 @@ export const uploadToFeathersService = (
       request.open('post', `${config.client.serverUrl}/${service}`, true)
       request.setRequestHeader('Authorization', `Bearer ${token}`)
       request.send(formData)
+      setTimeout(() => {
+        dispatchAction(FileBrowserAction.setUpdateNeeded({ updateNeeded: true }))
+      }, 2000)
     })
   }
 }

--- a/packages/editor/src/components/assets/FileBrowserContentPanel.tsx
+++ b/packages/editor/src/components/assets/FileBrowserContentPanel.tsx
@@ -102,7 +102,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
   )
   const fileState = useFileBrowserState()
   const filesValue = fileState.files.attach(Downgraded).value
-  const { skip, total, retrieving } = fileState.value
+  const { skip, total, retrieving, updateNeeded } = fileState.value
   const [fileProperties, setFileProperties] = useState<any>(null)
   const [openProperties, setOpenPropertiesModal] = useState(false)
   const [openCompress, setOpenCompress] = useState(false)
@@ -164,6 +164,10 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
   useEffect(() => {
     setLoading(false)
   }, [filesValue])
+
+  useEffect(() => {
+    if (updateNeeded) onRefreshDirectory()
+  }, [updateNeeded])
 
   useEffect(() => {
     FileBrowserService.fetchFiles(selectedDirectory)

--- a/packages/server-core/src/media/file-browser/file-browser.hooks.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.hooks.ts
@@ -1,4 +1,5 @@
-import { disallow, iff, isProvider } from 'feathers-hooks-common'
+import { iff, isProvider } from 'feathers-hooks-common'
+import { SYNC } from 'feathers-sync'
 
 import authenticate from '../../hooks/authenticate'
 import verifyScope from '../../hooks/verify-scope'
@@ -8,9 +9,19 @@ export default {
     all: [authenticate(), iff(isProvider('external'), verifyScope('editor', 'write') as any)],
     find: [],
     get: [],
-    create: [],
+    create: [
+      (context) => {
+        context[SYNC] = false
+        return context
+      }
+    ],
     update: [],
-    patch: [],
+    patch: [
+      (context) => {
+        context[SYNC] = false
+        return context
+      }
+    ],
     remove: []
   },
 


### PR DESCRIPTION
Large files were choking feathers-sync and leading to irregular behavior.

Added a FileBrowserService event for setting updateNeeded to true. upload.tsx now calls this on a slight delay so that the file browser can update after a file is uploaded through Import Asset/drag-and-drop.

## Summary

_A summary of changes being made in this PR_


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

