### PR TITLE
Fixed bugs with GH repo access

### DIFF
--- a/packages/common/src/dbmodels/GithubRepoAccess.ts
+++ b/packages/common/src/dbmodels/GithubRepoAccess.ts
@@ -1,5 +1,5 @@
 export interface GithubRepoAccessInterface {
   id: string
   repo: string
-  identityProviderId: string
+  hasWriteAccess: boolean
 }

--- a/packages/common/src/interfaces/GithubRepoAccess.ts
+++ b/packages/common/src/interfaces/GithubRepoAccess.ts
@@ -2,10 +2,12 @@ export interface GithubRepoAccess {
   id: string
   repo: string
   identityProviderId: string
+  hasWriteAccess: boolean
 }
 
 export const GithubRepoAccess: GithubRepoAccess = {
   id: '',
   repo: '',
-  identityProviderId: ''
+  identityProviderId: '',
+  hasWriteAccess: false
 }

--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -649,7 +649,7 @@ export class Project extends Service {
             }
           })
         : []
-      const repoPaths = repoAccess.map((item) => item.repo.toLowerCase())
+      const pushRepoPaths = repoAccess.filter((repo) => repo.hasWriteAccess).map((item) => item.repo.toLowerCase())
       let allowedProjectGithubRepos = allowedProjects.filter((project) => project.repositoryPath != null)
       allowedProjectGithubRepos = await Promise.all(
         allowedProjectGithubRepos.map(async (project) => {
@@ -661,21 +661,23 @@ export class Project extends Service {
         })
       )
       const pushableAllowedProjects = allowedProjectGithubRepos.filter(
-        (project) => repoPaths.indexOf(project.repositoryPath.toLowerCase().replace(/.git$/, '')) > -1
+        (project) => pushRepoPaths.indexOf(project.repositoryPath.toLowerCase().replace(/.git$/, '')) > -1
       )
       projectPushIds = projectPushIds.concat(pushableAllowedProjects.map((project) => project.id))
 
       if (githubIdentityProvider) {
         repoAccess.forEach((item, index) => {
-          const url = item.repo.toLowerCase()
-          repoAccess[index] = url
-          repoAccess.push(`${url}.git`)
-          const regexExec = GITHUB_URL_REGEX.exec(url)
-          if (regexExec) {
-            const split = regexExec[2].split('/')
-            repoAccess.push(`git@github.com:${split[0]}/${split[1]}`)
-            repoAccess.push(`git@github.com:${split[0]}/${split[1]}.git`)
-          }
+          if (repoAccess.hasWriteAccess) {
+            const url = item.repo.toLowerCase()
+            repoAccess[index] = url
+            repoAccess.push(`${url}.git`)
+            const regexExec = GITHUB_URL_REGEX.exec(url)
+            if (regexExec) {
+              const split = regexExec[2].split('/')
+              repoAccess.push(`git@github.com:${split[0]}/${split[1]}`)
+              repoAccess.push(`git@github.com:${split[0]}/${split[1]}.git`)
+            }
+          } else repoAccess.splice(index)
         })
 
         const matchingAllowedRepos = await this.app.service('project').Model.findAll({

--- a/packages/server-core/src/user/github-repo-access/github-repo-access.model.ts
+++ b/packages/server-core/src/user/github-repo-access/github-repo-access.model.ts
@@ -18,8 +18,11 @@ export default (app: Application) => {
       repo: {
         type: DataTypes.STRING,
         allowNull: false
+      },
+      hasWriteAccess: {
+        type: DataTypes.BOOLEAN
       }
-    } as any as GithubRepoAccessInterface,
+    },
     {
       hooks: {
         beforeCount(options: any): void {


### PR DESCRIPTION
## Summary

Project update destination check was not comparing the correct URL string.

Added 'hasWriteAccess' to github-repo-access model. This is needed to distinguish whether a user can push to that repo. github-repo-access-refresh now records this based on whether a user has admin, maintain, or write access to the repo. github-repo-access entries are now patched if they exist, to account for changes in write permission.

Updated allowed project find to better express push access.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/XRFoundation/XREngine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

