### PR TITLE
Fix useQuery causing HOOKSTATE-106 error

### DIFF
--- a/packages/engine/src/ecs/classes/World.ts
+++ b/packages/engine/src/ecs/classes/World.ts
@@ -267,7 +267,7 @@ export class World {
 
   buttons = {} as Readonly<ButtonInputStateType>
 
-  reactiveQueryStates = new Set<{ query: Query; state: State<Entity[]>; components: QueryComponents }>()
+  reactiveQueryStates = new Set<{ query: Query; result: State<Entity[]>; components: QueryComponents }>()
 
   #entityQuery = bitecs.defineQuery([bitecs.Not(EntityRemovedComponent)])
   entityQuery = () => this.#entityQuery(this) as Entity[]
@@ -389,11 +389,11 @@ export class World {
 
     for (const entity of this.#entityRemovedQuery(this)) removeEntity(entity as Entity, true, this)
 
-    for (const { query, state } of this.reactiveQueryStates) {
+    for (const { query, result } of this.reactiveQueryStates) {
       const entitiesAdded = query.enter().length
       const entitiesRemoved = query.exit().length
       if (entitiesAdded || entitiesRemoved) {
-        state.set(query())
+        result.set(query())
       }
     }
 


### PR DESCRIPTION
 Use an immediate (layout) effect to ensure that `queryResult`
 is deleted from the `reactiveQueryStates` map immediately when the
 component is unmounted -- before any other code attempts to set it
 (component state can't be modified after a component is unmounted)

