### PR TITLE
7532 project info split

### DIFF
--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -195,7 +195,9 @@
       "day": "day",
       "commitSHACopied": "Commit SHA copied",
       "buildStatus": "Build Status",
-      "defaultProjectUpdateTooltip": "default-project is updated when engine is updated"
+      "defaultProjectUpdateTooltip": "default-project is updated when engine is updated",
+      "refreshGithubRepoAccess": "Refresh GitHub Repo Access",
+      "refreshingGithubRepoAccess": "Refreshing"
     },
     "instance": {
       "confirmInstanceDelete": "Do you want to delete instance",
@@ -321,6 +323,7 @@
       "googleAnalyticsTrackingId": "Google Analytics Tracking ID",
       "certPath": "CertPath",
       "keyPath": "KeyPath",
+      "githubWebhookSecret": "Github Webhook Secret",
       "githubPrivateKey": "Github Private Key",
       "instanceserverUnreachableTimeoutSeconds": "Seconds for instanceserver to be considered unreachable",
       "project": "Project",

--- a/packages/client-core/src/admin/components/Setting/Server.tsx
+++ b/packages/client-core/src/admin/components/Setting/Server.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import InputSwitch from '@xrengine/client-core/src/common/components/InputSwitch'
 import InputText from '@xrengine/client-core/src/common/components/InputText'
+import { useHookstate } from '@xrengine/hyperflux'
 
 import { Box, Button, Grid, Typography } from '@mui/material'
 
@@ -20,36 +21,34 @@ const Server = () => {
   const [serverSetting] = serverSettingState?.server?.value || []
   const id = serverSetting?.id
 
-  const [gaTrackingId, setGaTrackingId] = useState(serverSetting?.gaTrackingId)
-  const [gitPem, setGitPem] = useState(serverSetting?.gitPem)
-  const [instanceserverUnreachableTimeoutSeconds, setInstanceserverUnreachableTimeoutSeconds] = useState(
-    serverSetting?.instanceserverUnreachableTimeoutSeconds
-  )
+  const gaTrackingId = useHookstate(serverSetting?.gaTrackingId)
+  const githubWebhookSecret = useHookstate(serverSetting?.githubWebhookSecret)
+  const instanceserverUnreachableTimeoutSeconds = useHookstate(serverSetting?.instanceserverUnreachableTimeoutSeconds)
   const [dryRun, setDryRun] = useState(true)
   const [local, setLocal] = useState(true)
 
   useEffect(() => {
     if (serverSetting) {
-      setGaTrackingId(serverSetting?.gaTrackingId)
-      setGitPem(serverSetting?.gitPem)
-      setInstanceserverUnreachableTimeoutSeconds(serverSetting?.instanceserverUnreachableTimeoutSeconds)
+      gaTrackingId.set(serverSetting?.gaTrackingId)
+      githubWebhookSecret.set(serverSetting?.githubWebhookSecret)
+      instanceserverUnreachableTimeoutSeconds.set(serverSetting?.instanceserverUnreachableTimeoutSeconds)
     }
   }, [serverSettingState?.updateNeeded?.value])
 
   const handleSubmit = (event) => {
     ServerSettingService.patchServerSetting(
       {
-        gaTrackingId: gaTrackingId,
-        gitPem: gitPem,
-        instanceserverUnreachableTimeoutSeconds: instanceserverUnreachableTimeoutSeconds
+        gaTrackingId: gaTrackingId.value,
+        githubWebhookSecret: githubWebhookSecret.value,
+        instanceserverUnreachableTimeoutSeconds: instanceserverUnreachableTimeoutSeconds.value
       },
       id
     )
   }
 
   const handleCancel = () => {
-    setGaTrackingId(serverSetting?.gaTrackingId)
-    setGitPem(serverSetting?.gitPem)
+    gaTrackingId.set(serverSetting?.gaTrackingId)
+    githubWebhookSecret.set(serverSetting?.githubWebhookSecret)
   }
 
   useEffect(() => {
@@ -140,9 +139,9 @@ const Server = () => {
           <InputText
             name="gaTrackingId"
             label={t('admin:components.setting.googleAnalyticsTrackingId')}
-            value={gaTrackingId || ''}
+            value={gaTrackingId.value || ''}
             startAdornment={<Icon style={{ marginRight: 8 }} fontSize={18} icon="emojione:key" />}
-            onChange={(e) => setGaTrackingId(e.target.value)}
+            onChange={(e) => gaTrackingId.set(e.target.value)}
           />
 
           <InputText
@@ -178,10 +177,10 @@ const Server = () => {
           />
 
           <InputText
-            name="githubPrivateKey"
-            label={t('admin:components.setting.githubPrivateKey')}
-            value={gitPem || ''}
-            onChange={(e) => setGitPem(e.target.value)}
+            name="githubWebhookSecret"
+            label={t('admin:components.setting.githubWebhookSecret')}
+            value={githubWebhookSecret.value || ''}
+            onChange={(e) => githubWebhookSecret.set(e.target.value)}
           />
 
           <InputText
@@ -194,8 +193,8 @@ const Server = () => {
           <InputText
             name="releaseName"
             label={t('admin:components.setting.instanceserverUnreachableTimeoutSeconds')}
-            value={instanceserverUnreachableTimeoutSeconds}
-            onChange={(e) => setInstanceserverUnreachableTimeoutSeconds(e.target.value)}
+            value={instanceserverUnreachableTimeoutSeconds.value}
+            onChange={(e) => instanceserverUnreachableTimeoutSeconds.set(e.target.value)}
           />
 
           <InputSwitch

--- a/packages/client-core/src/admin/styles/admin.module.scss
+++ b/packages/client-core/src/admin/styles/admin.module.scss
@@ -21,6 +21,14 @@
   }
 }
 
+.refreshGHBtn {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  background-color: var(--popupBackground) !important;
+  color: var(--textColor) !important;
+}
+
 .dateTimePickerDialog {
   background: var(--popupBackground);
   color: var(--textColor) !important;

--- a/packages/common/src/dbmodels/GithubRepoAccess.ts
+++ b/packages/common/src/dbmodels/GithubRepoAccess.ts
@@ -1,0 +1,5 @@
+export interface GithubRepoAccessInterface {
+  id: string
+  repo: string
+  identityProviderId: string
+}

--- a/packages/common/src/dbmodels/ServerSetting.ts
+++ b/packages/common/src/dbmodels/ServerSetting.ts
@@ -19,4 +19,5 @@ export interface ServerSettingInterface {
   local: boolean
   releaseName: string
   instanceserverUnreachableTimeoutSeconds: number
+  githubWebhookSecret: string
 }

--- a/packages/common/src/interfaces/GithubRepoAccess.ts
+++ b/packages/common/src/interfaces/GithubRepoAccess.ts
@@ -1,0 +1,11 @@
+export interface GithubRepoAccess {
+  id: string
+  repo: string
+  identityProviderId: string
+}
+
+export const GithubRepoAccess: GithubRepoAccess = {
+  id: '',
+  repo: '',
+  identityProviderId: ''
+}

--- a/packages/common/src/interfaces/ServerSetting.ts
+++ b/packages/common/src/interfaces/ServerSetting.ts
@@ -20,6 +20,7 @@ export interface ServerSetting {
   local?: boolean
   releaseName?: string
   instanceserverUnreachableTimeoutSeconds?: number
+  githubWebhookSecret?: string
 }
 
 export interface HubInfo {
@@ -28,6 +29,6 @@ export interface HubInfo {
 
 export interface PatchServerSetting {
   gaTrackingId?: string
-  gitPem?: string
+  githubWebhookSecret?: string
   instanceserverUnreachableTimeoutSeconds?: number
 }

--- a/packages/editor/src/components/projects/styles.module.scss
+++ b/packages/editor/src/components/projects/styles.module.scss
@@ -615,3 +615,12 @@
 #menu-projectURL {
   z-index: 1500;
 }
+
+.refreshGHBtn {
+  width: 200px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 14px;
+  background-color: var(--popupBackground) !important;
+  color: var(--textColor) !important;
+}

--- a/packages/editor/src/components/properties/ModelTransformProperties.tsx
+++ b/packages/editor/src/components/properties/ModelTransformProperties.tsx
@@ -5,23 +5,15 @@ import { DoubleSide, Mesh, MeshStandardMaterial } from 'three'
 
 import { API } from '@xrengine/client-core/src/API'
 import { FileBrowserService } from '@xrengine/client-core/src/common/services/FileBrowserService'
-import { AssetLoader } from '@xrengine/engine/src/assets/classes/AssetLoader'
 import { ModelTransformParameters } from '@xrengine/engine/src/assets/classes/ModelTransform'
-import { AssetClass } from '@xrengine/engine/src/assets/enum/AssetClass'
 import { Entity } from '@xrengine/engine/src/ecs/classes/Entity'
-import {
-  ComponentType,
-  getComponent,
-  getComponentState,
-  hasComponent
-} from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
+import { ComponentType, getComponentState, hasComponent } from '@xrengine/engine/src/ecs/functions/ComponentFunctions'
 import { MaterialSource, SourceType } from '@xrengine/engine/src/renderer/materials/components/MaterialSource'
 import MeshBasicMaterial from '@xrengine/engine/src/renderer/materials/constants/material-prototypes/MeshBasicMaterial.mat'
 import bakeToVertices from '@xrengine/engine/src/renderer/materials/functions/bakeToVertices'
-import { batchSetMaterialProperty } from '@xrengine/engine/src/renderer/materials/functions/batchEditMaterials'
 import { materialsFromSource } from '@xrengine/engine/src/renderer/materials/functions/MaterialLibraryFunctions'
 import { ModelComponent } from '@xrengine/engine/src/scene/components/ModelComponent'
-import { getState, useHookstate } from '@xrengine/hyperflux'
+import { useHookstate } from '@xrengine/hyperflux'
 import { State } from '@xrengine/hyperflux/functions/StateFunctions'
 
 import { ToggleButton } from '@mui/material'

--- a/packages/server-core/src/analytics/analytics/analytics.docs.ts
+++ b/packages/server-core/src/analytics/analytics/analytics.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/hooks/verify-scope.ts
+++ b/packages/server-core/src/hooks/verify-scope.ts
@@ -2,8 +2,8 @@ import { HookContext } from '@feathersjs/feathers'
 
 import { UserInterface } from '@xrengine/common/src/interfaces/User'
 
+import { Application } from '../../declarations'
 import { NotFoundException, UnauthenticatedException, UnauthorizedException } from '../util/exceptions/exception'
-import { Application } from './../../declarations'
 
 export default (currentType: string, scopeToVerify: string) => {
   return async (context: HookContext<Application>) => {

--- a/packages/server-core/src/media/static-resource-type/static-resource-type.docs.ts
+++ b/packages/server-core/src/media/static-resource-type/static-resource-type.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/media/static-resource/static-resource.docs.ts
+++ b/packages/server-core/src/media/static-resource/static-resource.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/networking/instance-attendance/instance-attendance.docs.ts
+++ b/packages/server-core/src/networking/instance-attendance/instance-attendance.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 
 export default {

--- a/packages/server-core/src/networking/instance-authorized-user/instance-authorized-user.docs.ts
+++ b/packages/server-core/src/networking/instance-authorized-user/instance-authorized-user.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/networking/instance-provision/instance-provision.docs.ts
+++ b/packages/server-core/src/networking/instance-provision/instance-provision.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/networking/instance/instance.docs.ts
+++ b/packages/server-core/src/networking/instance/instance.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 
 export default {

--- a/packages/server-core/src/networking/instanceserver-subdomain-provision/instanceserver-subdomain-provision.docs.ts
+++ b/packages/server-core/src/networking/instanceserver-subdomain-provision/instanceserver-subdomain-provision.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 
 export default {

--- a/packages/server-core/src/payments/seat-status/seat-status.docs.ts
+++ b/packages/server-core/src/payments/seat-status/seat-status.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/payments/seat/seat.docs.ts
+++ b/packages/server-core/src/payments/seat/seat.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/payments/subscription-confirm/subscription-confirm.docs.ts
+++ b/packages/server-core/src/payments/subscription-confirm/subscription-confirm.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/payments/subscription-level/subscription-level.docs.ts
+++ b/packages/server-core/src/payments/subscription-level/subscription-level.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/payments/subscription-type/subscription-type.docs.ts
+++ b/packages/server-core/src/payments/subscription-type/subscription-type.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/payments/subscription/subscription.docs.ts
+++ b/packages/server-core/src/payments/subscription/subscription.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/projects/project/github-helper.ts
+++ b/packages/server-core/src/projects/project/github-helper.ts
@@ -363,7 +363,8 @@ export const getOctokitForChecking = async (app: Application, url: string, param
   return {
     owner,
     repo,
-    octoKit
+    octoKit,
+    token: githubIdentityProvider.oauthToken
   }
 }
 

--- a/packages/server-core/src/projects/scene/scene.docs.ts
+++ b/packages/server-core/src/projects/scene/scene.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/setting/server-setting/server-setting.model.ts
+++ b/packages/server-core/src/setting/server-setting/server-setting.model.ts
@@ -6,7 +6,7 @@ import { Application } from '../../../declarations'
 
 export default (app: Application) => {
   const sequelizeClient: Sequelize = app.get('sequelizeClient')
-  const ServerSetting = sequelizeClient.define<Model<ServerSettingInterface>>(
+  return sequelizeClient.define<Model<ServerSettingInterface>>(
     'serverSetting',
     {
       id: {
@@ -90,6 +90,9 @@ export default (app: Application) => {
       instanceserverUnreachableTimeoutSeconds: {
         type: DataTypes.INTEGER,
         defaultValue: 2
+      },
+      githubWebhookSecret: {
+        type: DataTypes.STRING
       }
     },
     {
@@ -100,6 +103,4 @@ export default (app: Application) => {
       }
     }
   )
-
-  return ServerSetting
 }

--- a/packages/server-core/src/social/channel-type/channel-type.docs.ts
+++ b/packages/server-core/src/social/channel-type/channel-type.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 
 export default {

--- a/packages/server-core/src/social/channel/channel.docs.ts
+++ b/packages/server-core/src/social/channel/channel.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/social/group-user-rank/group-user-rank.docs.ts
+++ b/packages/server-core/src/social/group-user-rank/group-user-rank.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/social/group-user/group-user.docs.ts
+++ b/packages/server-core/src/social/group-user/group-user.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/social/group/group.docs.ts
+++ b/packages/server-core/src/social/group/group.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/social/invite-type/invite-type.docs.ts
+++ b/packages/server-core/src/social/invite-type/invite-type.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/social/invite/invite.docs.ts
+++ b/packages/server-core/src/social/invite/invite.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 
 export default {

--- a/packages/server-core/src/social/location-admin/location-admin.docs.ts
+++ b/packages/server-core/src/social/location-admin/location-admin.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/social/location-authorized-user/location-authorized-user.docs.ts
+++ b/packages/server-core/src/social/location-authorized-user/location-authorized-user.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/social/location-ban/location-ban.docs.ts
+++ b/packages/server-core/src/social/location-ban/location-ban.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/social/location-settings/location-settings-docs.ts
+++ b/packages/server-core/src/social/location-settings/location-settings-docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/social/location-type/location-type.docs.ts
+++ b/packages/server-core/src/social/location-type/location-type.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/social/location/location.docs.ts
+++ b/packages/server-core/src/social/location/location.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/social/message-status/message-status.docs.ts
+++ b/packages/server-core/src/social/message-status/message-status.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/social/message/message.docs.ts
+++ b/packages/server-core/src/social/message/message.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/social/party-user/party-user.docs.ts
+++ b/packages/server-core/src/social/party-user/party-user.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/social/party/party.docs.ts
+++ b/packages/server-core/src/social/party/party.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/user/avatar/avatar.docs.ts
+++ b/packages/server-core/src/user/avatar/avatar.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/user/email/email.docs.ts
+++ b/packages/server-core/src/user/email/email.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/user/github-repo-access/github-repo-access.class.ts
+++ b/packages/server-core/src/user/github-repo-access/github-repo-access.class.ts
@@ -1,0 +1,18 @@
+import { SequelizeServiceOptions, Service } from 'feathers-sequelize'
+
+import { GithubRepoAccessInterface } from '@xrengine/common/src/dbmodels/GithubRepoAccess'
+
+import { Application } from '../../../declarations'
+
+/**
+ * A class for github-repo-access service
+ */
+export class GithubRepoAccess<T = GithubRepoAccessInterface> extends Service<T> {
+  public app: Application
+  public docs: any
+
+  constructor(options: Partial<SequelizeServiceOptions>, app: Application) {
+    super(options)
+    this.app = app
+  }
+}

--- a/packages/server-core/src/user/github-repo-access/github-repo-access.docs.ts
+++ b/packages/server-core/src/user/github-repo-access/github-repo-access.docs.ts
@@ -3,17 +3,17 @@
  */
 export default {
   definitions: {
-    'login-token': {
+    'github-repo-access': {
       type: 'object',
       properties: {
-        identityProviderId: {
+        token: {
           type: 'string'
         }
       }
     },
-    'login-token_list': {
+    'github-repo-access_list': {
       type: 'array',
-      items: { $ref: '#/definitions/login-token' }
+      items: { $ref: '#/definitions/github-repo-access' }
     }
   }
 }

--- a/packages/server-core/src/user/github-repo-access/github-repo-access.hooks.ts
+++ b/packages/server-core/src/user/github-repo-access/github-repo-access.hooks.ts
@@ -1,0 +1,41 @@
+import { HookContext } from '@feathersjs/feathers'
+import { iff, isProvider } from 'feathers-hooks-common'
+
+import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
+
+const isPasswordAccountType = () => {
+  return (context: HookContext): boolean => {
+    return context.data.type === 'password'
+  }
+}
+
+export default {
+  before: {
+    all: [iff(isProvider('external'), authenticate() as any, verifyScope('admin', 'admin') as any)],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+  after: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+  error: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  }
+} as any

--- a/packages/server-core/src/user/github-repo-access/github-repo-access.model.ts
+++ b/packages/server-core/src/user/github-repo-access/github-repo-access.model.ts
@@ -1,0 +1,37 @@
+import { DataTypes, Model, Sequelize } from 'sequelize'
+
+import { GithubRepoAccessInterface } from '@xrengine/common/src/dbmodels/GithubRepoAccess'
+
+import { Application } from '../../../declarations'
+
+export default (app: Application) => {
+  const sequelizeClient: Sequelize = app.get('sequelizeClient')
+  const githubRepoAccess = sequelizeClient.define<Model<GithubRepoAccessInterface>>(
+    'github-repo-access',
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV1,
+        allowNull: false,
+        primaryKey: true
+      },
+      repo: {
+        type: DataTypes.STRING,
+        allowNull: false
+      }
+    } as any as GithubRepoAccessInterface,
+    {
+      hooks: {
+        beforeCount(options: any): void {
+          options.raw = true
+        }
+      }
+    }
+  )
+
+  ;(githubRepoAccess as any).associate = (models: any): void => {
+    ;(githubRepoAccess as any).belongsTo(models.identity_provider, { required: true, onDelete: 'cascade' })
+  }
+
+  return githubRepoAccess
+}

--- a/packages/server-core/src/user/github-repo-access/github-repo-access.service.ts
+++ b/packages/server-core/src/user/github-repo-access/github-repo-access.service.ts
@@ -1,0 +1,141 @@
+import { NotAuthenticated } from '@feathersjs/errors'
+import { Paginated } from '@feathersjs/feathers/lib'
+import crypto from 'crypto'
+import { iff, isProvider } from 'feathers-hooks-common'
+
+import { ServerSettingInterface } from '@xrengine/common/src/dbmodels/ServerSetting'
+import logger from '@xrengine/common/src/logger'
+
+import { Application } from '../../../declarations'
+import authenticate from '../../hooks/authenticate'
+import setResponseStatusCode from '../../hooks/set-response-status-code'
+import { getUserRepos } from '../../projects/project/github-helper'
+import { UnauthorizedException } from '../../util/exceptions/exception'
+import { GithubRepoAccess } from './github-repo-access.class'
+import githubRepoAccessDocs from './github-repo-access.docs'
+import hooks from './github-repo-access.hooks'
+import createModel from './github-repo-access.model'
+
+declare module '@xrengine/common/declarations' {
+  interface ServiceTypes {
+    'github-repo-access': any
+    'github-repo-access-webhook': any
+    'github-repo-access-refresh': any
+  }
+}
+
+const SIG_HEADER_NAME = 'x-hub-signature-256'
+const SIG_HASH_ALGORITHM = 'sha256'
+
+/**
+ * Initialize our service with any options it requires and docs
+ */
+export default (app: Application): void => {
+  const options = {
+    Model: createModel(app),
+    paginate: app.get('paginate'),
+    multi: true
+  }
+
+  const event = new GithubRepoAccess(options, app)
+  event.docs = githubRepoAccessDocs
+
+  app.use('github-repo-access', event)
+
+  const service = app.service('github-repo-access')
+
+  service.hooks(hooks)
+
+  app.use('github-repo-access-webhook', {
+    create: async (data, params): Promise<string> => {
+      try {
+        const secret = ((await app.service('server-setting').find()) as Paginated<ServerSettingInterface>).data[0]
+          .githubWebhookSecret
+        const sig = Buffer.from(params.headers[SIG_HEADER_NAME] || '', 'utf8')
+        const hmac = crypto.createHmac(SIG_HASH_ALGORITHM, secret)
+        const digest = Buffer.from(SIG_HASH_ALGORITHM + '=' + hmac.update(JSON.stringify(data)).digest('hex'), 'utf8')
+        if (sig.length !== digest.length || !crypto.timingSafeEqual(digest, sig)) {
+          throw new UnauthorizedException('Invalid secret')
+        }
+        const { blocked_user, member, membership } = data
+        const ghUser = member
+          ? member.login
+          : membership
+          ? membership.user.login
+          : blocked_user
+          ? blocked_user.login
+          : null
+        if (!ghUser) return ''
+        const githubIdentityProvider = await app.service('identity-provider').Model.findOne({
+          where: {
+            type: 'github',
+            accountIdentifier: ghUser
+          }
+        })
+        if (!githubIdentityProvider) return ''
+        const user = await app.service('user').get(githubIdentityProvider.userId)
+        // GitHub's API doesn't always reflect changes to user repo permissions right when a webhook is sent.
+        // 10 seconds should be more than enough time for the changes to propagate.
+        setTimeout(() => {
+          app.service('github-repo-access-refresh').find({ user })
+        }, 10000)
+        return ''
+      } catch (err) {
+        console.error(err)
+        throw err
+      }
+    }
+  })
+
+  app.service('github-repo-access-webhook').hooks({
+    after: {
+      create: [setResponseStatusCode(200)]
+    }
+  })
+  app.use('github-repo-access-refresh', {
+    find: async (params): Promise<void> => {
+      try {
+        const githubIdentityProvider = await (app.service('identity-provider') as any).Model.findOne({
+          where: {
+            userId: params.user.id,
+            type: 'github'
+          }
+        })
+        if (githubIdentityProvider) {
+          const existingGithubRepoAccesses = await app.service('github-repo-access').Model.findAll({
+            paginate: false,
+            where: {
+              identityProviderId: githubIdentityProvider.id
+            }
+          })
+          const githubRepos = (await getUserRepos(githubIdentityProvider.oauthToken)).map((repo) => repo.html_url)
+          await Promise.all(
+            githubRepos.map(async (repo) => {
+              if (!existingGithubRepoAccesses.find((access) => access.repo === repo))
+                await app.service('github-repo-access').create({
+                  repo: repo,
+                  identityProviderId: githubIdentityProvider.id
+                })
+            })
+          )
+          await Promise.all(
+            existingGithubRepoAccesses.map(async (repoAccess) => {
+              if (githubRepos.indexOf(repoAccess.repo) < 0)
+                await app.service('github-repo-access').remove(repoAccess.id)
+            })
+          )
+        }
+        return
+      } catch (err) {
+        logger.error(err)
+        throw err
+      }
+    }
+  })
+
+  app.service('github-repo-access-refresh').hooks({
+    before: {
+      find: [iff(isProvider('external'), authenticate() as any)]
+    }
+  })
+}

--- a/packages/server-core/src/user/identity-provider/identity-provider.docs.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/user/identity-provider/identity-provider.service.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.service.ts
@@ -5,7 +5,7 @@ import { IdentityProviderInterface } from '@xrengine/common/src/dbmodels/Identit
 import { Application } from '../../../declarations'
 import authenticate from '../../hooks/authenticate'
 import { IdentityProvider } from './identity-provider.class'
-import identyDocs from './identity-provider.docs'
+import identityProviderDocs from './identity-provider.docs'
 import hooks from './identity-provider.hooks'
 import createModel from './identity-provider.model'
 
@@ -27,7 +27,7 @@ export default (app: Application): void => {
   }
 
   const event = new IdentityProvider(options, app)
-  event.docs = identyDocs
+  event.docs = identityProviderDocs
 
   app.use('identity-provider', event)
 

--- a/packages/server-core/src/user/login/login.docs.ts
+++ b/packages/server-core/src/user/login/login.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/user/magic-link/magic-link.docs.ts
+++ b/packages/server-core/src/user/magic-link/magic-link.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/user/services.ts
+++ b/packages/server-core/src/user/services.ts
@@ -3,6 +3,7 @@ import Auth from './auth-management/auth-management.service'
 import Avatar from './avatar/avatar.service'
 import DiscordBotAuth from './discord-bot-auth/discord-bot-auth.service'
 import Email from './email/email.service'
+import GithubRepoAccess from './github-repo-access/github-repo-access.service'
 import IdentityProvider from './identity-provider/identity-provider.service'
 import LoginToken from './login-token/login-token.service'
 import Login from './login/login.service'
@@ -29,5 +30,6 @@ export default [
   MagicLink,
   Email,
   SMS,
-  DiscordBotAuth
+  DiscordBotAuth,
+  GithubRepoAccess
 ]

--- a/packages/server-core/src/user/sms/sms.docs.ts
+++ b/packages/server-core/src/user/sms/sms.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/user/strategies/github.ts
+++ b/packages/server-core/src/user/strategies/github.ts
@@ -74,6 +74,7 @@ export class GithubStrategy extends CustomOAuthStrategy {
     if (entity.type !== 'guest' && identityProvider.type === 'guest') {
       await this.app.service('identity-provider').remove(identityProvider.id)
       await this.app.service('user').remove(identityProvider.userId)
+      await this.app.service('github-repo-access-refresh').find(Object.assign({}, params, { user }))
       return super.updateEntity(entity, profile, params)
     }
     const existingEntity = await super.findEntity(profile, params)
@@ -82,9 +83,12 @@ export class GithubStrategy extends CustomOAuthStrategy {
       profile.oauthToken = params.access_token
       const newIP = await super.createEntity(profile, params)
       if (entity.type === 'guest') await this.app.service('identity-provider').remove(entity.id)
+      await this.app.service('github-repo-access-refresh').find(Object.assign({}, params, { user }))
       return newIP
-    } else if (existingEntity.userId === identityProvider.userId) return existingEntity
-    else {
+    } else if (existingEntity.userId === identityProvider.userId) {
+      await this.app.service('github-repo-access-refresh').find(Object.assign({}, params, { user }))
+      return existingEntity
+    } else {
       throw new Error('Another user is linked to this account')
     }
   }

--- a/packages/server-core/src/user/user-relationship-type/user-relationship-type.docs.ts
+++ b/packages/server-core/src/user/user-relationship-type/user-relationship-type.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/user/user-relationship/user-relationship.docs.ts
+++ b/packages/server-core/src/user/user-relationship/user-relationship.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {

--- a/packages/server-core/src/user/user-settings/user-settings.docs.ts
+++ b/packages/server-core/src/user/user-settings/user-settings.docs.ts
@@ -1,5 +1,5 @@
 /**
- * An object for swagger documentation configiration
+ * An object for swagger documentation configuration
  */
 export default {
   definitions: {


### PR DESCRIPTION
## Summary

Loading projects with associated push access was slow because the backend process
was making many requests to the GitHub API each time. Now, which repos a user
has access to is stored in a new database table. When a user logs in with GitHub,
their list of repo access is updated. Both /admin/projects and /studio have a button
that users logged in with GitHub can click to trigger the same behavior. Also added
a route for GH webhooks to trigger this re-fetch when a user is added/modified/removed
as a collaborator on a repo or an organization. Support for changes to teams is not
included because getting the list of users in a team is tricky.

Fixed an issue with users not being able to update a project from GitHub if they were
not part of the organization that owned the repo. This was leftover thinking from GitHub
Apps, which required Org access, and instead the backend check now gets the users allowed
repos instead.

Replaced some useState's with useHookstate's.

Updated the studio projects page to determine display of most projects' actions via the
same method as the admin projects page.

## References

closes #7532 #7547


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

